### PR TITLE
fix: scope ledger to the selected fiscal year

### DIFF
--- a/backend/routers/accounting_entry.py
+++ b/backend/routers/accounting_entry.py
@@ -75,7 +75,7 @@ async def get_ledger(
     _: _ReadAccess,
     from_date: date | None = Query(default=None),
     to_date: date | None = Query(default=None),
-    fiscal_year_id: int | None = Query(default=None),
+    fiscal_year_id: int = Query(...),
 ) -> LedgerRead:
     return await accounting_entry_service.get_ledger(
         db,

--- a/backend/services/accounting_entry_service.py
+++ b/backend/services/accounting_entry_service.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import date, timedelta
 from decimal import Decimal
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.models.accounting_account import AccountingAccount, AccountType
@@ -130,15 +130,17 @@ async def get_ledger(
     """Return all entries for a single account with a running balance."""
     opening = Decimal("0")
     if from_date is not None:
-        opening_entries = await get_journal(
-            db,
-            account_number=account_number,
-            to_date=from_date - timedelta(days=1),
-            fiscal_year_id=fiscal_year_id,
-            limit=100_000,
+        opening_query = select(
+            func.coalesce(func.sum(AccountingEntry.debit), 0),
+            func.coalesce(func.sum(AccountingEntry.credit), 0),
         )
-        for entry in opening_entries:
-            opening += Decimal(str(entry.debit)) - Decimal(str(entry.credit))
+        opening_query = opening_query.where(AccountingEntry.account_number == account_number)
+        opening_query = opening_query.where(AccountingEntry.date <= from_date - timedelta(days=1))
+        if fiscal_year_id is not None:
+            opening_query = opening_query.where(AccountingEntry.fiscal_year_id == fiscal_year_id)
+        opening_result = await db.execute(opening_query)
+        total_debit, total_credit = opening_result.one()
+        opening = Decimal(str(total_debit)) - Decimal(str(total_credit))
 
     entries = await get_journal(
         db,

--- a/backend/services/accounting_entry_service.py
+++ b/backend/services/accounting_entry_service.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import date
+from datetime import date, timedelta
 from decimal import Decimal
 
 from sqlalchemy import select
@@ -128,6 +128,18 @@ async def get_ledger(
     fiscal_year_id: int | None = None,
 ) -> LedgerRead:
     """Return all entries for a single account with a running balance."""
+    opening = Decimal("0")
+    if from_date is not None:
+        opening_entries = await get_journal(
+            db,
+            account_number=account_number,
+            to_date=from_date - timedelta(days=1),
+            fiscal_year_id=fiscal_year_id,
+            limit=100_000,
+        )
+        for entry in opening_entries:
+            opening += Decimal(str(entry.debit)) - Decimal(str(entry.credit))
+
     entries = await get_journal(
         db,
         account_number=account_number,
@@ -144,7 +156,7 @@ async def get_ledger(
     acct_obj = result.scalar_one_or_none()
     label = acct_obj.label if acct_obj else account_number
 
-    running = Decimal("0")
+    running = opening
     ledger_entries: list[LedgerEntry] = []
     for e in entries:
         running += Decimal(str(e.debit)) - Decimal(str(e.credit))
@@ -159,8 +171,6 @@ async def get_ledger(
                 running_balance=running,
             )
         )
-
-    opening = Decimal("0")
     closing = running
 
     return LedgerRead(

--- a/doc/backlog.md
+++ b/doc/backlog.md
@@ -331,14 +331,16 @@ Tout sujet concret qui doit survivre au-delà de la séance en cours doit être 
 
 ### BL-025 — Corriger le report à nouveau et les soldes du grand livre multi-exercices
 
-- **Dates** : `created=2026-04-13`
+- **Dates** : `created=2026-04-13`, `started=2026-04-13`, `completed=2026-04-13`
 - **Pourquoi** : le grand livre du compte `512102` cumule au moins deux écritures d'ouverture d'exercice (`2024` et `2025`), ce qui fausse le solde affiché ; le problème est probablement plus large et remet en cause la justesse comptable des vues par compte.
-- **Résultat attendu** : rétablir un calcul juste des soldes et des écritures d'ouverture dans le grand livre, en respectant la logique comptable attendue d'un exercice à l'autre.
+- **Résultat attendu** : rétablir un calcul juste des soldes et des écritures d'ouverture dans le grand livre, en respectant une lecture strictement bornée à l'exercice choisi, sans option `tous les exercices` sur cette vue.
 - **Questions à trancher** :
-	- quelle écriture d'ouverture doit être visible selon l'exercice affiché dans le grand livre ;
-	- faut-il filtrer différemment les écritures d'ouverture, recalculer le report à nouveau ou corriger la stratégie de reprise historique ;
-	- le problème touche-t-il aussi le journal, la balance et d'autres comptes au-delà de `512102`.
-- **Critère d'acceptation** : pour un exercice donné, le grand livre, la balance et les autres vues comptables affichent un solde cohérent avec les reports à nouveau attendus, sans cumul indu entre ouvertures d'exercices successifs.
+- **Décision produit actée** : le grand livre doit toujours afficher uniquement les transactions de l'exercice choisi ; il ne doit pas proposer `tous les exercices`, car cette agrégation rend ambigu le solde dès qu'un report à nouveau existe.
+- **Questions à trancher** :
+	- comment calculer le `solde d'ouverture` quand l'utilisateur borne en plus la vue avec une date de début à l'intérieur de l'exercice ;
+	- le problème touche-t-il aussi le journal, la balance et d'autres comptes au-delà de `512102` ;
+	- faut-il exposer séparément, plus tard, une vue d'historique brute multi-exercices distincte du grand livre.
+- **Critère d'acceptation** : pour un exercice donné, le grand livre n'affiche que les écritures rattachées à cet exercice, y compris son report à nouveau éventuel, et présente un solde cohérent sans cumul indu entre ouvertures d'exercices successifs.
 - **Point d'attention** : c'est un sujet comptable critique à traiter avant de faire confiance aux états ; il faudra le recouper avec `BL-010` et les choix de clôture des exercices historiques.
 
 ## Prêt
@@ -358,6 +360,7 @@ Tout sujet concret qui doit survivre au-delà de la séance en cours doit être 
 - **BL-007** — `created=2026-04-12`, `completed=2026-04-13` — La convention est arrêtée pour le mode de travail actuel : `doc/backlog.md` reste la source de vérité, sans synchronisation systématique avec des issues GitHub à ce stade.
 - **BL-009** — `created=2026-04-12`, `completed=2026-04-12` — Le plan comptable par défaut a été enrichi à partir des comptes réellement rencontrés dans les imports historiques.
 - **BL-010** — `created=2026-04-12`, `completed=2026-04-12` — Une stratégie sûre de clôture administrative des exercices historiques importés a été définie et livrée.
+- **BL-025** — `created=2026-04-13`, `started=2026-04-13`, `completed=2026-04-13` — Le grand livre est maintenant borné à l'exercice choisi, sans option multi-exercices, avec un solde d'ouverture cohérent quand la période démarre en cours d'exercice.
 - **BL-011** — `created=2026-04-12`, `completed=2026-04-12` — L'exercice courant global et son sélecteur partagé ont été livrés sur les écrans comptables concernés.
 - **BL-012** — `created=2026-04-12`, `completed=2026-04-12` — La liste des paiements affiche la référence métier et permet l'édition directe.
 - **BL-013** — `created=2026-04-12`, `completed=2026-04-12` — Le journal de caisse propose désormais référence, détail et édition directe.

--- a/doc/backlog.md
+++ b/doc/backlog.md
@@ -334,7 +334,6 @@ Tout sujet concret qui doit survivre au-delà de la séance en cours doit être 
 - **Dates** : `created=2026-04-13`, `started=2026-04-13`, `completed=2026-04-13`
 - **Pourquoi** : le grand livre du compte `512102` cumule au moins deux écritures d'ouverture d'exercice (`2024` et `2025`), ce qui fausse le solde affiché ; le problème est probablement plus large et remet en cause la justesse comptable des vues par compte.
 - **Résultat attendu** : rétablir un calcul juste des soldes et des écritures d'ouverture dans le grand livre, en respectant une lecture strictement bornée à l'exercice choisi, sans option `tous les exercices` sur cette vue.
-- **Questions à trancher** :
 - **Décision produit actée** : le grand livre doit toujours afficher uniquement les transactions de l'exercice choisi ; il ne doit pas proposer `tous les exercices`, car cette agrégation rend ambigu le solde dès qu'un report à nouveau existe.
 - **Questions à trancher** :
 	- comment calculer le `solde d'ouverture` quand l'utilisateur borne en plus la vue avec une date de début à l'intérieur de l'exercice ;

--- a/frontend/src/i18n/fr.ts
+++ b/frontend/src/i18n/fr.ts
@@ -502,6 +502,8 @@ export default {
     ledger: {
       title: 'Grand livre',
       select_account: 'Sélectionner un compte',
+      select_fiscal_year: 'Sélectionner un exercice',
+      no_fiscal_year: "Aucun exercice disponible. Creez d'abord un exercice.",
       opening_balance: "Solde d'ouverture",
       closing_balance: 'Solde de clôture',
       empty: 'Aucune écriture pour ce compte.',

--- a/frontend/src/views/AccountingLedgerView.vue
+++ b/frontend/src/views/AccountingLedgerView.vue
@@ -105,8 +105,12 @@ const fromDate = ref('')
 const toDate = ref('')
 const fiscalYearId = ref<number | undefined>()
 const loading = ref(false)
+const initializing = ref(true)
 
 const emptyStateMessage = computed(() => {
+  if (initializing.value) {
+    return t('common.loading')
+  }
   if (fiscalYears.value.length === 0) {
     return t('accounting.ledger.no_fiscal_year')
   }
@@ -131,16 +135,20 @@ async function load() {
 }
 
 onMounted(async () => {
-  const [accts, fiscalYearList, currentFiscalYear] = await Promise.all([
-    listAccountsApi(undefined, false),
-    listFiscalYearsApi(),
-    getCurrentFiscalYearApi(),
-  ])
-  accounts.value = accts.map((a) => ({
-    number: a.number,
-    displayLabel: `${a.number} — ${a.label}`,
-  }))
-  fiscalYears.value = fiscalYearList
-  fiscalYearId.value = currentFiscalYear?.id ?? fiscalYearList[0]?.id
+  try {
+    const [accts, fiscalYearList, currentFiscalYear] = await Promise.all([
+      listAccountsApi(undefined, false),
+      listFiscalYearsApi(),
+      getCurrentFiscalYearApi(),
+    ])
+    accounts.value = accts.map((a) => ({
+      number: a.number,
+      displayLabel: `${a.number} — ${a.label}`,
+    }))
+    fiscalYears.value = fiscalYearList
+    fiscalYearId.value = currentFiscalYear?.id ?? fiscalYearList[0]?.id
+  } finally {
+    initializing.value = false
+  }
 })
 </script>

--- a/frontend/src/views/AccountingLedgerView.vue
+++ b/frontend/src/views/AccountingLedgerView.vue
@@ -18,6 +18,15 @@
             />
           </div>
           <div class="app-field">
+            <label class="app-field__label">{{ t('accounting.journal.filter_fiscal_year') }}</label>
+            <Select
+              v-model="fiscalYearId"
+              :options="fiscalYears"
+              option-label="name"
+              option-value="id"
+            />
+          </div>
+          <div class="app-field">
             <label class="app-field__label">{{ t('accounting.journal.filter_from') }}</label>
             <InputText v-model="fromDate" type="date" />
           </div>
@@ -27,7 +36,12 @@
           </div>
           <div class="app-field">
             <label class="app-field__label">{{ t('common.search') }}</label>
-            <Button :label="t('common.search')" icon="pi pi-search" @click="load" :disabled="!accountNumber" />
+            <Button
+              :label="t('common.search')"
+              icon="pi pi-search"
+              @click="load"
+              :disabled="!accountNumber || !fiscalYearId"
+            />
           </div>
         </div>
       </div>
@@ -55,13 +69,13 @@
           </template>
         </DataTable>
       </template>
-      <div v-else class="app-empty-state">{{ t('accounting.ledger.select_account') }}</div>
+      <div v-else class="app-empty-state">{{ emptyStateMessage }}</div>
     </AppPanel>
   </AppPage>
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { computed, ref, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import Button from 'primevue/button'
 import Column from 'primevue/column'
@@ -72,24 +86,44 @@ import AppPage from '../components/ui/AppPage.vue'
 import AppPageHeader from '../components/ui/AppPageHeader.vue'
 import AppPanel from '../components/ui/AppPanel.vue'
 import AppStatCard from '../components/ui/AppStatCard.vue'
-import { getLedgerApi, listAccountsApi, type LedgerRead } from '../api/accounting'
+import {
+  getCurrentFiscalYearApi,
+  getLedgerApi,
+  listAccountsApi,
+  listFiscalYearsApi,
+  type FiscalYearRead,
+  type LedgerRead,
+} from '../api/accounting'
 
 const { t } = useI18n()
 
 const ledger = ref<LedgerRead | null>(null)
 const accounts = ref<Array<{ number: string; displayLabel: string }>>([])
+const fiscalYears = ref<FiscalYearRead[]>([])
 const accountNumber = ref('')
 const fromDate = ref('')
 const toDate = ref('')
+const fiscalYearId = ref<number | undefined>()
 const loading = ref(false)
 
+const emptyStateMessage = computed(() => {
+  if (fiscalYears.value.length === 0) {
+    return t('accounting.ledger.no_fiscal_year')
+  }
+  if (!fiscalYearId.value) {
+    return t('accounting.ledger.select_fiscal_year')
+  }
+  return t('accounting.ledger.select_account')
+})
+
 async function load() {
-  if (!accountNumber.value) return
+  if (!accountNumber.value || !fiscalYearId.value) return
   loading.value = true
   try {
     ledger.value = await getLedgerApi(accountNumber.value, {
       from_date: fromDate.value || undefined,
       to_date: toDate.value || undefined,
+      fiscal_year_id: fiscalYearId.value,
     })
   } finally {
     loading.value = false
@@ -97,10 +131,16 @@ async function load() {
 }
 
 onMounted(async () => {
-  const accts = await listAccountsApi(undefined, false)
+  const [accts, fiscalYearList, currentFiscalYear] = await Promise.all([
+    listAccountsApi(undefined, false),
+    listFiscalYearsApi(),
+    getCurrentFiscalYearApi(),
+  ])
   accounts.value = accts.map((a) => ({
     number: a.number,
     displayLabel: `${a.number} — ${a.label}`,
   }))
+  fiscalYears.value = fiscalYearList
+  fiscalYearId.value = currentFiscalYear?.id ?? fiscalYearList[0]?.id
 })
 </script>

--- a/tests/integration/test_accounting_api.py
+++ b/tests/integration/test_accounting_api.py
@@ -21,11 +21,13 @@ async def _create_fy(
     db: AsyncSession,
     name: str = "2024",
     status: FiscalYearStatus = FiscalYearStatus.OPEN,
+    start: date | None = None,
+    end: date | None = None,
 ) -> FiscalYear:
     fy = FiscalYear(
         name=name,
-        start_date=date(2024, 1, 1),
-        end_date=date(2024, 12, 31),
+        start_date=start or date(2024, 1, 1),
+        end_date=end or date(2024, 12, 31),
         status=status,
     )
     db.add(fy)
@@ -234,23 +236,29 @@ class TestBalanceAPI:
 
 class TestLedgerAPI:
     @pytest.mark.asyncio
-    async def test_empty_ledger(self, client: AsyncClient, auth_headers: dict) -> None:
+    async def test_requires_fiscal_year_filter(
+        self, client: AsyncClient, auth_headers: dict
+    ) -> None:
         response = await client.get("/api/accounting/entries/ledger/411100", headers=auth_headers)
-        assert response.status_code == 200
-        data = response.json()
-        assert data["entries"] == []
-        assert float(data["closing_balance"]) == 0.0
+        assert response.status_code == 422
 
     @pytest.mark.asyncio
     async def test_ledger_with_entries(
         self, client: AsyncClient, auth_headers: dict, db_session: AsyncSession
     ) -> None:
+        fy = await _create_fy(
+            db_session,
+            "2024",
+            start=date(2024, 1, 1),
+            end=date(2024, 12, 31),
+        )
         await _add_entry(
             db_session,
             "000001",
             "411100",
             debit=Decimal("100"),
             entry_date=date(2024, 1, 5),
+            fiscal_year_id=fy.id,
         )
         await _add_entry(
             db_session,
@@ -258,12 +266,110 @@ class TestLedgerAPI:
             "411100",
             credit=Decimal("40"),
             entry_date=date(2024, 1, 10),
+            fiscal_year_id=fy.id,
         )
-        response = await client.get("/api/accounting/entries/ledger/411100", headers=auth_headers)
+        response = await client.get(
+            f"/api/accounting/entries/ledger/411100?fiscal_year_id={fy.id}",
+            headers=auth_headers,
+        )
         assert response.status_code == 200
         data = response.json()
         assert len(data["entries"]) == 2
         assert float(data["closing_balance"]) == 60.0
+
+    @pytest.mark.asyncio
+    async def test_ledger_filters_by_fiscal_year(
+        self, client: AsyncClient, auth_headers: dict, db_session: AsyncSession
+    ) -> None:
+        fy_2024 = await _create_fy(
+            db_session,
+            "2024",
+            start=date(2024, 1, 1),
+            end=date(2024, 12, 31),
+        )
+        fy_2025 = await _create_fy(
+            db_session,
+            "2025",
+            start=date(2025, 1, 1),
+            end=date(2025, 12, 31),
+        )
+
+        await _add_entry(
+            db_session,
+            "000001",
+            "512102",
+            debit=Decimal("100"),
+            entry_date=date(2024, 12, 31),
+            fiscal_year_id=fy_2024.id,
+        )
+        await _add_entry(
+            db_session,
+            "000002",
+            "512102",
+            debit=Decimal("100"),
+            entry_date=date(2025, 1, 1),
+            fiscal_year_id=fy_2025.id,
+        )
+
+        response = await client.get(
+            f"/api/accounting/entries/ledger/512102?fiscal_year_id={fy_2025.id}",
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert [entry["entry_number"] for entry in data["entries"]] == ["000002"]
+
+    @pytest.mark.asyncio
+    async def test_ledger_returns_opening_balance_before_from_date(
+        self, client: AsyncClient, auth_headers: dict, db_session: AsyncSession
+    ) -> None:
+        fy_2025 = await _create_fy(
+            db_session,
+            "2025",
+            start=date(2025, 1, 1),
+            end=date(2025, 12, 31),
+        )
+
+        await _add_entry(
+            db_session,
+            "000001",
+            "512102",
+            debit=Decimal("100"),
+            entry_date=date(2025, 1, 1),
+            fiscal_year_id=fy_2025.id,
+        )
+        await _add_entry(
+            db_session,
+            "000002",
+            "512102",
+            debit=Decimal("50"),
+            entry_date=date(2025, 1, 15),
+            fiscal_year_id=fy_2025.id,
+        )
+        await _add_entry(
+            db_session,
+            "000003",
+            "512102",
+            credit=Decimal("30"),
+            entry_date=date(2025, 2, 10),
+            fiscal_year_id=fy_2025.id,
+        )
+
+        response = await client.get(
+            (
+                f"/api/accounting/entries/ledger/512102?fiscal_year_id={fy_2025.id}"
+                "&from_date=2025-02-01"
+            ),
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert float(data["opening_balance"]) == 150.0
+        assert len(data["entries"]) == 1
+        assert float(data["entries"][0]["running_balance"]) == 120.0
+        assert float(data["closing_balance"]) == 120.0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_accounting_entry_service.py
+++ b/tests/unit/test_accounting_entry_service.py
@@ -453,6 +453,78 @@ class TestGetLedger:
         assert result.entries[0].running_balance == Decimal("120")
         assert result.closing_balance == Decimal("120")
 
+    @pytest.mark.asyncio
+    async def test_from_date_equal_to_first_entry_keeps_zero_opening_balance(
+        self, db_session: AsyncSession
+    ) -> None:
+        fy_2025 = await _create_fy(
+            db_session,
+            "2025",
+            start=date(2025, 1, 1),
+            end=date(2025, 12, 31),
+        )
+
+        await _add_entry(
+            db_session,
+            entry_number="000001",
+            entry_date=date(2025, 1, 1),
+            account_number="512102",
+            debit=Decimal("100"),
+            fiscal_year_id=fy_2025.id,
+            source_type=EntrySourceType.CLOTURE,
+            label="RAN 2024",
+        )
+        await _add_entry(
+            db_session,
+            entry_number="000002",
+            entry_date=date(2025, 1, 15),
+            account_number="512102",
+            credit=Decimal("30"),
+            fiscal_year_id=fy_2025.id,
+            label="Dépense janvier",
+        )
+
+        result = await get_ledger(
+            db_session,
+            "512102",
+            fiscal_year_id=fy_2025.id,
+            from_date=date(2025, 1, 1),
+        )
+
+        assert result.opening_balance == Decimal("0")
+        assert [entry.entry_number for entry in result.entries] == ["000001", "000002"]
+
+    @pytest.mark.asyncio
+    async def test_from_date_before_first_entry_keeps_zero_opening_balance(
+        self, db_session: AsyncSession
+    ) -> None:
+        fy_2025 = await _create_fy(
+            db_session,
+            "2025",
+            start=date(2025, 1, 1),
+            end=date(2025, 12, 31),
+        )
+
+        await _add_entry(
+            db_session,
+            entry_number="000001",
+            entry_date=date(2025, 1, 10),
+            account_number="512102",
+            debit=Decimal("100"),
+            fiscal_year_id=fy_2025.id,
+            label="Encaissement janvier",
+        )
+
+        result = await get_ledger(
+            db_session,
+            "512102",
+            fiscal_year_id=fy_2025.id,
+            from_date=date(2025, 1, 5),
+        )
+
+        assert result.opening_balance == Decimal("0")
+        assert [entry.entry_number for entry in result.entries] == ["000001"]
+
 
 # ---------------------------------------------------------------------------
 # Compte de résultat

--- a/tests/unit/test_accounting_entry_service.py
+++ b/tests/unit/test_accounting_entry_service.py
@@ -64,11 +64,16 @@ async def _add_account(
     return a
 
 
-async def _create_fy(db: AsyncSession, name: str = "2024") -> FiscalYear:
+async def _create_fy(
+    db: AsyncSession,
+    name: str = "2024",
+    start: date | None = None,
+    end: date | None = None,
+) -> FiscalYear:
     fy = FiscalYear(
         name=name,
-        start_date=date(2024, 1, 1),
-        end_date=date(2024, 12, 31),
+        start_date=start or date(2024, 1, 1),
+        end_date=end or date(2024, 12, 31),
         status=FiscalYearStatus.OPEN,
     )
     db.add(fy)
@@ -345,6 +350,108 @@ class TestGetLedger:
         )
         result = await get_ledger(db_session, "411100")
         assert result.account_label == "Clients débiteurs"
+
+    @pytest.mark.asyncio
+    async def test_filters_entries_by_fiscal_year(self, db_session: AsyncSession) -> None:
+        fy_2024 = await _create_fy(
+            db_session,
+            "2024",
+            start=date(2024, 1, 1),
+            end=date(2024, 12, 31),
+        )
+        fy_2025 = await _create_fy(
+            db_session,
+            "2025",
+            start=date(2025, 1, 1),
+            end=date(2025, 12, 31),
+        )
+
+        await _add_entry(
+            db_session,
+            entry_number="000001",
+            entry_date=date(2024, 12, 31),
+            account_number="512102",
+            debit=Decimal("100"),
+            fiscal_year_id=fy_2024.id,
+            label="Solde 2024",
+        )
+        await _add_entry(
+            db_session,
+            entry_number="000002",
+            entry_date=date(2025, 1, 1),
+            account_number="512102",
+            debit=Decimal("100"),
+            fiscal_year_id=fy_2025.id,
+            source_type=EntrySourceType.CLOTURE,
+            label="RAN 2024",
+        )
+        await _add_entry(
+            db_session,
+            entry_number="000003",
+            entry_date=date(2025, 2, 10),
+            account_number="512102",
+            credit=Decimal("30"),
+            fiscal_year_id=fy_2025.id,
+            label="Dépense 2025",
+        )
+
+        result = await get_ledger(db_session, "512102", fiscal_year_id=fy_2025.id)
+
+        assert [entry.entry_number for entry in result.entries] == ["000002", "000003"]
+        assert result.opening_balance == Decimal("0")
+        assert result.closing_balance == Decimal("70")
+
+    @pytest.mark.asyncio
+    async def test_uses_prior_entries_as_opening_balance_within_fiscal_year(
+        self, db_session: AsyncSession
+    ) -> None:
+        fy_2025 = await _create_fy(
+            db_session,
+            "2025",
+            start=date(2025, 1, 1),
+            end=date(2025, 12, 31),
+        )
+
+        await _add_entry(
+            db_session,
+            entry_number="000001",
+            entry_date=date(2025, 1, 1),
+            account_number="512102",
+            debit=Decimal("100"),
+            fiscal_year_id=fy_2025.id,
+            source_type=EntrySourceType.CLOTURE,
+            label="RAN 2024",
+        )
+        await _add_entry(
+            db_session,
+            entry_number="000002",
+            entry_date=date(2025, 1, 15),
+            account_number="512102",
+            debit=Decimal("50"),
+            fiscal_year_id=fy_2025.id,
+            label="Encaissement janvier",
+        )
+        await _add_entry(
+            db_session,
+            entry_number="000003",
+            entry_date=date(2025, 2, 10),
+            account_number="512102",
+            credit=Decimal("30"),
+            fiscal_year_id=fy_2025.id,
+            label="Dépense février",
+        )
+
+        result = await get_ledger(
+            db_session,
+            "512102",
+            fiscal_year_id=fy_2025.id,
+            from_date=date(2025, 2, 1),
+        )
+
+        assert result.opening_balance == Decimal("150")
+        assert [entry.entry_number for entry in result.entries] == ["000003"]
+        assert result.entries[0].running_balance == Decimal("120")
+        assert result.closing_balance == Decimal("120")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
This PR fixes BL-025 by making the ledger operate within a single selected fiscal year, so opening entries and running balances no longer mix multiple fiscal years.

- require a fiscal year filter on the ledger endpoint and wire the ledger view to the current fiscal year by default
- compute the opening balance from prior entries inside the selected fiscal year when a start date is applied
- add backend tests for fiscal-year filtering and opening-balance behavior, and update the backlog status for BL-025

Checks performed:
- `python -m ruff check .`
- `python -m ruff format --check .`
- `python -m mypy backend tests`
- `python -m pytest tests`
- `npm --prefix frontend run test:unit -- --run`
- `npm --prefix frontend run type-check`
- `npm --prefix frontend run build`

## Summary by Sourcery

Scope the ledger to a single selected fiscal year and compute opening balances within that fiscal year when filtering by start date.

Bug Fixes:
- Ensure the ledger API only returns entries for the specified fiscal year and requires a fiscal_year_id filter, preventing multi-year mixes in balances.

Enhancements:
- Add a fiscal year selector to the ledger view, defaulting to the current fiscal year and updating empty-state messaging to guide selection.
- Adjust ledger opening-balance calculation to use prior entries within the selected fiscal year when a from_date is applied.

Documentation:
- Update backlog documentation to capture the product decision and completion of BL-025 regarding fiscal-year-bounded ledger behavior.

Tests:
- Extend integration and unit tests to cover fiscal-year filtering and opening-balance behavior in the ledger, including flexible fiscal-year date helpers.