### PR TITLE
Add treasury system opening support

### DIFF
--- a/backend/alembic/versions/0013_add_cash_register_source.py
+++ b/backend/alembic/versions/0013_add_cash_register_source.py
@@ -1,0 +1,36 @@
+"""Migration 0013 — add cash register source marker."""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0013"
+down_revision = "0012"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("cash_register") as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "source",
+                sa.String(length=20),
+                nullable=False,
+                server_default="manual",
+            )
+        )
+        batch_op.create_index("ix_cash_register_source", ["source"])
+
+    op.execute(
+        """
+        UPDATE cash_register
+        SET source = 'system_opening'
+        WHERE description = 'Ouverture du système'
+        """
+    )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("cash_register") as batch_op:
+        batch_op.drop_index("ix_cash_register_source")
+        batch_op.drop_column("source")

--- a/backend/models/bank.py
+++ b/backend/models/bank.py
@@ -19,6 +19,7 @@ _Decimal = Decimal
 class BankTransactionSource(StrEnum):
     MANUAL = "manual"
     IMPORT = "import"
+    SYSTEM_OPENING = "system_opening"
 
 
 class DepositType(StrEnum):
@@ -54,6 +55,10 @@ class BankTransaction(Base):
     created_at: Mapped[datetime] = mapped_column(
         DateTime, nullable=False, server_default=func.now()
     )
+
+    @property
+    def is_system_opening(self) -> bool:
+        return self.source == BankTransactionSource.SYSTEM_OPENING
 
 
 class Deposit(Base):

--- a/backend/models/cash.py
+++ b/backend/models/cash.py
@@ -44,6 +44,10 @@ class CashRegister(Base):
         DateTime, nullable=False, server_default=func.now()
     )
 
+    @property
+    def is_system_opening(self) -> bool:
+        return self.description == "Ouverture du système"
+
 
 class CashCount(Base):
     """Physical cash counting record."""

--- a/backend/models/cash.py
+++ b/backend/models/cash.py
@@ -20,6 +20,14 @@ class CashMovementType(StrEnum):
     OUT = "out"
 
 
+class CashEntrySource(StrEnum):
+    MANUAL = "manual"
+    SYSTEM_OPENING = "system_opening"
+
+
+CASH_SYSTEM_OPENING_DESCRIPTION = "Ouverture du système"
+
+
 class CashRegister(Base):
     """Journal entry for the cash register."""
 
@@ -37,6 +45,9 @@ class CashRegister(Base):
     )
     reference: Mapped[str | None] = mapped_column(String(100), nullable=True)
     description: Mapped[str] = mapped_column(Text, nullable=False, default="")
+    source: Mapped[CashEntrySource] = mapped_column(
+        String(20), nullable=False, index=True, default=CashEntrySource.MANUAL
+    )
     balance_after: Mapped[_Decimal] = mapped_column(
         Numeric(10, 2), nullable=False, default=Decimal("0")
     )
@@ -46,7 +57,7 @@ class CashRegister(Base):
 
     @property
     def is_system_opening(self) -> bool:
-        return self.description == "Ouverture du système"
+        return self.source == CashEntrySource.SYSTEM_OPENING
 
 
 class CashCount(Base):

--- a/backend/routers/settings.py
+++ b/backend/routers/settings.py
@@ -8,7 +8,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from backend.database import get_db
 from backend.models.user import User, UserRole
 from backend.routers.auth import require_role
-from backend.schemas.settings import AppSettingsRead, AppSettingsUpdate
+from backend.schemas.settings import (
+    AppSettingsRead,
+    AppSettingsUpdate,
+    TreasurySystemOpeningRead,
+    TreasurySystemOpeningUpdate,
+)
 from backend.services import settings as settings_service
 
 router = APIRouter(prefix="/settings", tags=["settings"])
@@ -33,6 +38,25 @@ async def update_settings(
 ) -> AppSettingsRead:
     """Update application settings (admin only)."""
     return await settings_service.update_settings(db, payload)  # type: ignore[return-value]
+
+
+@router.get("/system-opening", response_model=TreasurySystemOpeningRead)
+async def get_system_opening(
+    db: Annotated[AsyncSession, Depends(get_db)],
+    _current_user: _AdminRequired,
+) -> TreasurySystemOpeningRead:
+    """Return the current treasury system opening configuration (admin only)."""
+    return await settings_service.get_treasury_system_opening(db)
+
+
+@router.put("/system-opening", response_model=TreasurySystemOpeningRead)
+async def update_system_opening(
+    payload: TreasurySystemOpeningUpdate,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    _current_user: _AdminRequired,
+) -> TreasurySystemOpeningRead:
+    """Create or update the treasury system opening entries (admin only)."""
+    return await settings_service.upsert_treasury_system_opening(db, payload)
 
 
 @router.post("/reset-db", response_model=dict[str, int])

--- a/backend/schemas/cash.py
+++ b/backend/schemas/cash.py
@@ -54,6 +54,7 @@ class CashEntryRead(BaseModel):
     reference: str | None
     description: str
     balance_after: _Decimal
+    is_system_opening: bool
 
     model_config = {"from_attributes": True}
 

--- a/backend/schemas/settings.py
+++ b/backend/schemas/settings.py
@@ -1,5 +1,10 @@
 """Pydantic schemas for application settings."""
 
+from __future__ import annotations
+
+from datetime import date as _Date
+from decimal import Decimal as _Decimal
+
 from pydantic import BaseModel, field_validator
 
 
@@ -52,3 +57,34 @@ class AppSettingsUpdate(BaseModel):
         if v is not None and not 1 <= v <= 65535:
             raise ValueError("smtp_port must be between 1 and 65535")
         return v
+
+
+class SystemOpeningRead(BaseModel):
+    configured: bool
+    date: _Date | None = None
+    amount: _Decimal | None = None
+    reference: str | None = None
+
+
+class TreasurySystemOpeningRead(BaseModel):
+    default_date: _Date | None = None
+    bank: SystemOpeningRead
+    cash: SystemOpeningRead
+
+
+class SystemOpeningUpdate(BaseModel):
+    date: _Date
+    amount: _Decimal
+    reference: str | None = None
+
+    @field_validator("amount")
+    @classmethod
+    def amount_not_zero(cls, v: _Decimal) -> _Decimal:
+        if v == 0:
+            raise ValueError("amount must not be zero")
+        return v
+
+
+class TreasurySystemOpeningUpdate(BaseModel):
+    bank: SystemOpeningUpdate
+    cash: SystemOpeningUpdate

--- a/backend/services/bank_service.py
+++ b/backend/services/bank_service.py
@@ -24,15 +24,34 @@ async def _current_bank_balance(db: AsyncSession) -> Decimal:
     return Decimal(str(total))
 
 
+async def recompute_bank_balances(db: AsyncSession) -> bool:
+    """Recompute running bank balances and report whether persisted values changed."""
+    result = await db.execute(
+        select(BankTransaction).order_by(BankTransaction.date.asc(), BankTransaction.id.asc())
+    )
+    running_balance = Decimal("0")
+    changed = False
+    for entry in result.scalars().all():
+        running_balance += Decimal(str(entry.amount))
+        if entry.balance_after != running_balance:
+            entry.balance_after = running_balance
+            changed = True
+    return changed
+
+
 async def add_transaction(db: AsyncSession, payload: BankTransactionCreate) -> BankTransaction:
     tx = BankTransaction(**payload.model_dump())
     db.add(tx)
+    await db.flush()
+    await recompute_bank_balances(db)
     await db.commit()
     await db.refresh(tx)
     return tx
 
 
 async def get_transaction(db: AsyncSession, tx_id: int) -> BankTransaction | None:
+    if await recompute_bank_balances(db):
+        await db.commit()
     result = await db.execute(select(BankTransaction).where(BankTransaction.id == tx_id))
     return result.scalar_one_or_none()
 
@@ -46,6 +65,8 @@ async def list_transactions(
     skip: int = 0,
     limit: int | None = None,
 ) -> list[BankTransaction]:
+    if await recompute_bank_balances(db):
+        await db.commit()
     query = select(BankTransaction)
     if from_date is not None:
         query = query.where(BankTransaction.date >= from_date)
@@ -66,6 +87,8 @@ async def update_transaction(
 ) -> BankTransaction:
     for field, value in payload.model_dump(exclude_unset=True).items():
         setattr(tx, field, value)
+    await db.flush()
+    await recompute_bank_balances(db)
     await db.commit()
     await db.refresh(tx)
     return tx

--- a/backend/services/bank_service.py
+++ b/backend/services/bank_service.py
@@ -50,8 +50,6 @@ async def add_transaction(db: AsyncSession, payload: BankTransactionCreate) -> B
 
 
 async def get_transaction(db: AsyncSession, tx_id: int) -> BankTransaction | None:
-    if await recompute_bank_balances(db):
-        await db.commit()
     result = await db.execute(select(BankTransaction).where(BankTransaction.id == tx_id))
     return result.scalar_one_or_none()
 
@@ -65,8 +63,6 @@ async def list_transactions(
     skip: int = 0,
     limit: int | None = None,
 ) -> list[BankTransaction]:
-    if await recompute_bank_balances(db):
-        await db.commit()
     query = select(BankTransaction)
     if from_date is not None:
         query = query.where(BankTransaction.date >= from_date)

--- a/backend/services/cash_service.py
+++ b/backend/services/cash_service.py
@@ -8,7 +8,7 @@ from decimal import Decimal
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from backend.models.cash import CashCount, CashMovementType, CashRegister
+from backend.models.cash import CashCount, CashEntrySource, CashMovementType, CashRegister
 from backend.schemas.cash import CashCountCreate, CashEntryCreate, CashEntryUpdate
 
 # Denomination values in euros
@@ -70,6 +70,7 @@ async def add_cash_entry(db: AsyncSession, payload: CashEntryCreate) -> CashRegi
         payment_id=payload.payment_id,
         reference=payload.reference,
         description=payload.description,
+        source=CashEntrySource.MANUAL,
         balance_after=Decimal("0"),
     )
     db.add(entry)

--- a/backend/services/excel_import.py
+++ b/backend/services/excel_import.py
@@ -1975,7 +1975,7 @@ async def _import_cash_sheet(db: AsyncSession, ws: Any, result: ImportResult) ->
     Expected columns (flexible): date | libellé/description | entrée | sortie
     or: date | description | montant | type (E/S or in/out)
     """
-    from backend.models.cash import CashMovementType, CashRegister  # noqa: PLC0415
+    from backend.models.cash import CashEntrySource, CashMovementType, CashRegister  # noqa: PLC0415
     from backend.models.invoice import Invoice, InvoiceType  # noqa: PLC0415
     from backend.models.payment import Payment  # noqa: PLC0415
     from backend.services.accounting_engine import (  # noqa: PLC0415
@@ -2034,6 +2034,7 @@ async def _import_cash_sheet(db: AsyncSession, ws: Any, result: ImportResult) ->
             payment_id=payment_id,
             reference=cash_row.reference,
             description=cash_row.description,
+            source=CashEntrySource.MANUAL,
             balance_after=Decimal("0"),
         )
         db.add(entry)

--- a/backend/services/excel_import_parsers.py
+++ b/backend/services/excel_import_parsers.py
@@ -719,20 +719,21 @@ def parse_bank_sheet(
             amount = parse_decimal(get_row_value(row, montant_idx))
 
         entry_date = parse_date(get_row_value(row, date_idx))
-        if entry_date is None:
-            if should_ignore_bank_balance_description(
-                entry_date=entry_date,
-                amount=amount,
-                label=parse_str(get_row_value(row, libelle_idx)),
-                balance=parse_decimal(get_row_value(row, solde_idx)),
-            ):
-                ignored_issues.append(
-                    RowIgnoredIssue(
-                        source_row_number=source_row_number,
-                        message=BANK_BALANCE_DESCRIPTION_MESSAGE,
-                    )
+        if should_ignore_bank_balance_description(
+            entry_date=entry_date,
+            amount=amount,
+            label=parse_str(get_row_value(row, libelle_idx)),
+            balance=parse_decimal(get_row_value(row, solde_idx)),
+        ):
+            ignored_issues.append(
+                RowIgnoredIssue(
+                    source_row_number=source_row_number,
+                    message=BANK_BALANCE_DESCRIPTION_MESSAGE,
                 )
-                continue
+            )
+            continue
+
+        if entry_date is None:
             issues.append(make_validation_issue(source_row_number, [BANK_INVALID_DATE_MESSAGE]))
             continue
 

--- a/backend/services/excel_import_policy.py
+++ b/backend/services/excel_import_policy.py
@@ -232,11 +232,13 @@ def should_ignore_bank_balance_description(
     balance: Decimal | None,
 ) -> bool:
     """Return True when the row only documents a balance without a movement."""
+    normalized_label = label.strip().casefold()
+    has_balance_marker = any(marker in normalized_label for marker in ("solde", "ouverture"))
     return (
-        entry_date is None
-        and amount in (None, Decimal("0"))
+        amount in (None, Decimal("0"))
         and bool(label)
         and balance is not None
+        and (entry_date is None or has_balance_marker)
     )
 
 

--- a/backend/services/settings.py
+++ b/backend/services/settings.py
@@ -2,6 +2,7 @@
 
 import logging
 from datetime import date
+from decimal import Decimal
 from typing import Any, cast
 
 from sqlalchemy import delete, select
@@ -10,13 +11,16 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.database import Base
 from backend.models.app_settings import AppSettings
+from backend.models.bank import BankTransaction, BankTransactionSource
+from backend.models.cash import CashMovementType, CashRegister
 from backend.models.fiscal_year import FiscalYear, FiscalYearStatus
-from backend.schemas.settings import AppSettingsUpdate
+from backend.schemas.settings import AppSettingsUpdate, SystemOpeningRead, TreasurySystemOpeningRead, TreasurySystemOpeningUpdate
 
 logger = logging.getLogger(__name__)
 
 _SETTINGS_ID = 1
 _PRESERVED_TABLES = {"users"}
+_SYSTEM_OPENING_DESCRIPTION = "Ouverture du système"
 
 
 async def get_settings(db: AsyncSession) -> AppSettings:
@@ -39,6 +43,125 @@ async def update_settings(db: AsyncSession, payload: AppSettingsUpdate) -> AppSe
     await db.commit()
     await db.refresh(settings)
     return settings
+
+
+def _to_signed_cash_amount(entry: CashRegister | None) -> Decimal | None:
+    if entry is None:
+        return None
+    amount = Decimal(str(entry.amount))
+    return amount if entry.type == CashMovementType.IN else -amount
+
+
+async def _get_default_system_opening_date(db: AsyncSession) -> date | None:
+    result = await db.execute(select(FiscalYear.start_date).order_by(FiscalYear.start_date.asc()))
+    return result.scalars().first()
+
+
+async def get_treasury_system_opening(db: AsyncSession) -> TreasurySystemOpeningRead:
+    default_date = await _get_default_system_opening_date(db)
+    bank_entry = (
+        await db.execute(
+            select(BankTransaction)
+            .where(BankTransaction.source == BankTransactionSource.SYSTEM_OPENING)
+            .order_by(BankTransaction.date.asc(), BankTransaction.id.asc())
+        )
+    ).scalars().first()
+    cash_entry = (
+        await db.execute(
+            select(CashRegister)
+            .where(CashRegister.description == _SYSTEM_OPENING_DESCRIPTION)
+            .order_by(CashRegister.date.asc(), CashRegister.id.asc())
+        )
+    ).scalars().first()
+
+    return TreasurySystemOpeningRead(
+        default_date=default_date,
+        bank=SystemOpeningRead(
+            configured=bank_entry is not None,
+            date=bank_entry.date if bank_entry is not None else None,
+            amount=Decimal(str(bank_entry.amount)) if bank_entry is not None else None,
+            reference=bank_entry.reference if bank_entry is not None else None,
+        ),
+        cash=SystemOpeningRead(
+            configured=cash_entry is not None,
+            date=cash_entry.date if cash_entry is not None else None,
+            amount=_to_signed_cash_amount(cash_entry),
+            reference=cash_entry.reference if cash_entry is not None else None,
+        ),
+    )
+
+
+async def upsert_treasury_system_opening(
+    db: AsyncSession, payload: TreasurySystemOpeningUpdate
+) -> TreasurySystemOpeningRead:
+    from backend.services.bank_service import recompute_bank_balances
+    from backend.services.cash_service import recompute_cash_balances
+
+    bank_entries = (
+        await db.execute(
+            select(BankTransaction)
+            .where(BankTransaction.source == BankTransactionSource.SYSTEM_OPENING)
+            .order_by(BankTransaction.id.asc())
+        )
+    ).scalars().all()
+    cash_entries = (
+        await db.execute(
+            select(CashRegister)
+            .where(CashRegister.description == _SYSTEM_OPENING_DESCRIPTION)
+            .order_by(CashRegister.id.asc())
+        )
+    ).scalars().all()
+
+    bank_entry = bank_entries[0] if bank_entries else None
+    cash_entry = cash_entries[0] if cash_entries else None
+
+    for extra_entry in bank_entries[1:]:
+        await db.delete(extra_entry)
+    for extra_entry in cash_entries[1:]:
+        await db.delete(extra_entry)
+
+    if bank_entry is None:
+        bank_entry = BankTransaction(
+            date=payload.bank.date,
+            amount=payload.bank.amount,
+            reference=payload.bank.reference,
+            description=_SYSTEM_OPENING_DESCRIPTION,
+            balance_after=Decimal("0"),
+            source=BankTransactionSource.SYSTEM_OPENING,
+        )
+        db.add(bank_entry)
+    else:
+        bank_entry.date = payload.bank.date
+        bank_entry.amount = payload.bank.amount
+        bank_entry.reference = payload.bank.reference
+        bank_entry.description = _SYSTEM_OPENING_DESCRIPTION
+        bank_entry.source = BankTransactionSource.SYSTEM_OPENING
+
+    cash_amount = abs(payload.cash.amount)
+    cash_type = CashMovementType.IN if payload.cash.amount > 0 else CashMovementType.OUT
+    if cash_entry is None:
+        cash_entry = CashRegister(
+            date=payload.cash.date,
+            amount=cash_amount,
+            type=cash_type,
+            reference=payload.cash.reference,
+            description=_SYSTEM_OPENING_DESCRIPTION,
+            balance_after=Decimal("0"),
+        )
+        db.add(cash_entry)
+    else:
+        cash_entry.date = payload.cash.date
+        cash_entry.amount = cash_amount
+        cash_entry.type = cash_type
+        cash_entry.reference = payload.cash.reference
+        cash_entry.description = _SYSTEM_OPENING_DESCRIPTION
+
+    await db.flush()
+    await recompute_bank_balances(db)
+    await recompute_cash_balances(db)
+    await db.commit()
+
+    return await get_treasury_system_opening(db)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/services/settings.py
+++ b/backend/services/settings.py
@@ -12,7 +12,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from backend.database import Base
 from backend.models.app_settings import AppSettings
 from backend.models.bank import BankTransaction, BankTransactionSource
-from backend.models.cash import CashMovementType, CashRegister
+from backend.models.cash import (
+    CASH_SYSTEM_OPENING_DESCRIPTION,
+    CashEntrySource,
+    CashMovementType,
+    CashRegister,
+)
 from backend.models.fiscal_year import FiscalYear, FiscalYearStatus
 from backend.schemas.settings import (
     AppSettingsUpdate,
@@ -25,7 +30,6 @@ logger = logging.getLogger(__name__)
 
 _SETTINGS_ID = 1
 _PRESERVED_TABLES = {"users"}
-_SYSTEM_OPENING_DESCRIPTION = "Ouverture du système"
 
 
 async def get_settings(db: AsyncSession) -> AppSettings:
@@ -79,7 +83,7 @@ async def get_treasury_system_opening(db: AsyncSession) -> TreasurySystemOpening
         (
             await db.execute(
                 select(CashRegister)
-                .where(CashRegister.description == _SYSTEM_OPENING_DESCRIPTION)
+                .where(CashRegister.source == CashEntrySource.SYSTEM_OPENING)
                 .order_by(CashRegister.date.asc(), CashRegister.id.asc())
             )
         )
@@ -125,7 +129,7 @@ async def upsert_treasury_system_opening(
         (
             await db.execute(
                 select(CashRegister)
-                .where(CashRegister.description == _SYSTEM_OPENING_DESCRIPTION)
+                .where(CashRegister.source == CashEntrySource.SYSTEM_OPENING)
                 .order_by(CashRegister.id.asc())
             )
         )
@@ -146,7 +150,7 @@ async def upsert_treasury_system_opening(
             date=payload.bank.date,
             amount=payload.bank.amount,
             reference=payload.bank.reference,
-            description=_SYSTEM_OPENING_DESCRIPTION,
+            description=CASH_SYSTEM_OPENING_DESCRIPTION,
             balance_after=Decimal("0"),
             source=BankTransactionSource.SYSTEM_OPENING,
         )
@@ -155,7 +159,7 @@ async def upsert_treasury_system_opening(
         bank_entry.date = payload.bank.date
         bank_entry.amount = payload.bank.amount
         bank_entry.reference = payload.bank.reference
-        bank_entry.description = _SYSTEM_OPENING_DESCRIPTION
+        bank_entry.description = CASH_SYSTEM_OPENING_DESCRIPTION
         bank_entry.source = BankTransactionSource.SYSTEM_OPENING
 
     cash_amount = abs(payload.cash.amount)
@@ -166,7 +170,8 @@ async def upsert_treasury_system_opening(
             amount=cash_amount,
             type=cash_type,
             reference=payload.cash.reference,
-            description=_SYSTEM_OPENING_DESCRIPTION,
+            description=CASH_SYSTEM_OPENING_DESCRIPTION,
+            source=CashEntrySource.SYSTEM_OPENING,
             balance_after=Decimal("0"),
         )
         db.add(cash_entry)
@@ -175,7 +180,8 @@ async def upsert_treasury_system_opening(
         cash_entry.amount = cash_amount
         cash_entry.type = cash_type
         cash_entry.reference = payload.cash.reference
-        cash_entry.description = _SYSTEM_OPENING_DESCRIPTION
+        cash_entry.description = CASH_SYSTEM_OPENING_DESCRIPTION
+        cash_entry.source = CashEntrySource.SYSTEM_OPENING
 
     await db.flush()
     await recompute_bank_balances(db)

--- a/backend/services/settings.py
+++ b/backend/services/settings.py
@@ -14,7 +14,12 @@ from backend.models.app_settings import AppSettings
 from backend.models.bank import BankTransaction, BankTransactionSource
 from backend.models.cash import CashMovementType, CashRegister
 from backend.models.fiscal_year import FiscalYear, FiscalYearStatus
-from backend.schemas.settings import AppSettingsUpdate, SystemOpeningRead, TreasurySystemOpeningRead, TreasurySystemOpeningUpdate
+from backend.schemas.settings import (
+    AppSettingsUpdate,
+    SystemOpeningRead,
+    TreasurySystemOpeningRead,
+    TreasurySystemOpeningUpdate,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -60,19 +65,27 @@ async def _get_default_system_opening_date(db: AsyncSession) -> date | None:
 async def get_treasury_system_opening(db: AsyncSession) -> TreasurySystemOpeningRead:
     default_date = await _get_default_system_opening_date(db)
     bank_entry = (
-        await db.execute(
-            select(BankTransaction)
-            .where(BankTransaction.source == BankTransactionSource.SYSTEM_OPENING)
-            .order_by(BankTransaction.date.asc(), BankTransaction.id.asc())
+        (
+            await db.execute(
+                select(BankTransaction)
+                .where(BankTransaction.source == BankTransactionSource.SYSTEM_OPENING)
+                .order_by(BankTransaction.date.asc(), BankTransaction.id.asc())
+            )
         )
-    ).scalars().first()
+        .scalars()
+        .first()
+    )
     cash_entry = (
-        await db.execute(
-            select(CashRegister)
-            .where(CashRegister.description == _SYSTEM_OPENING_DESCRIPTION)
-            .order_by(CashRegister.date.asc(), CashRegister.id.asc())
+        (
+            await db.execute(
+                select(CashRegister)
+                .where(CashRegister.description == _SYSTEM_OPENING_DESCRIPTION)
+                .order_by(CashRegister.date.asc(), CashRegister.id.asc())
+            )
         )
-    ).scalars().first()
+        .scalars()
+        .first()
+    )
 
     return TreasurySystemOpeningRead(
         default_date=default_date,
@@ -98,27 +111,35 @@ async def upsert_treasury_system_opening(
     from backend.services.cash_service import recompute_cash_balances
 
     bank_entries = (
-        await db.execute(
-            select(BankTransaction)
-            .where(BankTransaction.source == BankTransactionSource.SYSTEM_OPENING)
-            .order_by(BankTransaction.id.asc())
+        (
+            await db.execute(
+                select(BankTransaction)
+                .where(BankTransaction.source == BankTransactionSource.SYSTEM_OPENING)
+                .order_by(BankTransaction.id.asc())
+            )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     cash_entries = (
-        await db.execute(
-            select(CashRegister)
-            .where(CashRegister.description == _SYSTEM_OPENING_DESCRIPTION)
-            .order_by(CashRegister.id.asc())
+        (
+            await db.execute(
+                select(CashRegister)
+                .where(CashRegister.description == _SYSTEM_OPENING_DESCRIPTION)
+                .order_by(CashRegister.id.asc())
+            )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
 
-    bank_entry = bank_entries[0] if bank_entries else None
-    cash_entry = cash_entries[0] if cash_entries else None
+    bank_entry: BankTransaction | None = bank_entries[0] if bank_entries else None
+    cash_entry: CashRegister | None = cash_entries[0] if cash_entries else None
 
-    for extra_entry in bank_entries[1:]:
-        await db.delete(extra_entry)
-    for extra_entry in cash_entries[1:]:
-        await db.delete(extra_entry)
+    for extra_bank_entry in bank_entries[1:]:
+        await db.delete(extra_bank_entry)
+    for extra_cash_entry in cash_entries[1:]:
+        await db.delete(extra_cash_entry)
 
     if bank_entry is None:
         bank_entry = BankTransaction(

--- a/frontend/src/api/bank.ts
+++ b/frontend/src/api/bank.ts
@@ -1,7 +1,7 @@
 import apiClient from './client'
 
 export type DepositType = 'cheques' | 'especes'
-export type BankTransactionSource = 'manual' | 'import'
+export type BankTransactionSource = 'manual' | 'import' | 'system_opening'
 
 export interface BankTransaction {
   id: number

--- a/frontend/src/api/cash.ts
+++ b/frontend/src/api/cash.ts
@@ -12,6 +12,7 @@ export interface CashEntry {
   reference: string | null
   description: string
   balance_after: string
+  is_system_opening: boolean
 }
 
 export interface CashEntryCreate {

--- a/frontend/src/api/settings.ts
+++ b/frontend/src/api/settings.ts
@@ -26,6 +26,30 @@ export interface AppSettingsUpdate {
   smtp_use_tls?: boolean
 }
 
+export interface SystemOpening {
+  configured: boolean
+  date: string | null
+  amount: string | null
+  reference: string | null
+}
+
+export interface TreasurySystemOpening {
+  default_date: string | null
+  bank: SystemOpening
+  cash: SystemOpening
+}
+
+export interface SystemOpeningUpdate {
+  date: string
+  amount: string
+  reference?: string | null
+}
+
+export interface TreasurySystemOpeningUpdate {
+  bank: SystemOpeningUpdate
+  cash: SystemOpeningUpdate
+}
+
 export async function getSettingsApi(): Promise<AppSettings> {
   const response = await apiClient.get<AppSettings>('/api/settings/')
   return response.data
@@ -33,6 +57,21 @@ export async function getSettingsApi(): Promise<AppSettings> {
 
 export async function updateSettingsApi(payload: AppSettingsUpdate): Promise<AppSettings> {
   const response = await apiClient.put<AppSettings>('/api/settings/', payload)
+  return response.data
+}
+
+export async function getSystemOpeningApi(): Promise<TreasurySystemOpening> {
+  const response = await apiClient.get<TreasurySystemOpening>('/api/settings/system-opening')
+  return response.data
+}
+
+export async function updateSystemOpeningApi(
+  payload: TreasurySystemOpeningUpdate,
+): Promise<TreasurySystemOpening> {
+  const response = await apiClient.put<TreasurySystemOpening>(
+    '/api/settings/system-opening',
+    payload,
+  )
   return response.data
 }
 

--- a/frontend/src/i18n/fr.ts
+++ b/frontend/src/i18n/fr.ts
@@ -397,6 +397,7 @@ export default {
     entry_date: 'Date',
     entry_amount: 'Montant',
     entry_type: 'Type',
+    entry_origin: 'Origine',
     entry_description: 'Description',
     entry_reference: 'Référence',
     balance_after: 'Solde après',
@@ -409,6 +410,9 @@ export default {
     movements: {
       in: 'Entrée',
       out: 'Sortie',
+    },
+    origins: {
+      system_opening: 'Ouverture du système',
     },
     metrics: {
       current_balance_caption: 'Toutes périodes confondues',
@@ -458,6 +462,7 @@ export default {
     sources: {
       manual: 'Manuel',
       import: 'Import',
+      system_opening: 'Ouverture du système',
     },
     deposit_types: {
       cheques: 'Chèques',
@@ -483,6 +488,29 @@ export default {
       'Identite administrative et informations qui structurent les documents emis.',
     section_smtp: 'Configuration e-mail (SMTP)',
     section_smtp_subtitle: "Parametres d'envoi pour les e-mails automatiques et les relances.",
+    system_opening_title: 'Ouverture du système',
+    system_opening_subtitle:
+      'Définis le point de départ réel de la banque et de la caisse sur le plus ancien exercice importé.',
+    system_opening_hint:
+      'Ces montants créent des écritures identifiées comme ouverture du système. Les valeurs négatives sont autorisées.',
+    system_opening_bank_title: 'Banque',
+    system_opening_bank_subtitle: 'Solde initial visible avant les premiers mouvements importés.',
+    system_opening_cash_title: 'Caisse',
+    system_opening_cash_subtitle: 'Espèces initiales connues au démarrage du système.',
+    system_opening_status_configured: 'Configurée',
+    system_opening_status_pending: 'À renseigner',
+    system_opening_date: 'Date',
+    system_opening_amount: 'Montant',
+    system_opening_reference: 'Référence / note',
+    system_opening_reference_placeholder: 'Ex : solde repris au 01/08/2024',
+    system_opening_default_date: 'Date par défaut proposée : {date}',
+    system_opening_save: "Enregistrer l'ouverture",
+    system_opening_saved: 'Ouverture du système enregistrée.',
+    system_opening_load_error: "Impossible de charger l'ouverture du système.",
+    system_opening_save_error: "Impossible d'enregistrer l'ouverture du système.",
+    system_opening_validation_error:
+      'Renseigne une date et un montant pour la banque et la caisse.',
+    system_opening_zero_error: 'Le montant doit être non nul pour la banque et la caisse.',
     asso_name: "Nom de l'association",
     siret: 'N° SIRET',
     address: 'Adresse',

--- a/frontend/src/i18n/fr.ts
+++ b/frontend/src/i18n/fr.ts
@@ -490,7 +490,7 @@ export default {
     section_smtp_subtitle: "Parametres d'envoi pour les e-mails automatiques et les relances.",
     system_opening_title: 'Ouverture du système',
     system_opening_subtitle:
-      'Définis le point de départ réel de la banque et de la caisse sur le plus ancien exercice importé.',
+      'Définissez le point de départ réel de la banque et de la caisse sur le plus ancien exercice importé.',
     system_opening_hint:
       'Ces montants créent des écritures identifiées comme ouverture du système. Les valeurs négatives sont autorisées.',
     system_opening_bank_title: 'Banque',

--- a/frontend/src/tests/views/CashView.spec.ts
+++ b/frontend/src/tests/views/CashView.spec.ts
@@ -60,6 +60,7 @@ const cashEntryFixture = {
   reference: 'CAISSE-2025-001',
   description: 'Participation sortie',
   balance_after: '145.00',
+  is_system_opening: false,
 }
 
 const ContainerStub = defineComponent({

--- a/frontend/src/tests/views/CashView.spec.ts
+++ b/frontend/src/tests/views/CashView.spec.ts
@@ -356,6 +356,16 @@ describe('CashView', () => {
     expect(wrapper.text()).toContain('Participation sortie')
   })
 
+  it('renders the system opening indicator when a cash entry is flagged', async () => {
+    mockListCashEntries.mockResolvedValue([{ ...cashEntryFixture, is_system_opening: true }])
+
+    const wrapper = mountView()
+    await flushView()
+
+    expect(wrapper.text()).toContain('cash.origins.system_opening')
+    expect(wrapper.find('.cash-entry-type__system-opening').exists()).toBe(true)
+  })
+
   it('edits a cash entry from the journal', async () => {
     const wrapper = mountView()
     await flushView()

--- a/frontend/src/views/BankView.vue
+++ b/frontend/src/views/BankView.vue
@@ -216,7 +216,10 @@
                 :show-add-button="false"
               >
                 <template #body="{ data }">
-                  <Tag :value="t(`bank.sources.${data.source}`)" severity="secondary" />
+                  <Tag
+                    :value="t(`bank.sources.${data.source}`)"
+                    :severity="data.source === 'system_opening' ? 'info' : 'secondary'"
+                  />
                 </template>
                 <template #filter="{ filterModel }">
                   <AppFilterMultiSelect
@@ -617,6 +620,7 @@ const depositTypeOptions = [
 const sourceOptions = [
   { label: t('bank.sources.manual'), value: 'manual' },
   { label: t('bank.sources.import'), value: 'import' },
+  { label: t('bank.sources.system_opening'), value: 'system_opening' },
 ]
 
 const yesNoOptions = [

--- a/frontend/src/views/CashView.vue
+++ b/frontend/src/views/CashView.vue
@@ -78,6 +78,7 @@
               :global-filter-fields="[
                 'date',
                 'type_label',
+                'origin_label',
                 'amount',
                 'reference',
                 'description',
@@ -110,10 +111,17 @@
                 :show-add-button="false"
               >
                 <template #body="{ data }">
-                  <Tag
-                    :value="t(`cash.movements.${data.type}`)"
-                    :severity="data.type === 'in' ? 'success' : 'danger'"
-                  />
+                  <div class="cash-entry-type">
+                    <Tag
+                      :value="t(`cash.movements.${data.type}`)"
+                      :severity="data.type === 'in' ? 'success' : 'danger'"
+                    />
+                    <Tag
+                      v-if="data.is_system_opening"
+                      :value="t('cash.origins.system_opening')"
+                      severity="info"
+                    />
+                  </div>
                 </template>
                 <template #filter="{ filterModel }">
                   <AppFilterMultiSelect
@@ -343,6 +351,10 @@
           <span class="cash-detail__label">{{ t('cash.entry_type') }}</span>
           <span>{{ t(`cash.movements.${selectedEntry.type}`) }}</span>
         </div>
+        <div v-if="selectedEntry.is_system_opening" class="cash-detail__row">
+          <span class="cash-detail__label">{{ t('cash.entry_origin') }}</span>
+          <Tag :value="t('cash.origins.system_opening')" severity="info" />
+        </div>
         <div class="cash-detail__row">
           <span class="cash-detail__label">{{ t('cash.entry_amount') }}</span>
           <span>{{ formatAmount(selectedEntry.amount) }}</span>
@@ -559,6 +571,7 @@ const entryRows = computed(() =>
   entries.value.map((entry) => ({
     ...entry,
     type_label: t(`cash.movements.${entry.type}`),
+    origin_label: entry.is_system_opening ? t('cash.origins.system_opening') : '',
     amount_value: parseFloat(entry.amount),
     balance_after_value: parseFloat(entry.balance_after),
   })),
@@ -869,6 +882,12 @@ onMounted(async () => {
 <style scoped>
 .cash-journal__actions {
   width: 8rem;
+}
+
+.cash-entry-type {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: var(--app-space-2);
 }
 
 .cash-form {

--- a/frontend/src/views/CashView.vue
+++ b/frontend/src/views/CashView.vue
@@ -119,6 +119,7 @@
                     <Tag
                       v-if="data.is_system_opening"
                       :value="t('cash.origins.system_opening')"
+                      class="cash-entry-type__system-opening"
                       severity="info"
                     />
                   </div>
@@ -353,7 +354,11 @@
         </div>
         <div v-if="selectedEntry.is_system_opening" class="cash-detail__row">
           <span class="cash-detail__label">{{ t('cash.entry_origin') }}</span>
-          <Tag :value="t('cash.origins.system_opening')" severity="info" />
+          <Tag
+            :value="t('cash.origins.system_opening')"
+            class="cash-entry-type__system-opening"
+            severity="info"
+          />
         </div>
         <div class="cash-detail__row">
           <span class="cash-detail__label">{{ t('cash.entry_amount') }}</span>

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -154,6 +154,173 @@
       {{ errorMessage }}
     </Message>
 
+    <form class="settings-form" @submit.prevent="saveSystemOpening">
+      <AppPanel
+        :title="t('settings.system_opening_title')"
+        :subtitle="t('settings.system_opening_subtitle')"
+      >
+        <p class="settings-opening__hint">{{ t('settings.system_opening_hint') }}</p>
+
+        <div class="settings-opening-grid">
+          <section class="settings-opening-card">
+            <div class="settings-opening-card__header">
+              <div>
+                <h3 class="settings-opening-card__title">
+                  {{ t('settings.system_opening_bank_title') }}
+                </h3>
+                <p class="settings-opening-card__subtitle">
+                  {{ t('settings.system_opening_bank_subtitle') }}
+                </p>
+              </div>
+              <Tag
+                :value="
+                  systemOpeningForm.bank.configured
+                    ? t('settings.system_opening_status_configured')
+                    : t('settings.system_opening_status_pending')
+                "
+                :severity="systemOpeningForm.bank.configured ? 'success' : 'warn'"
+              />
+            </div>
+
+            <div class="app-form-grid">
+              <div class="app-field">
+                <label for="system_opening_bank_date" class="app-field__label">
+                  {{ t('settings.system_opening_date') }}
+                </label>
+                <DatePicker
+                  id="system_opening_bank_date"
+                  v-model="systemOpeningForm.bank.date"
+                  date-format="yy-mm-dd"
+                  show-icon
+                  class="w-full"
+                />
+              </div>
+
+              <div class="app-field">
+                <label for="system_opening_bank_amount" class="app-field__label">
+                  {{ t('settings.system_opening_amount') }}
+                </label>
+                <InputNumber
+                  id="system_opening_bank_amount"
+                  v-model="systemOpeningForm.bank.amount"
+                  mode="decimal"
+                  :min-fraction-digits="2"
+                  :max-fraction-digits="2"
+                  class="w-full"
+                />
+              </div>
+
+              <div class="app-field app-field--full">
+                <label for="system_opening_bank_reference" class="app-field__label">
+                  {{ t('settings.system_opening_reference') }}
+                </label>
+                <InputText
+                  id="system_opening_bank_reference"
+                  v-model="systemOpeningForm.bank.reference"
+                  :placeholder="t('settings.system_opening_reference_placeholder')"
+                  class="w-full"
+                />
+              </div>
+            </div>
+          </section>
+
+          <section class="settings-opening-card">
+            <div class="settings-opening-card__header">
+              <div>
+                <h3 class="settings-opening-card__title">
+                  {{ t('settings.system_opening_cash_title') }}
+                </h3>
+                <p class="settings-opening-card__subtitle">
+                  {{ t('settings.system_opening_cash_subtitle') }}
+                </p>
+              </div>
+              <Tag
+                :value="
+                  systemOpeningForm.cash.configured
+                    ? t('settings.system_opening_status_configured')
+                    : t('settings.system_opening_status_pending')
+                "
+                :severity="systemOpeningForm.cash.configured ? 'success' : 'warn'"
+              />
+            </div>
+
+            <div class="app-form-grid">
+              <div class="app-field">
+                <label for="system_opening_cash_date" class="app-field__label">
+                  {{ t('settings.system_opening_date') }}
+                </label>
+                <DatePicker
+                  id="system_opening_cash_date"
+                  v-model="systemOpeningForm.cash.date"
+                  date-format="yy-mm-dd"
+                  show-icon
+                  class="w-full"
+                />
+              </div>
+
+              <div class="app-field">
+                <label for="system_opening_cash_amount" class="app-field__label">
+                  {{ t('settings.system_opening_amount') }}
+                </label>
+                <InputNumber
+                  id="system_opening_cash_amount"
+                  v-model="systemOpeningForm.cash.amount"
+                  mode="decimal"
+                  :min-fraction-digits="2"
+                  :max-fraction-digits="2"
+                  class="w-full"
+                />
+              </div>
+
+              <div class="app-field app-field--full">
+                <label for="system_opening_cash_reference" class="app-field__label">
+                  {{ t('settings.system_opening_reference') }}
+                </label>
+                <InputText
+                  id="system_opening_cash_reference"
+                  v-model="systemOpeningForm.cash.reference"
+                  :placeholder="t('settings.system_opening_reference_placeholder')"
+                  class="w-full"
+                />
+              </div>
+            </div>
+          </section>
+        </div>
+
+        <p v-if="systemOpeningDefaultDateLabel" class="settings-opening__default-date">
+          {{ t('settings.system_opening_default_date', { date: systemOpeningDefaultDateLabel }) }}
+        </p>
+
+        <div class="app-form-actions">
+          <Button
+            type="button"
+            :label="t('common.cancel')"
+            severity="secondary"
+            :disabled="systemOpeningSaving"
+            @click="resetSystemOpening"
+          />
+          <Button
+            type="submit"
+            :label="t('settings.system_opening_save')"
+            :loading="systemOpeningSaving"
+            icon="pi pi-wallet"
+          />
+        </div>
+      </AppPanel>
+    </form>
+
+    <Message
+      v-if="systemOpeningSuccessMessage"
+      severity="success"
+      class="mt-4"
+      :closable="true"
+    >
+      {{ systemOpeningSuccessMessage }}
+    </Message>
+    <Message v-if="systemOpeningErrorMessage" severity="error" class="mt-4" :closable="true">
+      {{ systemOpeningErrorMessage }}
+    </Message>
+
     <AppPanel
       class="danger-panel"
       :title="t('settings.danger_zone')"
@@ -198,20 +365,27 @@ import { onMounted, ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import Button from 'primevue/button'
 import ConfirmDialog from 'primevue/confirmdialog'
+import DatePicker from 'primevue/datepicker'
 import InputNumber from 'primevue/inputnumber'
 import InputText from 'primevue/inputtext'
 import Message from 'primevue/message'
 import Password from 'primevue/password'
 import Select from 'primevue/select'
+import Tag from 'primevue/tag'
 import Textarea from 'primevue/textarea'
 import ToggleSwitch from 'primevue/toggleswitch'
 import { useConfirm } from 'primevue/useconfirm'
 import {
   bootstrapAccountingApi,
+  getSystemOpeningApi,
   getSettingsApi,
   resetDbApi,
+  updateSystemOpeningApi,
   updateSettingsApi,
   type AppSettingsUpdate,
+  type SystemOpening,
+  type TreasurySystemOpening,
+  type TreasurySystemOpeningUpdate,
 } from '@/api/settings'
 import AppPage from '@/components/ui/AppPage.vue'
 import AppPageHeader from '@/components/ui/AppPageHeader.vue'
@@ -242,6 +416,18 @@ interface SettingsForm {
   smtp_use_tls: boolean
 }
 
+interface SystemOpeningFormValue {
+  configured: boolean
+  date: Date | null
+  amount: number | null
+  reference: string
+}
+
+interface TreasurySystemOpeningForm {
+  bank: SystemOpeningFormValue
+  cash: SystemOpeningFormValue
+}
+
 const defaultForm = (): SettingsForm => ({
   association_name: '',
   association_address: '',
@@ -255,15 +441,35 @@ const defaultForm = (): SettingsForm => ({
   smtp_use_tls: true,
 })
 
+const defaultSystemOpeningForm = (): TreasurySystemOpeningForm => ({
+  bank: {
+    configured: false,
+    date: null,
+    amount: null,
+    reference: '',
+  },
+  cash: {
+    configured: false,
+    date: null,
+    amount: null,
+    reference: '',
+  },
+})
+
 const confirm = useConfirm()
 const form = ref<SettingsForm>(defaultForm())
+const systemOpeningForm = ref<TreasurySystemOpeningForm>(defaultSystemOpeningForm())
 const loading = ref(false)
 const resetting = ref(false)
 const bootstrapping = ref(false)
+const systemOpeningSaving = ref(false)
+const systemOpeningDefaultDate = ref<string | null>(null)
 const successMessage = ref('')
 const errorMessage = ref('')
 const resetMessage = ref('')
 const bootstrapMessage = ref('')
+const systemOpeningSuccessMessage = ref('')
+const systemOpeningErrorMessage = ref('')
 
 const MONTHS = [
   'Janvier',
@@ -280,6 +486,54 @@ const MONTHS = [
   'Décembre',
 ]
 const monthOptions = MONTHS.map((label, i) => ({ label, value: i + 1 }))
+const systemOpeningDefaultDateLabel = computed(() =>
+  systemOpeningDefaultDate.value ? systemOpeningDefaultDate.value.split('-').reverse().join('/') : '',
+)
+
+function toIsoDate(value: Date): string {
+  const year = value.getFullYear()
+  const month = String(value.getMonth() + 1).padStart(2, '0')
+  const day = String(value.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+function fromIsoDate(value: string | null): Date | null {
+  if (!value) {
+    return null
+  }
+
+  const [year = 1970, month = 1, day = 1] = value.split('-').map(Number)
+  return new Date(year, month - 1, day, 12)
+}
+
+function toSystemOpeningFormValue(
+  data: SystemOpening,
+  defaultDate: string | null,
+): SystemOpeningFormValue {
+  return {
+    configured: data.configured,
+    date: fromIsoDate(data.date ?? defaultDate),
+    amount: data.amount !== null ? Number(data.amount) : null,
+    reference: data.reference ?? '',
+  }
+}
+
+function applySystemOpening(data: TreasurySystemOpening): void {
+  systemOpeningDefaultDate.value = data.default_date
+  systemOpeningForm.value = {
+    bank: toSystemOpeningFormValue(data.bank, data.default_date),
+    cash: toSystemOpeningFormValue(data.cash, data.default_date),
+  }
+}
+
+async function loadSystemOpening(): Promise<void> {
+  try {
+    const data = await getSystemOpeningApi()
+    applySystemOpening(data)
+  } catch {
+    systemOpeningErrorMessage.value = t('settings.system_opening_load_error')
+  }
+}
 
 async function load(): Promise<void> {
   try {
@@ -335,6 +589,60 @@ function reset(): void {
   void load()
 }
 
+function resetSystemOpening(): void {
+  void loadSystemOpening()
+}
+
+function buildSystemOpeningPayload(): TreasurySystemOpeningUpdate | null {
+  const bank = systemOpeningForm.value.bank
+  const cash = systemOpeningForm.value.cash
+
+  if (!bank.date || bank.amount === null || !cash.date || cash.amount === null) {
+    systemOpeningErrorMessage.value = t('settings.system_opening_validation_error')
+    return null
+  }
+
+  if (bank.amount === 0 || cash.amount === 0) {
+    systemOpeningErrorMessage.value = t('settings.system_opening_zero_error')
+    return null
+  }
+
+  return {
+    bank: {
+      date: toIsoDate(bank.date),
+      amount: bank.amount.toFixed(2),
+      reference: bank.reference.trim() || null,
+    },
+    cash: {
+      date: toIsoDate(cash.date),
+      amount: cash.amount.toFixed(2),
+      reference: cash.reference.trim() || null,
+    },
+  }
+}
+
+async function saveSystemOpening(): Promise<void> {
+  systemOpeningSaving.value = true
+  systemOpeningSuccessMessage.value = ''
+  systemOpeningErrorMessage.value = ''
+
+  const payload = buildSystemOpeningPayload()
+  if (!payload) {
+    systemOpeningSaving.value = false
+    return
+  }
+
+  try {
+    const data = await updateSystemOpeningApi(payload)
+    applySystemOpening(data)
+    systemOpeningSuccessMessage.value = t('settings.system_opening_saved')
+  } catch {
+    systemOpeningErrorMessage.value = t('settings.system_opening_save_error')
+  } finally {
+    systemOpeningSaving.value = false
+  }
+}
+
 function confirmReset(): void {
   confirm.require({
     message: t('settings.reset_db_confirm'),
@@ -379,7 +687,9 @@ async function bootstrapAccounting(): Promise<void> {
   }
 }
 
-onMounted(load)
+onMounted(() => {
+  void Promise.all([load(), loadSystemOpening()])
+})
 </script>
 
 <style scoped>
@@ -396,6 +706,49 @@ onMounted(load)
   padding-top: var(--app-space-4);
 }
 
+.settings-opening__hint,
+.settings-opening__default-date {
+  margin: 0;
+  color: var(--app-text-muted);
+}
+
+.settings-opening-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--app-space-4);
+}
+
+.settings-opening-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--app-space-4);
+  padding: var(--app-space-4);
+  border: 1px solid var(--app-border-subtle);
+  border-radius: var(--app-radius-lg);
+  background: var(--app-surface-subtle);
+}
+
+.settings-opening-card__header {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--app-space-3);
+  align-items: flex-start;
+}
+
+.settings-opening-card__title,
+.settings-opening-card__subtitle {
+  margin: 0;
+}
+
+.settings-opening-card__title {
+  font-size: 1rem;
+}
+
+.settings-opening-card__subtitle {
+  margin-top: var(--app-space-1);
+  color: var(--app-text-muted);
+}
+
 .settings-danger {
   display: flex;
   flex-direction: column;
@@ -410,5 +763,15 @@ onMounted(load)
 .danger-panel :deep(.app-panel__title) {
   color: v-bind(dangerTitleColor);
   font-weight: 600;
+}
+
+@media (max-width: 767px) {
+  .settings-opening-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .settings-opening-card__header {
+    flex-direction: column;
+  }
 }
 </style>

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -309,12 +309,7 @@
       </AppPanel>
     </form>
 
-    <Message
-      v-if="systemOpeningSuccessMessage"
-      severity="success"
-      class="mt-4"
-      :closable="true"
-    >
+    <Message v-if="systemOpeningSuccessMessage" severity="success" class="mt-4" :closable="true">
       {{ systemOpeningSuccessMessage }}
     </Message>
     <Message v-if="systemOpeningErrorMessage" severity="error" class="mt-4" :closable="true">
@@ -487,7 +482,9 @@ const MONTHS = [
 ]
 const monthOptions = MONTHS.map((label, i) => ({ label, value: i + 1 }))
 const systemOpeningDefaultDateLabel = computed(() =>
-  systemOpeningDefaultDate.value ? systemOpeningDefaultDate.value.split('-').reverse().join('/') : '',
+  systemOpeningDefaultDate.value
+    ? systemOpeningDefaultDate.value.split('-').reverse().join('/')
+    : '',
 )
 
 function toIsoDate(value: Date): string {

--- a/tests/integration/test_import_api.py
+++ b/tests/integration/test_import_api.py
@@ -2673,6 +2673,56 @@ async def test_preview_and_import_gestion_ignore_bank_opening_descriptive_rows(
 
 @pytest.mark.asyncio
 @pytest.mark.skipif(not OPENPYXL_AVAILABLE, reason="openpyxl not installed")
+async def test_preview_and_import_gestion_ignore_dated_bank_opening_balance_rows(
+    client: AsyncClient, auth_headers: dict
+) -> None:
+    """Bank preview and import should ignore dated opening balance rows without movement."""
+    content = _make_multi_sheet_xlsx(
+        {
+            "Banque": (
+                ["Date", "Montant", "Libellé", "Solde"],
+                [
+                    ["2024-08-01", None, "Solde initial", 566.76],
+                    [None, None, "Assurance MAIF", 566.76],
+                    ["2024-08-02", -18, "Paiement CB", 548.76],
+                ],
+            )
+        }
+    )
+
+    preview_response = await client.post(
+        "/api/import/excel/gestion/preview",
+        files={"file": ("Gestion 2024.xlsx", content, _XLSX_MIME)},
+        headers=auth_headers,
+    )
+
+    assert preview_response.status_code == 200
+    preview_data = preview_response.json()
+    sheets = {sheet["name"]: sheet for sheet in preview_data["sheets"]}
+    assert preview_data["can_import"] is True
+    assert sheets["Banque"]["rows"] == 1
+    assert sheets["Banque"]["ignored_rows"] == 2
+    assert sheets["Banque"]["blocked_rows"] == 0
+    assert any(
+        "descriptive" in warning.lower() or "solde" in warning.lower()
+        for warning in sheets["Banque"]["warnings"]
+    )
+
+    import_response = await client.post(
+        "/api/import/excel/gestion",
+        files={"file": ("Gestion 2024.xlsx", content, _XLSX_MIME)},
+        headers=auth_headers,
+    )
+
+    assert import_response.status_code == 200
+    import_data = import_response.json()
+    assert import_data["bank_created"] == 1
+    assert import_data["ignored_rows"] == 2
+    assert import_data["blocked_rows"] == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not OPENPYXL_AVAILABLE, reason="openpyxl not installed")
 async def test_preview_and_import_gestion_block_bank_row_with_isolated_year(
     client: AsyncClient, auth_headers: dict
 ) -> None:

--- a/tests/integration/test_settings_api.py
+++ b/tests/integration/test_settings_api.py
@@ -6,7 +6,7 @@ from httpx import AsyncClient
 from sqlalchemy import select
 
 from backend.models.bank import BankTransaction, BankTransactionSource
-from backend.models.cash import CashMovementType, CashRegister
+from backend.models.cash import CashEntrySource, CashMovementType, CashRegister
 from backend.models.fiscal_year import FiscalYear, FiscalYearStatus
 
 
@@ -171,12 +171,68 @@ class TestTreasurySystemOpening:
 
         assert bank_entry.source == BankTransactionSource.SYSTEM_OPENING
         assert bank_entry.reference == "Solde banque initial"
+        assert cash_entry.source == CashEntrySource.SYSTEM_OPENING
         assert cash_entry.type == CashMovementType.OUT
         assert cash_entry.amount == 15
         assert cash_entry.reference == "Ajustement initial"
 
 
 class TestNonAdminAccess:
+    async def test_tresorier_cannot_access_system_opening_get(
+        self, client: AsyncClient, db_session, auth_headers: dict
+    ):
+        from backend.models.user import User, UserRole
+        from backend.services.auth import hash_password
+
+        tresorier = User(
+            username="tresorier-system-opening-read",
+            email="tresorier-system-opening-read@test.com",
+            password_hash=hash_password("password123"),
+            role=UserRole.TRESORIER,
+            is_active=True,
+        )
+        db_session.add(tresorier)
+        await db_session.commit()
+
+        login = await client.post(
+            "/api/auth/login",
+            data={"username": "tresorier-system-opening-read", "password": "password123"},
+        )
+        headers = {"Authorization": f"Bearer {login.json()['access_token']}"}
+        response = await client.get("/api/settings/system-opening", headers=headers)
+        assert response.status_code == 403
+
+    async def test_tresorier_cannot_access_system_opening_put(
+        self, client: AsyncClient, db_session, auth_headers: dict
+    ):
+        from backend.models.user import User, UserRole
+        from backend.services.auth import hash_password
+
+        tresorier = User(
+            username="tresorier-system-opening-write",
+            email="tresorier-system-opening-write@test.com",
+            password_hash=hash_password("password123"),
+            role=UserRole.TRESORIER,
+            is_active=True,
+        )
+        db_session.add(tresorier)
+        await db_session.commit()
+
+        login = await client.post(
+            "/api/auth/login",
+            data={"username": "tresorier-system-opening-write", "password": "password123"},
+        )
+        headers = {"Authorization": f"Bearer {login.json()['access_token']}"}
+        response = await client.put(
+            "/api/settings/system-opening",
+            json={
+                "bank": {"date": "2024-08-01", "amount": "100.00"},
+                "cash": {"date": "2024-08-01", "amount": "50.00"},
+            },
+            headers=headers,
+        )
+        assert response.status_code == 403
+
     async def test_tresorier_cannot_access_settings(
         self, client: AsyncClient, db_session, auth_headers: dict
     ):

--- a/tests/integration/test_settings_api.py
+++ b/tests/integration/test_settings_api.py
@@ -1,7 +1,13 @@
 """Integration tests for GET/PUT /api/settings."""
 
+from datetime import date
+
 from httpx import AsyncClient
 from sqlalchemy import select
+
+from backend.models.bank import BankTransaction, BankTransactionSource
+from backend.models.cash import CashMovementType, CashRegister
+from backend.models.fiscal_year import FiscalYear, FiscalYearStatus
 
 
 class TestGetSettings:
@@ -105,6 +111,69 @@ class TestUpdateSettings:
         data = response.json()
         assert data["smtp_host"] == "smtp.gmail.com"
         assert data["smtp_user"] == "test@gmail.com"
+
+
+class TestTreasurySystemOpening:
+    async def test_get_system_opening_requires_auth(self, client: AsyncClient) -> None:
+        response = await client.get("/api/settings/system-opening")
+        assert response.status_code == 401
+
+    async def test_get_system_opening_returns_default_date(
+        self, client: AsyncClient, auth_headers: dict, db_session
+    ) -> None:
+        db_session.add(
+            FiscalYear(
+                name="2024",
+                start_date=date(2024, 8, 1),
+                end_date=date(2025, 7, 31),
+                status=FiscalYearStatus.OPEN,
+            )
+        )
+        await db_session.commit()
+
+        response = await client.get("/api/settings/system-opening", headers=auth_headers)
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["default_date"] == "2024-08-01"
+        assert payload["bank"]["configured"] is False
+        assert payload["cash"]["configured"] is False
+
+    async def test_put_system_opening_creates_bank_and_cash_entries(
+        self, client: AsyncClient, auth_headers: dict, db_session
+    ) -> None:
+        response = await client.put(
+            "/api/settings/system-opening",
+            json={
+                "bank": {
+                    "date": "2024-08-01",
+                    "amount": "100.00",
+                    "reference": "Solde banque initial",
+                },
+                "cash": {
+                    "date": "2024-08-01",
+                    "amount": "-15.00",
+                    "reference": "Ajustement initial",
+                },
+            },
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["bank"]["configured"] is True
+        assert payload["bank"]["amount"] == "100.00"
+        assert payload["cash"]["configured"] is True
+        assert payload["cash"]["amount"] == "-15.00"
+
+        bank_entry = (await db_session.execute(select(BankTransaction))).scalar_one()
+        cash_entry = (await db_session.execute(select(CashRegister))).scalar_one()
+
+        assert bank_entry.source == BankTransactionSource.SYSTEM_OPENING
+        assert bank_entry.reference == "Solde banque initial"
+        assert cash_entry.type == CashMovementType.OUT
+        assert cash_entry.amount == 15
+        assert cash_entry.reference == "Ajustement initial"
 
 
 class TestNonAdminAccess:

--- a/tests/unit/test_excel_import_policy.py
+++ b/tests/unit/test_excel_import_policy.py
@@ -166,6 +166,18 @@ def test_should_ignore_bank_balance_description() -> None:
         label="Solde au 01/01",
         balance=Decimal("1250.00"),
     )
+    assert should_ignore_bank_balance_description(
+        entry_date=date(2024, 8, 1),
+        amount=None,
+        label="Solde initial",
+        balance=Decimal("1250.00"),
+    )
+    assert not should_ignore_bank_balance_description(
+        entry_date=date(2024, 8, 2),
+        amount=None,
+        label="Paiement carte",
+        balance=Decimal("1232.00"),
+    )
     assert BANK_BALANCE_DESCRIPTION_MESSAGE == "ligne descriptive de solde ignoree"
 
 

--- a/tests/unit/test_settings_service.py
+++ b/tests/unit/test_settings_service.py
@@ -20,14 +20,18 @@ from backend.models.contact import Contact, ContactType
 from backend.models.fiscal_year import FiscalYear, FiscalYearStatus
 from backend.models.import_log import ImportLog, ImportLogStatus, ImportLogType
 from backend.models.user import User, UserRole
-from backend.schemas.settings import AppSettingsUpdate, SystemOpeningUpdate, TreasurySystemOpeningUpdate
+from backend.schemas.settings import (
+    AppSettingsUpdate,
+    SystemOpeningUpdate,
+    TreasurySystemOpeningUpdate,
+)
 from backend.services.settings import (
     bootstrap_accounting_setup,
     get_settings,
     get_treasury_system_opening,
     reset_data,
-    upsert_treasury_system_opening,
     update_settings,
+    upsert_treasury_system_opening,
 )
 
 
@@ -300,11 +304,23 @@ class TestTreasurySystemOpening:
         assert opening.cash.amount == Decimal("50.00")
 
         bank_entries = (
-            await db_session.execute(select(BankTransaction).order_by(BankTransaction.date, BankTransaction.id))
-        ).scalars().all()
+            (
+                await db_session.execute(
+                    select(BankTransaction).order_by(BankTransaction.date, BankTransaction.id)
+                )
+            )
+            .scalars()
+            .all()
+        )
         cash_entries = (
-            await db_session.execute(select(CashRegister).order_by(CashRegister.date, CashRegister.id))
-        ).scalars().all()
+            (
+                await db_session.execute(
+                    select(CashRegister).order_by(CashRegister.date, CashRegister.id)
+                )
+            )
+            .scalars()
+            .all()
+        )
 
         assert len(bank_entries) == 2
         assert bank_entries[0].source == BankTransactionSource.SYSTEM_OPENING

--- a/tests/unit/test_settings_service.py
+++ b/tests/unit/test_settings_service.py
@@ -15,7 +15,12 @@ from backend.models.accounting_rule import (
 )
 from backend.models.app_settings import AppSettings
 from backend.models.bank import BankTransaction, BankTransactionSource
-from backend.models.cash import CashMovementType, CashRegister
+from backend.models.cash import (
+    CASH_SYSTEM_OPENING_DESCRIPTION,
+    CashEntrySource,
+    CashMovementType,
+    CashRegister,
+)
 from backend.models.contact import Contact, ContactType
 from backend.models.fiscal_year import FiscalYear, FiscalYearStatus
 from backend.models.import_log import ImportLog, ImportLogStatus, ImportLogType
@@ -25,6 +30,8 @@ from backend.schemas.settings import (
     SystemOpeningUpdate,
     TreasurySystemOpeningUpdate,
 )
+from backend.services.bank_service import recompute_bank_balances
+from backend.services.cash_service import recompute_cash_balances
 from backend.services.settings import (
     bootstrap_accounting_setup,
     get_settings,
@@ -328,7 +335,8 @@ class TestTreasurySystemOpening:
         assert bank_entries[1].balance_after == Decimal("110.00")
 
         assert len(cash_entries) == 2
-        assert cash_entries[0].description == "Ouverture du système"
+        assert cash_entries[0].description == CASH_SYSTEM_OPENING_DESCRIPTION
+        assert cash_entries[0].source == CashEntrySource.SYSTEM_OPENING
         assert cash_entries[0].balance_after == Decimal("50.00")
         assert cash_entries[1].balance_after == Decimal("80.00")
 
@@ -358,5 +366,86 @@ class TestTreasurySystemOpening:
         assert len(cash_entries) == 1
         assert opening.bank.amount == Decimal("125.00")
         assert opening.cash.amount == Decimal("-10.00")
-        assert cash_entries[0].type == CashMovementType.OUT
-        assert cash_entries[0].amount == Decimal("10.00")
+        opening_bank_entries = [
+            entry for entry in bank_entries if entry.source == BankTransactionSource.SYSTEM_OPENING
+        ]
+        assert len(opening_bank_entries) == 1
+
+    async def test_upsert_moving_opening_dates_recomputes_running_balances(
+        self, db_session: AsyncSession
+    ) -> None:
+        await upsert_treasury_system_opening(
+            db_session,
+            TreasurySystemOpeningUpdate(
+                bank=SystemOpeningUpdate(date=date(2024, 8, 2), amount=Decimal("100.00")),
+                cash=SystemOpeningUpdate(date=date(2024, 8, 2), amount=Decimal("50.00")),
+            ),
+        )
+
+        bank_tx = BankTransaction(
+            date=date(2024, 8, 3),
+            amount=Decimal("10.00"),
+            reference="RELEVE-2",
+            description="Operation courante",
+            balance_after=Decimal("0"),
+            source=BankTransactionSource.MANUAL,
+        )
+        cash_tx = CashRegister(
+            date=date(2024, 8, 3),
+            amount=Decimal("20.00"),
+            type=CashMovementType.IN,
+            reference="CAISSE-2",
+            description="Recette",
+            source=CashEntrySource.MANUAL,
+            balance_after=Decimal("0"),
+        )
+        db_session.add_all([bank_tx, cash_tx])
+        await db_session.flush()
+        await recompute_bank_balances(db_session)
+        await recompute_cash_balances(db_session)
+        await db_session.commit()
+
+        opening = await upsert_treasury_system_opening(
+            db_session,
+            TreasurySystemOpeningUpdate(
+                bank=SystemOpeningUpdate(date=date(2024, 8, 1), amount=Decimal("80.00")),
+                cash=SystemOpeningUpdate(date=date(2024, 8, 1), amount=Decimal("40.00")),
+            ),
+        )
+
+        bank_entries = (
+            (
+                await db_session.execute(
+                    select(BankTransaction).order_by(BankTransaction.date, BankTransaction.id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        cash_entries = (
+            (
+                await db_session.execute(
+                    select(CashRegister).order_by(CashRegister.date, CashRegister.id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+        assert opening.bank.amount == Decimal("80.00")
+        assert opening.cash.amount == Decimal("40.00")
+        opening_bank_entries = [
+            entry for entry in bank_entries if entry.source == BankTransactionSource.SYSTEM_OPENING
+        ]
+        opening_cash_entries = [
+            entry for entry in cash_entries if entry.source == CashEntrySource.SYSTEM_OPENING
+        ]
+
+        assert len(opening_bank_entries) == 1
+        assert len(opening_cash_entries) == 1
+        assert bank_entries[0].date == date(2024, 8, 1)
+        assert bank_entries[0].balance_after == Decimal("80.00")
+        assert bank_entries[1].balance_after == Decimal("90.00")
+        assert cash_entries[0].date == date(2024, 8, 1)
+        assert cash_entries[0].balance_after == Decimal("40.00")
+        assert cash_entries[1].balance_after == Decimal("60.00")

--- a/tests/unit/test_settings_service.py
+++ b/tests/unit/test_settings_service.py
@@ -1,6 +1,7 @@
 """Unit tests for the settings service."""
 
 from datetime import date
+from decimal import Decimal
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -13,15 +14,19 @@ from backend.models.accounting_rule import (
     TriggerType,
 )
 from backend.models.app_settings import AppSettings
+from backend.models.bank import BankTransaction, BankTransactionSource
+from backend.models.cash import CashMovementType, CashRegister
 from backend.models.contact import Contact, ContactType
 from backend.models.fiscal_year import FiscalYear, FiscalYearStatus
 from backend.models.import_log import ImportLog, ImportLogStatus, ImportLogType
 from backend.models.user import User, UserRole
-from backend.schemas.settings import AppSettingsUpdate
+from backend.schemas.settings import AppSettingsUpdate, SystemOpeningUpdate, TreasurySystemOpeningUpdate
 from backend.services.settings import (
     bootstrap_accounting_setup,
     get_settings,
+    get_treasury_system_opening,
     reset_data,
+    upsert_treasury_system_opening,
     update_settings,
 )
 
@@ -221,3 +226,121 @@ class TestBootstrapAccountingSetup:
             "rules_inserted": 0,
             "fiscal_years_created": 0,
         }
+
+
+class TestTreasurySystemOpening:
+    async def test_returns_oldest_fiscal_year_start_as_default_date(
+        self, db_session: AsyncSession
+    ) -> None:
+        db_session.add_all(
+            [
+                FiscalYear(
+                    name="2024",
+                    start_date=date(2024, 8, 1),
+                    end_date=date(2025, 7, 31),
+                    status=FiscalYearStatus.OPEN,
+                ),
+                FiscalYear(
+                    name="2025",
+                    start_date=date(2025, 8, 1),
+                    end_date=date(2026, 7, 31),
+                    status=FiscalYearStatus.OPEN,
+                ),
+            ]
+        )
+        await db_session.commit()
+
+        opening = await get_treasury_system_opening(db_session)
+
+        assert opening.default_date == date(2024, 8, 1)
+        assert opening.bank.configured is False
+        assert opening.cash.configured is False
+
+    async def test_upsert_creates_openings_and_recomputes_running_balances(
+        self, db_session: AsyncSession
+    ) -> None:
+        bank_tx = BankTransaction(
+            date=date(2024, 8, 2),
+            amount=Decimal("10.00"),
+            reference="RELEVE-1",
+            description="Operation courante",
+            balance_after=Decimal("10.00"),
+            source=BankTransactionSource.IMPORT,
+        )
+        cash_entry = CashRegister(
+            date=date(2024, 8, 2),
+            amount=Decimal("30.00"),
+            type=CashMovementType.IN,
+            reference="CAISSE-1",
+            description="Recette",
+            balance_after=Decimal("30.00"),
+        )
+        db_session.add_all([bank_tx, cash_entry])
+        await db_session.commit()
+
+        opening = await upsert_treasury_system_opening(
+            db_session,
+            TreasurySystemOpeningUpdate(
+                bank=SystemOpeningUpdate(
+                    date=date(2024, 8, 1),
+                    amount=Decimal("100.00"),
+                    reference="Solde banque initial",
+                ),
+                cash=SystemOpeningUpdate(
+                    date=date(2024, 8, 1),
+                    amount=Decimal("50.00"),
+                    reference="Fond de caisse initial",
+                ),
+            ),
+        )
+
+        assert opening.bank.configured is True
+        assert opening.bank.amount == Decimal("100.00")
+        assert opening.cash.configured is True
+        assert opening.cash.amount == Decimal("50.00")
+
+        bank_entries = (
+            await db_session.execute(select(BankTransaction).order_by(BankTransaction.date, BankTransaction.id))
+        ).scalars().all()
+        cash_entries = (
+            await db_session.execute(select(CashRegister).order_by(CashRegister.date, CashRegister.id))
+        ).scalars().all()
+
+        assert len(bank_entries) == 2
+        assert bank_entries[0].source == BankTransactionSource.SYSTEM_OPENING
+        assert bank_entries[0].balance_after == Decimal("100.00")
+        assert bank_entries[1].balance_after == Decimal("110.00")
+
+        assert len(cash_entries) == 2
+        assert cash_entries[0].description == "Ouverture du système"
+        assert cash_entries[0].balance_after == Decimal("50.00")
+        assert cash_entries[1].balance_after == Decimal("80.00")
+
+    async def test_upsert_updates_existing_openings_without_duplication(
+        self, db_session: AsyncSession
+    ) -> None:
+        await upsert_treasury_system_opening(
+            db_session,
+            TreasurySystemOpeningUpdate(
+                bank=SystemOpeningUpdate(date=date(2024, 8, 1), amount=Decimal("100.00")),
+                cash=SystemOpeningUpdate(date=date(2024, 8, 1), amount=Decimal("20.00")),
+            ),
+        )
+
+        opening = await upsert_treasury_system_opening(
+            db_session,
+            TreasurySystemOpeningUpdate(
+                bank=SystemOpeningUpdate(date=date(2024, 8, 1), amount=Decimal("125.00")),
+                cash=SystemOpeningUpdate(date=date(2024, 8, 1), amount=Decimal("-10.00")),
+            ),
+        )
+
+        bank_entries = (await db_session.execute(select(BankTransaction))).scalars().all()
+        cash_entries = (await db_session.execute(select(CashRegister))).scalars().all()
+
+        assert len(bank_entries) == 1
+        assert len(cash_entries) == 1
+        assert opening.bank.amount == Decimal("125.00")
+        assert opening.cash.amount == Decimal("-10.00")
+        assert cash_entries[0].type == CashMovementType.OUT
+        assert cash_entries[0].amount == Decimal("10.00")


### PR DESCRIPTION
This PR adds explicit treasury system opening support for bank and cash so the oldest imported fiscal year can start from a real opening balance instead of implicit import artifacts.

- add admin settings API and UI to configure bank and cash system opening entries
- persist opening values as real treasury entries and recompute running balances consistently
- surface system opening markers in bank and cash views
- extend backend and frontend tests for the new workflow
- ignore dated bank balance-only opening rows during Excel import when they carry no movement amount

## Summary by Sourcery

Add configurable treasury system opening entries for bank and cash and ensure they are reflected consistently in balances, imports, and UI.

New Features:
- Introduce admin API and settings UI to configure treasury system opening entries for bank and cash, with validation and status indicators.
- Expose system opening flags and origins on bank and cash entries and surface them in list and detail views.

Bug Fixes:
- Ignore descriptive or opening-balance-only bank rows without movement during Excel import to prevent spurious transactions.

Enhancements:
- Persist system opening values as dedicated bank and cash entries and recompute running balances centrally when transactions or openings change.
- Extend backend and frontend tests to cover treasury system opening workflows, balance recomputation, and updated import behavior.

Tests:
- Add unit and integration tests for treasury system opening APIs, services, balance recomputation, and Excel import policies.