### PR TITLE
docs: close BL-026 validation and capture follow-ups

### DIFF
--- a/doc/backlog.md
+++ b/doc/backlog.md
@@ -66,6 +66,7 @@ Tout sujet concret qui doit survivre au-delà de la séance en cours doit être 
 | BL-022 | 2026-04-13 | Évolution | Utilisateurs / Sécurité | P1 | Renforcer la gestion des utilisateurs avec des rôles métier plus clairs, la création et l'administration des comptes, l'autonomie sur le profil et un socle de sécurité de compte plus complet |
 | BL-024 | 2026-04-13 | Correction | Paiements / Banque | P1 | Clarifier le workflow cible de saisie des paiements et corriger l'automatisme qui remet en banque les paiements `espèces` et `virement` dès leur encodage |
 | BL-027 | 2026-04-15 | Évolution | Import Excel / Trésorerie | P1 | Gérer une ouverture du système explicite pour Banque et Caisse sur le premier exercice importé |
+| BL-028 | 2026-04-16 | Correction | Comptabilité / Factures clients | P1 | Ventiler les factures clients mixtes de type `cs+a` sur les mêmes comptes produits que dans Excel quand l'information source le permet |
 
 ## Détail des sujets
 
@@ -135,15 +136,36 @@ Tout sujet concret qui doit survivre au-delà de la séance en cours doit être 
 - **Phase 1** : initialiser proprement Solde à partir des fichiers historiques existants.
 - **Phase 2** : réimporter régulièrement Excel pour vérifier que les écritures et mouvements saisis dans Solde correspondent exactement à la réalité comptable de référence.
 - **Résultat attendu** : détecter toute écriture manquante, en trop ou divergente, avec un haut niveau d'exigence sur montants, dates, libellés et équilibres, et une politique claire sur ce qui reste bloquant versus seulement signalé.
+- **Décisions de cadrage issues de `BL-026`** :
+	- prévoir deux modes de comparaison distincts : `convergence globale` pour comparer l'état final Excel et l'état final Solde, y compris les écritures d'ouverture et les écritures importées depuis `Comptabilite`, et `validation du moteur Gestion` pour comparer seulement les écritures générées par `Gestion` avec les écritures Excel correspondant aux mêmes événements métier ;
+	- ne pas imposer une identité ligne à ligne comme unique cible : certaines différences de structure doivent être rapprochées par des règles métier explicites ;
+	- pour les fournisseurs, considérer comme cas normalisable le fait qu'Excel porte souvent un paiement direct (`charge -> banque/caisse`) alors que Solde modélise `facture fournisseur -> règlement` ;
+	- pour les factures clients mixtes de type `cs+a`, considérer au contraire que la ventilation multi-comptes observée dans Excel exprime une réalité comptable cible et non un simple artefact de rapprochement ;
+	- sur les salaires, ne pas ouvrir de sujet correctif tant qu'aucun écart métier de montant n'est démontré ; au besoin, formaliser seulement une convention de date et de regroupement pour la comparaison.
 - **Premier lot visé** :
+	- formaliser ces deux modes de validation (`convergence globale` et `validation du moteur Gestion`) et leurs périmètres respectifs ;
 	- formaliser un contrat de comparaison par domaine (`Factures`, `Paiements`, `Caisse`, `Banque`, `Journal`) ;
 	- ajouter un mode de comparaison sans écriture, probablement adossé à la preview existante ;
 	- catégoriser les écarts avec des codes stables (`missing-in-solde`, `extra-in-solde`, `amount-mismatch`, `date-mismatch`, `ambiguous-match`, `ignored-by-policy`, `blocked-by-coexistence`) ;
+	- porter explicitement des règles de projection ou de normalisation pour les cas attendus (`facture fournisseur + règlement` côté Solde vs paiement direct côté Excel, ouvertures d'exercice, autres écarts de granularité assumés) ;
 	- produire un rapport exploitable avec résumé global, détail par feuille et exemples d'écarts ;
 	- cibler d'abord la chaîne réelle `Gestion 2024` / `Gestion 2025` avant toute généralisation plus large.
-- **Critère d'acceptation** : on doit pouvoir répondre, sans rien persister, à quatre questions simples : qu'est-ce qui manque dans Solde, qu'est-ce qui est en trop, qu'est-ce qui diverge, et qu'est-ce qui est ignoré volontairement selon la politique métier.
+- **Critère d'acceptation** : on doit pouvoir répondre, sans rien persister, à quatre questions simples pour chacun des deux modes : qu'est-ce qui manque dans Solde, qu'est-ce qui est en trop, qu'est-ce qui diverge, et qu'est-ce qui est ignoré volontairement selon la politique métier.
 - **Hors périmètre initial** : pas de correction automatique des écarts, pas d'ouverture large de l'import `Comptabilite` en réel tant que `BL-005` n'est pas tranché, et pas d'outil générique de réconciliation déconnecté du cas de reprise réel.
 - **Enjeu** : sujet critique pour la confiance métier pendant toute la transition hors Excel.
+
+### BL-028 — Ventiler les factures clients mixtes `cs+a` comme dans la comptabilité Excel
+
+- **Dates** : `created=2026-04-16`
+- **Pourquoi** : pendant `BL-026`, il apparaît que certaines factures clients historiques, comme `2024-0186`, sont ventilées dans Excel sur plusieurs comptes produits parce qu'elles mélangent des lignes de cours (`cs`) et d'adhésion (`a`). Aujourd'hui, Solde ne reproduit pas forcément cette ventilation fine, ce qui gêne le rapprochement comptable par compte et ne reflète pas totalement la réalité comptable attendue.
+- **Résultat attendu** : quand l'information source de `Gestion` permet d'identifier une facture mixte, Solde doit générer la même ventilation comptable par compte produit que celle attendue dans Excel, au lieu de s'appuyer uniquement sur un total global de facture.
+- **Périmètre initial** :
+	- identifier dans les données `Gestion` les signaux exploitables permettant de distinguer les composantes d'une facture mixte ;
+	- définir la règle comptable cible de ventilation par compte produit ;
+	- adapter la génération des écritures de factures clients pour refléter cette ventilation ;
+	- ajouter une couverture de tests ciblée sur au moins un cas réel de facture mixte.
+- **Critère d'acceptation** : sur un cas comme `2024-0186`, les écritures générées par Solde portent les mêmes montants sur les mêmes comptes produits que la comptabilité Excel de référence, sans casser les cas simples mono-produit.
+- **Point d'attention** : ce sujet est distinct de `BL-008` ; ici l'objectif est d'aligner le comportement comptable réel de Solde, pas seulement de mieux tolérer un écart dans l'outil de comparaison.
 
 ### BL-009 — Enrichir le plan comptable par défaut à partir des imports réels
 
@@ -341,17 +363,17 @@ Tout sujet concret qui doit survivre au-delà de la séance en cours doit être 
 
 ### BL-026 — Valider les imports Excel par rapprochement chiffré sur 2024 et 2025
 
-- **Dates** : `created=2026-04-15`, `started=2026-04-15`
+- **Dates** : `created=2026-04-15`, `started=2026-04-15`, `completed=2026-04-16`
 - **Pourquoi** : après la fiabilisation de la mécanique d'import, il faut maintenant confirmer sur le cas réel que les données visibles dans Solde correspondent bien aux fichiers Excel sources, aussi bien côté `Gestion` que côté `Comptabilité`, et cela sur les deux exercices historiques.
 - **Résultat attendu** : disposer d'une validation explicite, exercice par exercice, des chiffres importés dans Solde par rapport aux fichiers Excel `2024` et `2025`, avec une liste claire des écarts constatés ou la confirmation qu'il n'y en a pas.
-- **Avancement actuel** : le cadrage initial de la recette est posé dans `doc/dev/bl-026-cadrage-validation-imports-excel.md`, avec distinction entre sources primaires et secondaires, séquence de validation par exercice et matrice de rapprochement `Gestion` / `Comptabilité`.
+- **Résultat livré** : le cadrage de recette a été formalisé dans `doc/dev/bl-026-cadrage-validation-imports-excel.md` et un constat exploitable a été produit dans `doc/dev/bl-026-constat-validation-imports.md` pour l'exercice `2024`, avec distinction entre chiffres conformes, écarts justifiés de modélisation et sujets à corriger. Le ticket est clos comme ticket de constat et d'orientation ; la poursuite de la validation comptable stricte est désormais renvoyée vers `BL-008`, et l'alignement du comportement comptable attendu sur les factures clients mixtes vers `BL-028`.
 - **Périmètre minimal** :
 	- comparer les chiffres de `Gestion` visibles dans l'application avec ceux des fichiers Excel correspondants pour `2024` et `2025` ;
 	- comparer les chiffres de `Comptabilité` visibles dans l'application avec ceux des fichiers Excel correspondants pour `2024` et `2025` ;
 	- expliciter la méthode de rapprochement retenue par écran ou par état (totaux, comptes, journaux, soldes, volumes) ;
 	- consigner tout écart résiduel avec un diagnostic exploitable pour décider s'il s'agit d'un bug, d'un problème de données source ou d'un écart de lecture métier.
 - **Critère d'acceptation** : pour chacun des deux exercices, on peut produire un constat de validation lisible indiquant ce qui a été comparé, quels chiffres concordent entre Excel et Solde, et quels écarts restent ouverts le cas échéant.
-- **Point d'attention** : ce ticket est complémentaire de `BL-008` ; ici l'objectif n'est pas de concevoir le futur mode générique de convergence, mais de valider concrètement la reprise réelle déjà importée sur `2024` et `2025`.
+- **Point d'attention** : ce ticket est complémentaire de `BL-008` ; la clôture de `BL-026` ne signifie pas que la convergence comptable Excel/Solde est entièrement démontrée, mais que les écarts restants ont été suffisamment qualifiés pour être repris dans des tickets plus ciblés.
 
 ### BL-027 — Gérer une ouverture du système explicite pour Banque et Caisse
 
@@ -374,7 +396,6 @@ Tout sujet concret qui doit survivre au-delà de la séance en cours doit être 
 
 - **BL-021** — `created=2026-04-13`, `started=2026-04-13` — Les lots 1 à 3 du manuel utilisateur sont livrés, mais le lot 4 reste à réaliser pour finaliser la stabilisation éditoriale et l'enrichissement visuel.
 - **BL-022** — `created=2026-04-13`, `started=2026-04-13` — Les lots 1 et 2 sont intégrés dans `develop` ; les lots suivants restent à traiter et le retest des droits réels a été traité séparément dans `BL-023`, désormais terminé.
-- **BL-026** — `created=2026-04-15`, `started=2026-04-15` — Branche de travail créée pour lancer la validation chiffrée des imports Excel `Gestion` / `Comptabilité` sur les exercices `2024` et `2025`.
 
 ## Fait
 
@@ -390,6 +411,7 @@ Tout sujet concret qui doit survivre au-delà de la séance en cours doit être 
 - **BL-017** — `created=2026-04-13`, `started=2026-04-14`, `completed=2026-04-14` — L'affichage des mois et périodes métier est maintenant uniformisé au format français sur `Salaires` et le `Dashboard` sans changer les formats d'échange ISO.
 - **BL-018** — `created=2026-04-13`, `started=2026-04-14`, `completed=2026-04-14` — Les écrans de liste principaux partagent maintenant un socle commun de tri, filtres et compteurs d'état, avec filtres de date FR/ISO et exclusion explicite des tableaux fixes `bilan` / `résultat`.
 - **BL-023** — `created=2026-04-13`, `started=2026-04-14`, `completed=2026-04-14` — Les rôles métier `Gestionnaire` / `Comptable` / `Administrateur` sont maintenant alignés entre docs, navigation, guards frontend et permissions backend, avec séparation visible `Gestion` / `Comptabilité` et couverture de test ciblée.
+- **BL-026** — `created=2026-04-15`, `started=2026-04-15`, `completed=2026-04-16` — Le ticket a livré un cadrage de recette et un constat exploitable sur la reprise `2024`, puis a été clos une fois les écarts résiduels requalifiés en différences de modélisation assumées ou en suites dédiées (`BL-008`, `BL-028`).
 - **BL-012** — `created=2026-04-12`, `completed=2026-04-12` — La liste des paiements affiche la référence métier et permet l'édition directe.
 - **BL-013** — `created=2026-04-12`, `completed=2026-04-12` — Le journal de caisse propose désormais référence, détail et édition directe.
 - **BL-014** — `created=2026-04-12`, `completed=2026-04-12` — Le journal comptable est enrichi pour la lecture métier, le détail et la navigation vers les factures.

--- a/doc/backlog.md
+++ b/doc/backlog.md
@@ -65,6 +65,7 @@ Tout sujet concret qui doit survivre au-delà de la séance en cours doit être 
 | BL-020 | 2026-04-13 | Documentation | Développement | P3 | Documenter clairement comment participer au projet : prérequis, environnement local, commandes utiles, qualité attendue et workflow PR |
 | BL-022 | 2026-04-13 | Évolution | Utilisateurs / Sécurité | P1 | Renforcer la gestion des utilisateurs avec des rôles métier plus clairs, la création et l'administration des comptes, l'autonomie sur le profil et un socle de sécurité de compte plus complet |
 | BL-024 | 2026-04-13 | Correction | Paiements / Banque | P1 | Clarifier le workflow cible de saisie des paiements et corriger l'automatisme qui remet en banque les paiements `espèces` et `virement` dès leur encodage |
+| BL-027 | 2026-04-15 | Évolution | Import Excel / Trésorerie | P1 | Gérer une ouverture du système explicite pour Banque et Caisse sur le premier exercice importé |
 
 ## Détail des sujets
 
@@ -338,6 +339,33 @@ Tout sujet concret qui doit survivre au-delà de la séance en cours doit être 
 - **Critère d'acceptation** : pour un exercice donné, le grand livre n'affiche que les écritures rattachées à cet exercice, y compris son report à nouveau éventuel, et présente un solde cohérent sans cumul indu entre ouvertures d'exercices successifs.
 - **Point d'attention** : c'est un sujet comptable critique à traiter avant de faire confiance aux états ; il faudra le recouper avec `BL-010` et les choix de clôture des exercices historiques.
 
+### BL-026 — Valider les imports Excel par rapprochement chiffré sur 2024 et 2025
+
+- **Dates** : `created=2026-04-15`, `started=2026-04-15`
+- **Pourquoi** : après la fiabilisation de la mécanique d'import, il faut maintenant confirmer sur le cas réel que les données visibles dans Solde correspondent bien aux fichiers Excel sources, aussi bien côté `Gestion` que côté `Comptabilité`, et cela sur les deux exercices historiques.
+- **Résultat attendu** : disposer d'une validation explicite, exercice par exercice, des chiffres importés dans Solde par rapport aux fichiers Excel `2024` et `2025`, avec une liste claire des écarts constatés ou la confirmation qu'il n'y en a pas.
+- **Avancement actuel** : le cadrage initial de la recette est posé dans `doc/dev/bl-026-cadrage-validation-imports-excel.md`, avec distinction entre sources primaires et secondaires, séquence de validation par exercice et matrice de rapprochement `Gestion` / `Comptabilité`.
+- **Périmètre minimal** :
+	- comparer les chiffres de `Gestion` visibles dans l'application avec ceux des fichiers Excel correspondants pour `2024` et `2025` ;
+	- comparer les chiffres de `Comptabilité` visibles dans l'application avec ceux des fichiers Excel correspondants pour `2024` et `2025` ;
+	- expliciter la méthode de rapprochement retenue par écran ou par état (totaux, comptes, journaux, soldes, volumes) ;
+	- consigner tout écart résiduel avec un diagnostic exploitable pour décider s'il s'agit d'un bug, d'un problème de données source ou d'un écart de lecture métier.
+- **Critère d'acceptation** : pour chacun des deux exercices, on peut produire un constat de validation lisible indiquant ce qui a été comparé, quels chiffres concordent entre Excel et Solde, et quels écarts restent ouverts le cas échéant.
+- **Point d'attention** : ce ticket est complémentaire de `BL-008` ; ici l'objectif n'est pas de concevoir le futur mode générique de convergence, mais de valider concrètement la reprise réelle déjà importée sur `2024` et `2025`.
+
+### BL-027 — Gérer une ouverture du système explicite pour Banque et Caisse
+
+- **Dates** : `created=2026-04-15`
+- **Pourquoi** : pendant la validation `BL-026`, il apparaît que le premier exercice importé a besoin d'un point de départ explicite côté gestion pour `Banque` et `Caisse`, distinct de l'ouverture comptable de l'exercice. Aujourd'hui, les lignes Excel de `solde initial` sont traitées comme des lignes ignorées, ce qui ne permet pas de représenter proprement l'état hérité du système avant le premier exercice suivi.
+- **Résultat attendu** : définir puis implémenter une notion d'`ouverture du système` pour `Banque` et `Caisse`, injectée une seule fois sur le plus ancien exercice importé, contribuant aux soldes cumulés, et identifiée visiblement comme donnée spéciale dans l'interface (badge, type ou rendu distinct).
+- **Périmètre initial** :
+	- gérer explicitement un solde d'ouverture `Banque` sur le premier exercice importé ;
+	- gérer explicitement un solde d'ouverture `Caisse` sur le premier exercice importé ;
+	- rendre ces lignes distinguables des mouvements normaux dans les écrans de trésorerie ;
+	- éviter toute réinjection automatique du même concept sur les exercices suivants.
+- **Critère d'acceptation** : après import du plus ancien exercice, les écrans `Banque` et `Caisse` affichent un point de départ cohérent et identifié comme `ouverture du système`, les soldes des exercices suivants héritent correctement de ce point de départ sans doublon, et les chiffres `BL-026` peuvent être remesurés proprement pour la trésorerie.
+- **Point d'attention** : ce sujet doit être traité sur une branche distincte de `BL-026`, car il fera évoluer les chiffres de `Banque` et `Caisse` déjà relevés dans le constat de validation.
+
 ## Prêt
 
 - Aucun sujet pour le moment.
@@ -346,6 +374,7 @@ Tout sujet concret qui doit survivre au-delà de la séance en cours doit être 
 
 - **BL-021** — `created=2026-04-13`, `started=2026-04-13` — Les lots 1 à 3 du manuel utilisateur sont livrés, mais le lot 4 reste à réaliser pour finaliser la stabilisation éditoriale et l'enrichissement visuel.
 - **BL-022** — `created=2026-04-13`, `started=2026-04-13` — Les lots 1 et 2 sont intégrés dans `develop` ; les lots suivants restent à traiter et le retest des droits réels a été traité séparément dans `BL-023`, désormais terminé.
+- **BL-026** — `created=2026-04-15`, `started=2026-04-15` — Branche de travail créée pour lancer la validation chiffrée des imports Excel `Gestion` / `Comptabilité` sur les exercices `2024` et `2025`.
 
 ## Fait
 

--- a/doc/dev/bl-026-cadrage-validation-imports-excel.md
+++ b/doc/dev/bl-026-cadrage-validation-imports-excel.md
@@ -1,0 +1,180 @@
+# BL-026 — Cadrage de la validation chiffrée des imports Excel
+
+## Objectif
+
+Valider, sur la reprise réelle `2024` et `2025`, que les chiffres visibles dans Solde concordent avec les fichiers Excel sources :
+
+- côté `Gestion` ;
+- côté `Comptabilité` ;
+- exercice par exercice ;
+- avec une méthode de rapprochement explicite et réutilisable.
+
+Ce document cadre la méthode de recette. Il ne définit pas encore un moteur générique de réconciliation automatisée.
+
+## Faits vérifiés dans le code
+
+### Imports et ordre de rejeu
+
+- L'application expose bien quatre raccourcis de test pour `Gestion 2024`, `Gestion 2025`, `Comptabilité 2024` et `Comptabilité 2025`.
+- La documentation existante recommande déjà l'ordre de rejeu suivant :
+  1. `Gestion 2024`
+  2. `Gestion 2025`
+  3. `Comptabilité 2024`
+  4. `Comptabilité 2025`
+- Cet ordre reste la base de la validation `BL-026`, car certains rapprochements de paiements ne deviennent stables qu'après import de l'exercice précédent.
+
+### Sources Solde exploitables
+
+#### Sources primaires comptables
+
+Les écrans et endpoints suivants sont directement exploitables comme sources primaires pour une validation par exercice, car ils acceptent un `fiscal_year_id` explicite :
+
+- `Journal`
+- `Balance`
+- `Bilan`
+- `Résultat`
+- `Grand livre`
+
+#### Sources primaires gestion
+
+Les écrans et endpoints suivants sont exploitables comme sources primaires de gestion, mais par filtre de date ou d'année civile, pas par `fiscal_year_id` :
+
+- `Factures clients`
+- `Factures fournisseurs`
+- `Paiements`
+- `Banque`
+- `Caisse`
+- `Salaires`
+
+Conséquence : pour la partie `Gestion`, la validation doit se faire sur le périmètre de dates exact des exercices, et non sur le seul nom de fichier `2024` ou `2025`.
+
+#### Sources secondaires seulement
+
+Les éléments suivants sont utiles comme contrôle rapide ou sanity check, mais ne doivent pas servir de preuve principale pour `BL-026` :
+
+- `Dashboard`, car ses KPI ne sont pas filtrés par exercice ;
+- les bandeaux de résultat d'import, car ils reflètent l'opération d'import, pas l'état final consolidé de l'application ;
+- la preview d'import, car elle décrit un fichier avant écriture, pas le résultat persistant final.
+
+## Principe de validation retenu
+
+Le ticket vise une validation chiffrée lisible et défendable. Le principe retenu est donc :
+
+1. comparer d'abord les données source Excel et l'état final de Solde, pas seulement les compteurs d'import ;
+2. raisonner par exercice réel et par domaine métier ;
+3. utiliser les états comptables comme preuve principale côté comptabilité ;
+4. utiliser les listes et totaux filtrés par date comme preuve principale côté gestion ;
+5. consigner explicitement tout écart avec une hypothèse de cause.
+
+## Périmètre de comparaison
+
+### 1. Gestion
+
+Pour chaque exercice, comparer au minimum :
+
+- le nombre et le total des `factures clients` ;
+- le nombre et le total des `factures fournisseurs` si le fichier en génère ;
+- le nombre et le total des `paiements` ;
+- le nombre et le total des mouvements de `caisse` ;
+- le nombre et le total des mouvements de `banque` ;
+- les `salaires` si l'exercice contient une feuille correspondante ;
+- quelques cas ciblés de rapprochement métier sensibles : paiements déposés ou non, factures fournisseurs reconstruites via références `FF-*`, mouvements de solde initial ignorés.
+
+### 2. Comptabilité
+
+Pour chaque exercice, comparer au minimum :
+
+- le nombre d'écritures du `Journal` ;
+- le total `débit` et le total `crédit` du `Journal` ;
+- la `Balance` par compte avec contrôle des totaux `débit`, `crédit` et `solde` ;
+- le `Bilan` (`total actif`, `total passif`, `résultat`) ;
+- le `Résultat` (`charges`, `produits`, résultat net) ;
+- un jeu réduit de `grands livres` sur comptes sensibles pour vérification détaillée si un écart apparaît.
+
+## Matrice de preuves à produire
+
+| Domaine | Source Excel | Source Solde | Portée | Type de preuve |
+|---|---|---|---|---|
+| Factures clients | feuille `Factures` gestion | écran `Factures clients` + API `GET /invoices` | exercice par dates | nombre, total, échantillons |
+| Factures fournisseurs | feuilles `Banque` / `Caisse` si reconstruction `FF-*` | écran `Factures fournisseurs` + API `GET /invoices` | exercice par dates | nombre, total, références sensibles |
+| Paiements | feuille `Paiements` gestion | écran `Paiements` + API `GET /payments` | exercice par dates | nombre, total, déposés/non déposés |
+| Caisse | feuille `Caisse` gestion | écran `Caisse` + API `GET /cash/entries` | exercice par dates | nombre, total net, cas ignorés |
+| Banque | feuille `Banque` gestion | écran `Banque` + API `GET /bank/transactions` | exercice par dates | nombre, total net, cas ignorés |
+| Salaires | feuille salaires si présente | écran `Salaires` | exercice par dates/mois | nombre, totaux |
+| Journal | feuille `Journal` comptabilité | écran/API `journal-grouped` | exercice par `fiscal_year_id` | nombre, débit, crédit |
+| Balance | feuille `Journal` agrégée par compte | écran/API `balance` | exercice par `fiscal_year_id` | par compte + totaux |
+| Bilan | feuille `Journal` retraitée | écran/API `bilan` | exercice par `fiscal_year_id` | actif, passif, résultat |
+| Résultat | feuille `Journal` retraitée | écran/API `resultat` | exercice par `fiscal_year_id` | charges, produits, résultat |
+| Grand livre | feuille `Journal` détaillée | écran/API `ledger/{account}` | exercice par `fiscal_year_id` | contrôle ciblé en cas d'écart |
+
+## Séquence de validation recommandée
+
+### Étape 1 — figer le périmètre des exercices
+
+Avant toute comparaison, relever les bornes réelles des exercices présents dans Solde.
+
+Règle : toujours comparer sur les dates réelles de l'exercice, pas sur une hypothèse d'année civile fondée sur le nom du fichier.
+
+### Étape 2 — valider la gestion sur l'état final importé
+
+Pour chaque exercice :
+
+1. filtrer les écrans ou APIs de gestion sur la plage de dates exacte de l'exercice ;
+2. relever les compteurs et totaux visibles ;
+3. reconstruire les mêmes chiffres côté Excel ;
+4. noter les écarts éventuels ;
+5. qualifier chaque écart :
+   - comportement attendu d'import ;
+   - divergence de données ;
+   - bug probable ;
+   - ambiguïté métier ou source.
+
+### Étape 3 — valider la comptabilité par exercice
+
+Pour chaque exercice :
+
+1. relever les chiffres du `Journal` ;
+2. vérifier l'égalité `total débit = total crédit` ;
+3. relever la `Balance` complète ;
+4. relever le `Bilan` et le `Résultat` ;
+5. si un écart persiste, ouvrir un ou plusieurs `Grands livres` ciblés pour isoler le compte responsable.
+
+### Étape 4 — produire un constat de validation
+
+Pour chaque exercice, produire un constat unique avec :
+
+- ce qui a été comparé ;
+- les chiffres Excel ;
+- les chiffres Solde ;
+- le statut (`conforme`, `écart justifié`, `écart à corriger`, `à clarifier`) ;
+- les remarques utiles pour la suite du ticket.
+
+## Format attendu du constat
+
+Le format cible pour la recette est le suivant.
+
+### Exercice `...`
+
+| Domaine | Excel | Solde | Statut | Commentaire |
+|---|---|---|---|---|
+| Factures clients | ... | ... | ... | ... |
+| Factures fournisseurs | ... | ... | ... | ... |
+| Paiements | ... | ... | ... | ... |
+| Caisse | ... | ... | ... | ... |
+| Banque | ... | ... | ... | ... |
+| Journal | ... | ... | ... | ... |
+| Balance | ... | ... | ... | ... |
+| Bilan | ... | ... | ... | ... |
+| Résultat | ... | ... | ... | ... |
+
+## Points d'attention
+
+- Ne pas utiliser le `Dashboard` comme preuve principale par exercice.
+- Ne pas comparer uniquement les compteurs retournés par l'import : la cible est l'état persistant final de Solde.
+- Pour la gestion, préférer les filtres de date exacts aux comparaisons globales de listes non bornées.
+- Les écritures auto-générées issues de la gestion et les écritures importées de comptabilité doivent être lues ensemble dans les états comptables finaux si l'objectif est de comparer Solde à la réalité Excel complète.
+- Les lignes explicitement ignorées par politique d'import (`Total`, `solde initial`, écriture nulle, etc.) doivent être connues avant de qualifier un écart comme bug.
+
+## Prochaine étape recommandée
+
+Préparer un premier relevé de validation sur l'exercice que l'utilisateur est en train de rejouer, avec un gabarit de constat rempli partiellement dès que les imports sont terminés.

--- a/doc/dev/bl-026-constat-validation-imports.md
+++ b/doc/dev/bl-026-constat-validation-imports.md
@@ -15,7 +15,7 @@ Méthode de référence : `doc/dev/bl-026-cadrage-validation-imports-excel.md`.
 - Import `Comptabilité 2024` : `succès avec avertissements`
 - Import `Comptabilité 2025` : `non lancé`
 - Exercices présents dans Solde : `2023`, `2024` et `2025` (créés via le bouton "créer le socle comptable")
-- Observations préalables : `test centré sur l'exercice 2024 uniquement ; les exercices 2023, 2024 et 2025 affichent tous des chiffres dans l'écran Balance ; pour les écrans de gestion, le relevé se fait en vue tous les exercices puis avec filtre strict sur la colonne date`
+- Observations préalables : `test centré sur l'exercice 2024 uniquement ; les exercices 2023, 2024 et 2025 affichent tous des chiffres dans l'écran Balance ; pour les écrans de gestion, le relevé se fait avec l'exercice 2024 sélectionné ; relevé visuel Banque/Caisse reconfirmé le 2026-04-16 après configuration de l'ouverture du système au 2024-08-01 (banque 8 155,62 € ; caisse 226,79 €)`
 
 ## Capture rapide pendant le test 2024
 
@@ -34,12 +34,13 @@ Méthode de référence : `doc/dev/bl-026-cadrage-validation-imports-excel.md`.
 - `Factures clients` : total visible `245`, montant total `22357.00 €`, montant payé `22253.00 €`, montant en retard `0.00 €`
 - `Factures fournisseurs` : total visible `36`, montant total `4403.81 €`
 - `Paiements` : total visible `266`, montant total `23028.00 €`, non remis en banque `2`
-- `Caisse` : solde courant `-171.81 €`, variation de période `-171.81 €`, nombre d'écritures `102` ; cartes alignées sur le périmètre affiché (`Périmètre affiché`)
-- `Banque` : solde courant `2674.77 €`, variation de période `+2674.77 €`, nombre de transactions `204` ; cartes alignées sur le périmètre affiché (`Périmètre affiché`)
-- `Journal` : nombre d'écritures `670`, total débit `184 989,16 €`, total crédit `184 989,16 €`
-- `Balance` : total débit `184 989,16 €`, total crédit `184 989,16 €` ; totaux calculés directement depuis la base locale car l'écran n'affiche pas de total général
-- `Bilan` : total actif `54 196,45 €`, total passif `-60 018,54 €`, résultat `-5 822,09 €`
-- `Résultat` : total charges `31 052,56 €`, total produits `25 230,47 €`, résultat net `-5 822,09 €`
+- `Caisse` : solde courant `54.98 €`, variation de période `+54.98 €`, nombre d'écritures `103`, comptages visibles `0` ; relevé visuel confirmé sur l'écran `Caisse` avec l'exercice `2024` sélectionné
+- `Banque` : solde courant `2674.77 €`, variation de période `+2674.77 €`, nombre de transactions `204`, bordereaux visibles `0` ; relevé visuel confirmé sur l'écran `Banque` avec l'exercice `2024` sélectionné
+- `Salaires` : total visible `22`, brut `20 509,94 €`, net `15 964,81 €`, coût total `25 221,81 €` ; relevé visuel confirmé sur l'écran `Salaires` avec l'exercice `2024` sélectionné
+- `Journal` : nombre d'écritures `670`, total débit `184 989,16 €`, total crédit `184 989,16 €`, sources distinctes `5` ; relevé visuel confirmé sur l'écran `Journal comptable` avec l'exercice `2024` sélectionné
+- `Balance` : lignes de balance visibles confirmées sur l'écran `Balance générale` avec l'exercice `2024` sélectionné ; l'écran ne montre toujours pas de total général visible, donc les totaux `débit 184 989,16 €` et `crédit 184 989,16 €` restent issus du calcul en base locale
+- `Bilan` : total actif `54 196,45 €`, total passif `-60 018,54 €`, résultat `-5 822,09 €` ; relevé visuel confirmé sur l'écran `Bilan simplifié` avec l'exercice `2024` sélectionné ; l'UI affiche explicitement `Total passif : -60 018,54 €` et `Résultat de l'exercice : -5 822,09 €`
+- `Résultat` : total charges `31 052,56 €`, total produits `25 230,47 €`, résultat net `-5 822,09 €` ; relevé visuel confirmé sur l'écran `Compte de résultat` avec l'exercice `2024` sélectionné ; l'UI affiche `Déficit : -5 822,09`
 
 ## Exercice 2024
 
@@ -48,27 +49,29 @@ Méthode de référence : `doc/dev/bl-026-cadrage-validation-imports-excel.md`.
 
 | Domaine | Chiffres Excel | Chiffres Solde | Statut | Commentaire |
 |---|---|---|---|---|
-| Factures clients | `245 factures ; total 22 357,00 € ; payé 22 253,00 € ; en retard 104,00 € (calculé)` | `245 factures ; total 22 357,00 € ; payé 22 253,00 € ; en retard 0,00 €` | `à clarifier` | `nombre, total et payé conformes ; écart de 104,00 € sur le montant en retard` |
-| Factures fournisseurs | `à reconstruire depuis les onglets Banque et Caisse (références FF-*/vlookup)` | `36 factures ; total 4 403,81 €` | `à instruire` | `pas d'onglet dédié dans Gestion 2024.xlsx ; rapprochement Excel direct non encore fait` |
+| Factures clients | `245 factures ; total 22 357,00 € ; payé 22 253,00 € ; en retard 104,00 € (calculé)` | `245 factures ; total 22 357,00 € ; payé 22 253,00 € ; en retard 0,00 €` | `à clarifier` | `nombre, total et payé conformes ; les 104,00 € restants correspondent aux factures 2024-0277 (78,00 €) et 2025-0010 (26,00 €), encore au statut sent sans due_date, donc non comptées comme overdue par l'UI` |
+| Factures fournisseurs | `36 références FF-* reconstituées depuis Banque/Caisse ; Banque = 20 lignes / 3 811,00 € ; Caisse = 16 lignes / 592,81 € ; total 4 403,81 €` | `36 factures ; total 4 403,81 € ; payé 4 403,81 €` | `conforme` | `la reconstruction par références FF-* sur la plage 2024-08-01 -> 2025-07-31 retombe exactement sur les factures fournisseurs créées dans Solde` |
 | Paiements | `266 paiements ; total 23 028,00 € ; 2 non remis` | `266 paiements ; total 23 028,00 € ; 2 non remis` | `conforme` | `nombre, total et non remis conformes` |
-| Caisse |  | `solde -171,81 € ; variation -171,81 € ; 102 écritures` | `à clarifier` | `relevé provisoire ; dépend du futur traitement de l'ouverture du système sur le premier exercice importé` |
-| Banque |  | `solde 2 674,77 € ; variation +2 674,77 € ; 204 transactions` | `à reprendre` | `cartes alignées sur le périmètre affiché après correction frontend du 2026-04-15 ; chiffres susceptibles d'évoluer après traitement de l'ouverture du système` |
-| Salaires |  | `23 salaires créés à l'import ; contrôle écran détaillé non encore relevé` |  |  |
-| Journal |  | `670 opérations ; débit 184 989,16 € ; crédit 184 989,16 €` |  |  |
-| Balance |  | `débit 184 989,16 € ; crédit 184 989,16 €` |  | `totaux calculés directement depuis la base locale, car non affichés dans l'écran` |
-| Bilan |  | `actif 54 196,45 € ; passif -60 018,54 € ; résultat -5 822,09 €` |  |  |
-| Résultat |  | `charges 31 052,56 € ; produits 25 230,47 € ; résultat -5 822,09 €` |  |  |
+| Caisse | `102 mouvements importés ; flux net -171,81 € ; ouverture du système hors fichier = +226,79 €` | `solde 54,98 € ; variation +54,98 € ; 103 écritures ; 0 comptages visibles` | `écart justifié` | `relevé visuel reconfirmé le 2026-04-16 ; BL-027 appliqué : Solde affiche le cumul des flux importés et d'une ouverture du système explicite au 2024-08-01` |
+| Banque | `203 mouvements importés ; flux net -5 480,85 € ; ouverture du système hors fichier = +8 155,62 €` | `solde 2 674,77 € ; variation +2 674,77 € ; 204 transactions ; 0 bordereaux visibles` | `écart justifié` | `relevé visuel reconfirmé le 2026-04-16 ; BL-027 appliqué : le solde visible intègre l'ouverture du système au 2024-08-01 en plus des transactions importées` |
+| Salaires | `25 lignes candidates dans l'onglet Aide Salaires ; 22 salaires distincts après déduplication mois + employé ; brut 20 509,94 € ; net 15 964,81 € ; coût total 25 221,81 €` | `22 salaires sur l'exercice 2024 ; brut 20 509,94 € ; net 15 964,81 € ; coût total 25 221,81 €` | `à clarifier` | `relevé visuel écran confirmé le 2026-04-16 ; les chiffres Solde concordent avec la logique d'import actuelle ; réserve méthodologique : la colonne Excel reste dérivée du parseur d'import et non d'un relevé indépendant du classeur` |
+| Journal | `1 390 lignes de journal ; 1 385 lignes importables (5 écritures nulles ignorées) ; 660 opérations (colonne N° de 0 à 659) ; débit 181 885,84 € ; crédit 181 885,84 €` | `670 opérations ; débit 184 989,16 € ; crédit 184 989,16 € ; 5 sources distinctes` | `à clarifier` | `l'écart ne vient pas d'un sur-découpage ChangeNum : l'onglet Journal retombe aussi sur 660 groupes ; Solde affiche 670 groupes car 107 groupes base-only et 97 groupes Excel-only ne partagent pas la même signature date + comptes + montants, soit un delta net de +10 groupes et +3 103,32 €` |
+| Balance | `débit 181 885,84 € ; crédit 181 885,84 € ; solde débiteur 87 045,59 € ; solde créditeur 87 045,59 €` | `balance affichée confirmée visuellement sur l'exercice 2024 ; totaux Solde débit/crédit = 184 989,16 € / 184 989,16 €` | `à clarifier` | `le delta de 3 103,32 € suit le même motif que le Journal : des écritures de gestion auto-générées, surtout fournisseurs via 401000 et certains groupes de salaires, ne retombent pas sur une signature identique à celle du journal Excel` |
+| Bilan |  | `actif 54 196,45 € ; passif -60 018,54 € ; résultat -5 822,09 €` | `à clarifier` | `relevé visuel écran confirmé le 2026-04-16 ; l'UI affiche explicitement un total passif négatif, reste à décider si cette convention d'affichage est celle attendue pour la recette` |
+| Résultat |  | `charges 31 052,56 € ; produits 25 230,47 € ; résultat -5 822,09 €` | `relevé visuel` | `écran confirmé le 2026-04-16 ; l'UI qualifie explicitement le résultat de déficit` |
 
 ### Vérifications ciblées 2024
 
 - Comptes ou écritures sensibles vérifiés : `531000 Caisse`, `512100 Compte courant`, `512102 Compte d'épargne`, `110000 Report à nouveau`, `431100 URSSAF`
 - Lignes explicitement ignorées connues : `Gestion 2024 : 5 ignorées, 0 bloquante ; Comptabilité 2024 : 1367 ignorées, 0 bloquante`
-- Écarts restant à instruire : `rapprochement Excel -> Solde encore à finaliser domaine par domaine ; factures fournisseurs à reconstruire depuis Banque/Caisse (références FF-*) ; trésorerie 2024 à remesurer après traitement du sujet BL-027 sur l'ouverture du système Banque/Caisse du premier exercice importé ; contrôle détaillé écran Salaires non encore relevé ; vérifier si le signe du total passif affiché dans le Bilan correspond bien à la convention d'affichage attendue`
+- Rapprochement technique du Journal 2024 : `le seul onglet Journal contient 1 385 lignes comptables importables, 660 opérations (colonne N° = 0..659) et 181 885,84 € au débit comme au crédit ; l'algorithme d'import reconstruit aussi 660 groupes sur cet onglet, donc le différentiel Solde n'est pas causé par ChangeNum ; les groupes non rapprochés côté base sont uniquement des sources auto-générées invoice/payment/salary, jamais des groupes manual importés depuis Comptabilité`
+- Écarts restant à instruire : `rapprochement Excel -> Solde encore à finaliser domaine par domaine ; pour le Journal et la Balance, arrêter explicitement la convention de comparaison retenue entre état final Solde et journal Excel, au lieu de viser une identité brute ligne à ligne quand la modélisation diffère ; trancher la convention métier du montant en retard client quand une facture reste impayée sans due_date ni statut overdue ; vérifier si le signe du total passif affiché dans le Bilan correspond bien à la convention d'affichage attendue ; préciser dans la synthèse finale la convention retenue pour comparer la trésorerie importée et l'ouverture du système hors fichier ; confirmer si les salaires doivent être rapprochés seulement sur les montants métier ou aussi sur une convention stricte de date et de regroupement`
 
 ## Exercice 2025
 
 - Bornes de l'exercice dans Solde : `...`
 - Fichier(s) Excel de référence : `...`
+- Décision de clôture `BL-026` : `l'exercice 2025 n'est pas poursuivi dans ce ticket ; la suite de la validation stricte est reportée après cadrage de BL-008 et traitement des correctifs identifiés comme BL-028`
 
 | Domaine | Chiffres Excel | Chiffres Solde | Statut | Commentaire |
 |---|---|---|---|---|
@@ -91,8 +94,8 @@ Méthode de référence : `doc/dev/bl-026-cadrage-validation-imports-excel.md`.
 
 ## Synthèse globale
 
-- Niveau de confiance sur la reprise `Gestion` : `...`
-- Niveau de confiance sur la reprise `Comptabilité` : `...`
-- Écarts bloquants : `...`
-- Écarts non bloquants : `...`
-- Sujets à transformer en correctifs distincts : `...`
+- Niveau de confiance sur la reprise `Gestion` : `élevé sur l'exercice 2024 pour les chiffres métier visibles : factures fournisseurs, paiements, banque et caisse sont conformes ou justifiés ; la validation 2025 reste à faire et certains points de convention métier demeurent ouverts côté factures clients et salaires`
+- Niveau de confiance sur la reprise `Comptabilité` : `moyen à bon sur l'exercice 2024 : les états principaux sont cohérents et les écarts résiduels identifiés relèvent en partie de différences de modélisation entre Excel et Solde ; la validation 2025 n'est pas poursuivie dans BL-026 et la règle de comparaison comptable cible doit encore être figée`
+- Écarts bloquants : `aucun écart bloquant démontré à ce stade sur la reprise 2024 ; en revanche, il n'existe pas encore de convention de rapprochement assez explicite pour conclure à une convergence comptable brute Excel = Solde sur le journal final, ce qui motive la bascule vers BL-008 et BL-028`
+- Écarts non bloquants : `montant en retard client dépendant de la convention UI (`due_date` / `overdue`) ; trésorerie 2024 nécessitant l'intégration de l'ouverture du système hors fichier ; comparaison comptable 2024 sensible à des différences de granularité (facture fournisseur + règlement dans Solde vs paiement direct dans Excel, ventilation produit côté clients, regroupements salariaux)`
+- Sujets à transformer en correctifs distincts : `BL-028 pour la ventilation comptable des factures clients mixtes de type cs+a ; BL-008 pour un mode de validation itérative distinguant convergence globale et validation du moteur Gestion ; éventuellement un sujet dédié si la convention d'affichage du passif au Bilan doit être revue ; la validation future de 2025 devra être reprise dans ce nouveau cadre plutôt que prolongée telle quelle dans BL-026`

--- a/doc/dev/bl-026-constat-validation-imports.md
+++ b/doc/dev/bl-026-constat-validation-imports.md
@@ -1,0 +1,98 @@
+# BL-026 — Constat de validation des imports Excel
+
+## Rappel
+
+Ce document sert à consigner le résultat effectif de la validation chiffrée entre les fichiers Excel sources et les données visibles dans Solde.
+
+Méthode de référence : `doc/dev/bl-026-cadrage-validation-imports-excel.md`.
+
+## Préconditions du relevé
+
+- Base utilisée : `base locale de dev après reset`
+- Date du relevé : `2026-04-15`
+- Import `Gestion 2024` : `succès avec avertissements`
+- Import `Gestion 2025` : `non lancé`
+- Import `Comptabilité 2024` : `succès avec avertissements`
+- Import `Comptabilité 2025` : `non lancé`
+- Exercices présents dans Solde : `2023`, `2024` et `2025` (créés via le bouton "créer le socle comptable")
+- Observations préalables : `test centré sur l'exercice 2024 uniquement ; les exercices 2023, 2024 et 2025 affichent tous des chiffres dans l'écran Balance ; pour les écrans de gestion, le relevé se fait en vue tous les exercices puis avec filtre strict sur la colonne date`
+
+## Capture rapide pendant le test 2024
+
+### Résultat d'import à relever tout de suite
+
+- Résultat `Gestion 2024` : `succès avec avertissements`
+- Compteurs `Gestion 2024` : `contacts=66`, `factures=303`, `paiements=308`, `salaires=23`, `caisse=102`, `banque=210`, `écritures=1445`
+- Lignes `Gestion 2024` ignorées / bloquées : `ignorées=5`, `bloquantes=0`
+- Résultat `Comptabilité 2024` : `succès avec avertissements`
+- Compteurs `Comptabilité 2024` : `écritures=23`, `ignorées=1367`, `bloquées=0`
+- Messages d'avertissement ou d'erreur à conserver : `rien`
+
+### Contrôles Solde à relever juste après import
+
+- Bornes exactes de l'exercice `2024` dans Solde : `2024-08-01 -> 2025-07-31` (statut `Ouvert`)
+- `Factures clients` : total visible `245`, montant total `22357.00 €`, montant payé `22253.00 €`, montant en retard `0.00 €`
+- `Factures fournisseurs` : total visible `36`, montant total `4403.81 €`
+- `Paiements` : total visible `266`, montant total `23028.00 €`, non remis en banque `2`
+- `Caisse` : solde courant `-171.81 €`, variation de période `-171.81 €`, nombre d'écritures `102` ; cartes alignées sur le périmètre affiché (`Périmètre affiché`)
+- `Banque` : solde courant `2674.77 €`, variation de période `+2674.77 €`, nombre de transactions `204` ; cartes alignées sur le périmètre affiché (`Périmètre affiché`)
+- `Journal` : nombre d'écritures `670`, total débit `184 989,16 €`, total crédit `184 989,16 €`
+- `Balance` : total débit `184 989,16 €`, total crédit `184 989,16 €` ; totaux calculés directement depuis la base locale car l'écran n'affiche pas de total général
+- `Bilan` : total actif `54 196,45 €`, total passif `-60 018,54 €`, résultat `-5 822,09 €`
+- `Résultat` : total charges `31 052,56 €`, total produits `25 230,47 €`, résultat net `-5 822,09 €`
+
+## Exercice 2024
+
+- Bornes de l'exercice dans Solde : `2024-08-01 -> 2025-07-31` (statut `Ouvert`)
+- Fichier(s) Excel de référence : `Gestion 2024.xlsx` et `Comptabilite 2024.xlsx`
+
+| Domaine | Chiffres Excel | Chiffres Solde | Statut | Commentaire |
+|---|---|---|---|---|
+| Factures clients | `245 factures ; total 22 357,00 € ; payé 22 253,00 € ; en retard 104,00 € (calculé)` | `245 factures ; total 22 357,00 € ; payé 22 253,00 € ; en retard 0,00 €` | `à clarifier` | `nombre, total et payé conformes ; écart de 104,00 € sur le montant en retard` |
+| Factures fournisseurs | `à reconstruire depuis les onglets Banque et Caisse (références FF-*/vlookup)` | `36 factures ; total 4 403,81 €` | `à instruire` | `pas d'onglet dédié dans Gestion 2024.xlsx ; rapprochement Excel direct non encore fait` |
+| Paiements | `266 paiements ; total 23 028,00 € ; 2 non remis` | `266 paiements ; total 23 028,00 € ; 2 non remis` | `conforme` | `nombre, total et non remis conformes` |
+| Caisse |  | `solde -171,81 € ; variation -171,81 € ; 102 écritures` | `à clarifier` | `relevé provisoire ; dépend du futur traitement de l'ouverture du système sur le premier exercice importé` |
+| Banque |  | `solde 2 674,77 € ; variation +2 674,77 € ; 204 transactions` | `à reprendre` | `cartes alignées sur le périmètre affiché après correction frontend du 2026-04-15 ; chiffres susceptibles d'évoluer après traitement de l'ouverture du système` |
+| Salaires |  | `23 salaires créés à l'import ; contrôle écran détaillé non encore relevé` |  |  |
+| Journal |  | `670 opérations ; débit 184 989,16 € ; crédit 184 989,16 €` |  |  |
+| Balance |  | `débit 184 989,16 € ; crédit 184 989,16 €` |  | `totaux calculés directement depuis la base locale, car non affichés dans l'écran` |
+| Bilan |  | `actif 54 196,45 € ; passif -60 018,54 € ; résultat -5 822,09 €` |  |  |
+| Résultat |  | `charges 31 052,56 € ; produits 25 230,47 € ; résultat -5 822,09 €` |  |  |
+
+### Vérifications ciblées 2024
+
+- Comptes ou écritures sensibles vérifiés : `531000 Caisse`, `512100 Compte courant`, `512102 Compte d'épargne`, `110000 Report à nouveau`, `431100 URSSAF`
+- Lignes explicitement ignorées connues : `Gestion 2024 : 5 ignorées, 0 bloquante ; Comptabilité 2024 : 1367 ignorées, 0 bloquante`
+- Écarts restant à instruire : `rapprochement Excel -> Solde encore à finaliser domaine par domaine ; factures fournisseurs à reconstruire depuis Banque/Caisse (références FF-*) ; trésorerie 2024 à remesurer après traitement du sujet BL-027 sur l'ouverture du système Banque/Caisse du premier exercice importé ; contrôle détaillé écran Salaires non encore relevé ; vérifier si le signe du total passif affiché dans le Bilan correspond bien à la convention d'affichage attendue`
+
+## Exercice 2025
+
+- Bornes de l'exercice dans Solde : `...`
+- Fichier(s) Excel de référence : `...`
+
+| Domaine | Chiffres Excel | Chiffres Solde | Statut | Commentaire |
+|---|---|---|---|---|
+| Factures clients |  |  |  |  |
+| Factures fournisseurs |  |  |  |  |
+| Paiements |  |  |  |  |
+| Caisse |  |  |  |  |
+| Banque |  |  |  |  |
+| Salaires |  |  |  |  |
+| Journal |  |  |  |  |
+| Balance |  |  |  |  |
+| Bilan |  |  |  |  |
+| Résultat |  |  |  |  |
+
+### Vérifications ciblées 2025
+
+- Comptes ou écritures sensibles vérifiés : `...`
+- Lignes explicitement ignorées connues : `...`
+- Écarts restant à instruire : `...`
+
+## Synthèse globale
+
+- Niveau de confiance sur la reprise `Gestion` : `...`
+- Niveau de confiance sur la reprise `Comptabilité` : `...`
+- Écarts bloquants : `...`
+- Écarts non bloquants : `...`
+- Sujets à transformer en correctifs distincts : `...`

--- a/frontend/src/i18n/fr.ts
+++ b/frontend/src/i18n/fr.ts
@@ -416,6 +416,7 @@ export default {
     },
     metrics: {
       current_balance_caption: 'Toutes périodes confondues',
+      visible_scope_caption: 'Périmètre affiché',
       period_variation_caption: 'Période : {period}',
       entries_total: '{count} écriture(s) sur la période',
       counts_total: '{count} comptage(s) sur la période',
@@ -473,6 +474,7 @@ export default {
     import_success: '{n} opération(s) importée(s).',
     metrics: {
       current_balance_caption: 'Toutes périodes confondues',
+      visible_scope_caption: 'Périmètre affiché',
       period_variation_caption: 'Période : {period}',
       transactions_total: '{count} au total',
       pending_payments: '{count} paiement(s) en attente',

--- a/frontend/src/views/BankView.vue
+++ b/frontend/src/views/BankView.vue
@@ -25,14 +25,14 @@
     <section class="app-stat-grid">
       <AppStatCard
         :label="t('bank.current_balance')"
-        :value="formatAmount(balance)"
-        :caption="t('bank.metrics.current_balance_caption')"
+        :value="displayBalanceValue"
+        :caption="currentBalanceCaption"
       />
       <AppStatCard
         :label="t('bank.period_variation')"
-        :value="formatSignedAmount(periodVariation)"
-        :caption="t('bank.metrics.period_variation_caption', { period: selectedPeriodLabel })"
-        :tone="periodVariationTone"
+        :value="formatSignedAmount(displayedPeriodVariation)"
+        :caption="periodVariationCaption"
+        :tone="displayedPeriodVariationTone"
       />
       <AppStatCard
         :label="t('bank.transactions_title')"
@@ -652,6 +652,10 @@ const periodVariation = computed(() =>
   transactions.value.reduce((total, transaction) => total + parseFloat(transaction.amount), 0),
 )
 
+const displayedPeriodVariation = computed(() =>
+  displayedTransactions.value.reduce((total, transaction) => total + parseFloat(transaction.amount), 0),
+)
+
 const selectedPeriodLabel = computed(
   () => fiscalYearStore.selectedFiscalYear?.name ?? t('app.all_fiscal_years'),
 )
@@ -659,6 +663,12 @@ const selectedPeriodLabel = computed(
 const periodVariationTone = computed(() => {
   if (periodVariation.value > 0) return 'success'
   if (periodVariation.value < 0) return 'danger'
+  return 'warn'
+})
+
+const displayedPeriodVariationTone = computed(() => {
+  if (displayedPeriodVariation.value > 0) return 'success'
+  if (displayedPeriodVariation.value < 0) return 'danger'
   return 'warn'
 })
 
@@ -712,6 +722,44 @@ const activeHasFilters = computed(() =>
   activeTab.value === 'transactions'
     ? transactionHasActiveFilters.value
     : depositHasActiveFilters.value,
+)
+
+function pickLatestVisibleBalanceAfter(
+  rows: Array<{ id: number; date: string; balance_after: string }>,
+): string | null {
+  if (rows.length === 0) {
+    return null
+  }
+
+  const latestRow = rows.reduce((latest, current) => {
+    if (current.date > latest.date) {
+      return current
+    }
+    if (current.date === latest.date && current.id > latest.id) {
+      return current
+    }
+    return latest
+  })
+
+  return latestRow.balance_after
+}
+
+const scopedBalance = computed(() => pickLatestVisibleBalanceAfter(displayedTransactions.value))
+
+const displayBalanceValue = computed(() =>
+  formatAmount(scopedBalance.value ?? balance.value),
+)
+
+const currentBalanceCaption = computed(() =>
+  transactionHasActiveFilters.value || fiscalYearStore.selectedFiscalYear
+    ? t('bank.metrics.visible_scope_caption')
+    : t('bank.metrics.current_balance_caption'),
+)
+
+const periodVariationCaption = computed(() =>
+  transactionHasActiveFilters.value
+    ? t('bank.metrics.visible_scope_caption')
+    : t('bank.metrics.period_variation_caption', { period: selectedPeriodLabel.value }),
 )
 
 function resetActiveFilters() {

--- a/frontend/src/views/CashView.vue
+++ b/frontend/src/views/CashView.vue
@@ -15,14 +15,14 @@
     <section class="app-stat-grid">
       <AppStatCard
         :label="t('cash.current_balance')"
-        :value="formatAmount(balance)"
-        :caption="t('cash.metrics.current_balance_caption')"
+        :value="displayBalanceValue"
+        :caption="currentBalanceCaption"
       />
       <AppStatCard
         :label="t('cash.period_variation')"
-        :value="formatSignedAmount(periodVariation)"
-        :caption="t('cash.metrics.period_variation_caption', { period: selectedPeriodLabel })"
-        :tone="periodVariationTone"
+        :value="formatSignedAmount(displayedPeriodVariation)"
+        :caption="periodVariationCaption"
+        :tone="displayedPeriodVariationTone"
       />
       <AppStatCard
         :label="t('cash.journal')"
@@ -598,6 +598,13 @@ const periodVariation = computed(() =>
   }, 0),
 )
 
+const displayedPeriodVariation = computed(() =>
+  displayedEntries.value.reduce((total, entry) => {
+    const amount = parseFloat(entry.amount)
+    return total + (entry.type === 'out' ? -amount : amount)
+  }, 0),
+)
+
 const selectedPeriodLabel = computed(
   () => fiscalYearStore.selectedFiscalYear?.name ?? t('app.all_fiscal_years'),
 )
@@ -605,6 +612,12 @@ const selectedPeriodLabel = computed(
 const periodVariationTone = computed(() => {
   if (periodVariation.value > 0) return 'success'
   if (periodVariation.value < 0) return 'danger'
+  return 'warn'
+})
+
+const displayedPeriodVariationTone = computed(() => {
+  if (displayedPeriodVariation.value > 0) return 'success'
+  if (displayedPeriodVariation.value < 0) return 'danger'
   return 'warn'
 })
 
@@ -654,6 +667,44 @@ const activeGlobalFilter = computed({
 
 const activeHasFilters = computed(() =>
   activeTab.value === 'journal' ? entryHasActiveFilters.value : countHasActiveFilters.value,
+)
+
+function pickLatestVisibleBalanceAfter(
+  rows: Array<{ id: number; date: string; balance_after: string }>,
+): string | null {
+  if (rows.length === 0) {
+    return null
+  }
+
+  const latestRow = rows.reduce((latest, current) => {
+    if (current.date > latest.date) {
+      return current
+    }
+    if (current.date === latest.date && current.id > latest.id) {
+      return current
+    }
+    return latest
+  })
+
+  return latestRow.balance_after
+}
+
+const scopedBalance = computed(() => pickLatestVisibleBalanceAfter(displayedEntries.value))
+
+const displayBalanceValue = computed(() =>
+  formatAmount(scopedBalance.value ?? balance.value),
+)
+
+const currentBalanceCaption = computed(() =>
+  entryHasActiveFilters.value || fiscalYearStore.selectedFiscalYear
+    ? t('cash.metrics.visible_scope_caption')
+    : t('cash.metrics.current_balance_caption'),
+)
+
+const periodVariationCaption = computed(() =>
+  entryHasActiveFilters.value
+    ? t('cash.metrics.visible_scope_caption')
+    : t('cash.metrics.period_variation_caption', { period: selectedPeriodLabel.value }),
 )
 
 function resetActiveFilters() {


### PR DESCRIPTION
This PR closes BL-026 as a validation and orientation ticket for the 2024 import replay.

- update the BL-026 findings document with the current validation conclusion and the decision to stop before 2025
- move BL-026 to done in the backlog and record the follow-up path through BL-008 and BL-028
- add BL-028 to track mixed customer invoice account splitting (`cs+a`) as a real accounting behavior gap

Known local check status before push:
- backend checks are already failing outside this change set (`mypy`, missing `pytest_asyncio` for `pytest`)
- frontend checks are already failing outside this change set (`BankView`/`CashView` lint and one `CashView` test)

## Summary by Sourcery

Adjust bank and cash metrics to reflect the currently visible scope, and document the outcome and follow-ups of the BL-026 Excel import validation.

New Features:
- Show scoped balances and period variations in Bank and Cash views based on the filtered transactions/entries and selected fiscal year.
- Add a visible-scope caption for treasury metrics to clarify when figures are limited by filters or fiscal-year selection.
- Introduce backlog items BL-027 and BL-028 to track opening-balance handling for treasury and mixed customer invoice account splitting, and document BL-026’s validation framework and conclusions.

Enhancements:
- Clarify backlog documentation around BL-026, including its decisions, acceptance criteria, and linkage to subsequent validation work.

Documentation:
- Add detailed developer documentation for the BL-026 Excel import validation strategy and the resulting 2024 validation findings.