### PR TITLE
fix: restore develop checks

### DIFF
--- a/backend/routers/accounting_entry.py
+++ b/backend/routers/accounting_entry.py
@@ -151,7 +151,7 @@ async def update_manual_entry(
         status_code = (
             status.HTTP_404_NOT_FOUND
             if "not found" in detail
-            else status.HTTP_422_UNPROCESSABLE_ENTITY
+            else status.HTTP_422_UNPROCESSABLE_CONTENT
         )
         raise HTTPException(status_code=status_code, detail=detail) from exc
     return cast(list[AccountingEntryRead], [debit, credit])

--- a/backend/routers/bank.py
+++ b/backend/routers/bank.py
@@ -136,7 +136,7 @@ async def import_csv(
         rows = parse_credit_mutuel_csv(payload.content)
     except BankImportError as exc:
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(exc)
         ) from exc
 
     created: list[BankTransactionRead] = []
@@ -197,7 +197,7 @@ async def import_ofx(
         rows = parse_ofx(payload.content)
     except BankImportError as exc:
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(exc)
         ) from exc
     return await _import_rows(rows, db)
 
@@ -217,7 +217,7 @@ async def import_qif(
         rows = parse_qif(payload.content)
     except BankImportError as exc:
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(exc)
         ) from exc
     return await _import_rows(rows, db)
 
@@ -270,7 +270,7 @@ async def create_deposit(
         deposit = await bank_service.create_deposit(db, payload)
     except ValueError as exc:
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(exc)
         ) from exc
     pids = await bank_service.get_deposit_payment_ids(db, deposit.id)
     return DepositRead(

--- a/backend/routers/fiscal_year.py
+++ b/backend/routers/fiscal_year.py
@@ -90,7 +90,7 @@ async def close_fiscal_year(
         closed = await fiscal_year_service.close_fiscal_year(db, fy)
     except FiscalYearError as exc:
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(exc)
         ) from exc
     return closed  # type: ignore[return-value]
 
@@ -109,7 +109,7 @@ async def administrative_close_fiscal_year(
         closed = await fiscal_year_service.administrative_close_fiscal_year(db, fy)
     except FiscalYearError as exc:
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(exc)
         ) from exc
     return closed  # type: ignore[return-value]
 
@@ -133,6 +133,6 @@ async def open_new_fiscal_year(
         new_fy = await fiscal_year_service.open_new_fiscal_year(db, closed_fy, payload)
     except FiscalYearError as exc:
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(exc)
         ) from exc
     return new_fy  # type: ignore[return-value]

--- a/backend/routers/invoice.py
+++ b/backend/routers/invoice.py
@@ -245,7 +245,7 @@ async def send_invoice_email(
     contact = result.scalar_one_or_none()
     if contact is None or not contact.email:
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail="Contact has no email address",
         )
 

--- a/frontend/src/tests/views/CashView.spec.ts
+++ b/frontend/src/tests/views/CashView.spec.ts
@@ -331,7 +331,7 @@ describe('CashView', () => {
 
     expect(wrapper.text()).toContain('cash.current_balance')
     expect(wrapper.text()).toContain('145.00 €')
-    expect(wrapper.text()).toContain('cash.metrics.current_balance_caption')
+    expect(wrapper.text()).toContain('cash.metrics.visible_scope_caption')
     expect(wrapper.text()).toContain('cash.period_variation')
     expect(wrapper.text()).toContain('+45.00 €')
     expect(wrapper.text()).toContain('cash.metrics.period_variation_caption')

--- a/frontend/src/views/BankView.vue
+++ b/frontend/src/views/BankView.vue
@@ -648,23 +648,16 @@ const depositRows = computed(() =>
   })),
 )
 
-const periodVariation = computed(() =>
-  transactions.value.reduce((total, transaction) => total + parseFloat(transaction.amount), 0),
-)
-
 const displayedPeriodVariation = computed(() =>
-  displayedTransactions.value.reduce((total, transaction) => total + parseFloat(transaction.amount), 0),
+  displayedTransactions.value.reduce(
+    (total, transaction) => total + parseFloat(transaction.amount),
+    0,
+  ),
 )
 
 const selectedPeriodLabel = computed(
   () => fiscalYearStore.selectedFiscalYear?.name ?? t('app.all_fiscal_years'),
 )
-
-const periodVariationTone = computed(() => {
-  if (periodVariation.value > 0) return 'success'
-  if (periodVariation.value < 0) return 'danger'
-  return 'warn'
-})
 
 const displayedPeriodVariationTone = computed(() => {
   if (displayedPeriodVariation.value > 0) return 'success'
@@ -746,9 +739,7 @@ function pickLatestVisibleBalanceAfter(
 
 const scopedBalance = computed(() => pickLatestVisibleBalanceAfter(displayedTransactions.value))
 
-const displayBalanceValue = computed(() =>
-  formatAmount(scopedBalance.value ?? balance.value),
-)
+const displayBalanceValue = computed(() => formatAmount(scopedBalance.value ?? balance.value))
 
 const currentBalanceCaption = computed(() =>
   transactionHasActiveFilters.value || fiscalYearStore.selectedFiscalYear

--- a/frontend/src/views/CashView.vue
+++ b/frontend/src/views/CashView.vue
@@ -591,13 +591,6 @@ const countRows = computed(() =>
   })),
 )
 
-const periodVariation = computed(() =>
-  entries.value.reduce((total, entry) => {
-    const amount = parseFloat(entry.amount)
-    return total + (entry.type === 'out' ? -amount : amount)
-  }, 0),
-)
-
 const displayedPeriodVariation = computed(() =>
   displayedEntries.value.reduce((total, entry) => {
     const amount = parseFloat(entry.amount)
@@ -608,12 +601,6 @@ const displayedPeriodVariation = computed(() =>
 const selectedPeriodLabel = computed(
   () => fiscalYearStore.selectedFiscalYear?.name ?? t('app.all_fiscal_years'),
 )
-
-const periodVariationTone = computed(() => {
-  if (periodVariation.value > 0) return 'success'
-  if (periodVariation.value < 0) return 'danger'
-  return 'warn'
-})
 
 const displayedPeriodVariationTone = computed(() => {
   if (displayedPeriodVariation.value > 0) return 'success'
@@ -691,9 +678,7 @@ function pickLatestVisibleBalanceAfter(
 
 const scopedBalance = computed(() => pickLatestVisibleBalanceAfter(displayedEntries.value))
 
-const displayBalanceValue = computed(() =>
-  formatAmount(scopedBalance.value ?? balance.value),
-)
+const displayBalanceValue = computed(() => formatAmount(scopedBalance.value ?? balance.value))
 
 const currentBalanceCaption = computed(() =>
   entryHasActiveFilters.value || fiscalYearStore.selectedFiscalYear


### PR DESCRIPTION
This PR restores the current develop branch to a clean, validated state.

- remove dead frontend computed values in Bank and Cash views
- align the CashView test with the current visible-scope caption behavior
- replace deprecated FastAPI 422 constants with HTTP_422_UNPROCESSABLE_CONTENT
- re-run backend and frontend validation, including vue-tsc, mypy, pytest, eslint, prettier, and vitest

## Summary by Sourcery

Clean up unused frontend metrics and align validation behavior with updated FastAPI and UI expectations.

Bug Fixes:
- Align Cash view balance caption test with the current visible-scope caption behavior.

Enhancements:
- Remove unused period variation computations and tones from Bank and Cash views while keeping displayed variations.
- Update backend HTTP 422 responses to use the non-deprecated HTTP_422_UNPROCESSABLE_CONTENT constant.

Tests:
- Adjust CashView test assertion to match the visible-scope caption key.