### PR TITLE
fix: split cs+a invoice revenue entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Ce projet respecte le [Versionnage sémantique](https://semver.org/lang/fr/).
 **Backend**
 - `excel_import.py` : support des feuilles Caisse (`caisse`/`cash`) et Banque (`banque`/`bank`/`relev`) dans l'import Excel de gestion ; déduplication des numéros de factures dans le même batch ; création automatique du contact si absent (plutôt que saut de ligne silencieux)
 - sécurité et robustesse revues après commentaires de PR : secret JWT obligatoire hors dev/test, conversion propre des erreurs d'édition manuelle en réponses HTTP, metadata Alembic complétée pour l'autogénération
+- factures clients mixtes `cs+a` : quand la feuille `Factures` expose des montants distincts `cours` et `adhésion`, l'import historique crée les lignes de facture correspondantes et la génération comptable ventile désormais les produits sur les comptes dédiés au lieu d'un seul produit global
 
 **Frontend — bugfixes interface**
 - `index.html` : correction de `<\/script>` → `</script>` (artefact d'échappement introduit lors de la création du fichier)

--- a/backend/alembic/versions/0014_add_invoice_explicit_breakdown_flag.py
+++ b/backend/alembic/versions/0014_add_invoice_explicit_breakdown_flag.py
@@ -1,0 +1,26 @@
+"""Migration 0014 - add invoice explicit breakdown flag."""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0014"
+down_revision = "0013"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("invoices") as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "has_explicit_breakdown",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.false(),
+            )
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("invoices") as batch_op:
+        batch_op.drop_column("has_explicit_breakdown")

--- a/backend/models/invoice.py
+++ b/backend/models/invoice.py
@@ -6,7 +6,7 @@ from datetime import date, datetime
 from decimal import Decimal
 from enum import StrEnum
 
-from sqlalchemy import Date, DateTime, ForeignKey, Numeric, String, Text, func
+from sqlalchemy import Boolean, Date, DateTime, ForeignKey, Numeric, String, Text, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from backend.database import Base
@@ -54,6 +54,9 @@ class Invoice(Base):
     )
     paid_amount: Mapped[_Decimal] = mapped_column(
         Numeric(10, 2), nullable=False, default=Decimal("0")
+    )
+    has_explicit_breakdown: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default="0"
     )
     status: Mapped[InvoiceStatus] = mapped_column(
         String(20), nullable=False, default=InvoiceStatus.DRAFT, index=True

--- a/backend/services/accounting_engine.py
+++ b/backend/services/accounting_engine.py
@@ -143,7 +143,11 @@ async def _generate_split_client_invoice_entries(
     context: Mapping[str, object],
     fiscal_year_id: int | None,
 ) -> list[AccountingEntry] | None:
-    if invoice.label != InvoiceLabel.CS_ADHESION or len(invoice.lines) < 2:
+    if (
+        invoice.label != InvoiceLabel.CS_ADHESION
+        or not invoice.has_explicit_breakdown
+        or len(invoice.lines) < 2
+    ):
         return None
 
     grouped_amounts: dict[InvoiceLabel, Decimal] = {}
@@ -164,15 +168,39 @@ async def _generate_split_client_invoice_entries(
         return None
 
     cs_a_rule = await _get_rule(db, TriggerType.INVOICE_CLIENT_CS_A)
-    cs_rule = await _get_rule(db, TriggerType.INVOICE_CLIENT_CS)
-    adhesion_rule = await _get_rule(db, TriggerType.INVOICE_CLIENT_A)
-    if cs_a_rule is None or cs_rule is None or adhesion_rule is None:
+    cs_rule = (
+        await _get_rule(db, TriggerType.INVOICE_CLIENT_CS)
+        if grouped_amounts[InvoiceLabel.CS] > 0
+        else None
+    )
+    adhesion_rule = (
+        await _get_rule(db, TriggerType.INVOICE_CLIENT_A)
+        if grouped_amounts[InvoiceLabel.ADHESION] > 0
+        else None
+    )
+    if cs_a_rule is None:
+        return None
+    if grouped_amounts[InvoiceLabel.CS] > 0 and cs_rule is None:
+        return None
+    if grouped_amounts[InvoiceLabel.ADHESION] > 0 and adhesion_rule is None:
         return None
 
     debit_entries = [entry for entry in cs_a_rule.entries if entry.side == "debit"]
-    cs_credit_entries = [entry for entry in cs_rule.entries if entry.side == "credit"]
-    adhesion_credit_entries = [entry for entry in adhesion_rule.entries if entry.side == "credit"]
-    if not debit_entries or not cs_credit_entries or not adhesion_credit_entries:
+    cs_credit_entries = [
+        entry
+        for entry in (cs_rule.entries if cs_rule is not None else [])
+        if entry.side == "credit"
+    ]
+    adhesion_credit_entries = [
+        entry
+        for entry in (adhesion_rule.entries if adhesion_rule is not None else [])
+        if entry.side == "credit"
+    ]
+    if not debit_entries:
+        return None
+    if grouped_amounts[InvoiceLabel.CS] > 0 and not cs_credit_entries:
+        return None
+    if grouped_amounts[InvoiceLabel.ADHESION] > 0 and not adhesion_credit_entries:
         return None
 
     created: list[AccountingEntry] = []
@@ -188,30 +216,32 @@ async def _generate_split_client_invoice_entries(
             fiscal_year_id,
         )
     )
-    created.extend(
-        await _apply_rule_entries(
-            db,
-            cs_credit_entries,
-            grouped_amounts[InvoiceLabel.CS],
-            invoice.date,
-            context,
-            EntrySourceType.INVOICE,
-            invoice.id,
-            fiscal_year_id,
+    if grouped_amounts[InvoiceLabel.CS] > 0:
+        created.extend(
+            await _apply_rule_entries(
+                db,
+                cs_credit_entries,
+                grouped_amounts[InvoiceLabel.CS],
+                invoice.date,
+                context,
+                EntrySourceType.INVOICE,
+                invoice.id,
+                fiscal_year_id,
+            )
         )
-    )
-    created.extend(
-        await _apply_rule_entries(
-            db,
-            adhesion_credit_entries,
-            grouped_amounts[InvoiceLabel.ADHESION],
-            invoice.date,
-            context,
-            EntrySourceType.INVOICE,
-            invoice.id,
-            fiscal_year_id,
+    if grouped_amounts[InvoiceLabel.ADHESION] > 0:
+        created.extend(
+            await _apply_rule_entries(
+                db,
+                adhesion_credit_entries,
+                grouped_amounts[InvoiceLabel.ADHESION],
+                invoice.date,
+                context,
+                EntrySourceType.INVOICE,
+                invoice.id,
+                fiscal_year_id,
+            )
         )
-    )
     return created
 
 

--- a/backend/services/accounting_engine.py
+++ b/backend/services/accounting_engine.py
@@ -8,7 +8,8 @@ received, deposit created, etc.).
 from __future__ import annotations
 
 import re
-from collections.abc import Mapping
+import unicodedata
+from collections.abc import Mapping, Sequence
 from datetime import date
 from decimal import Decimal
 from typing import TYPE_CHECKING, cast
@@ -22,9 +23,9 @@ from backend.models.accounting_entry import (
     EntrySourceType,
     build_entry_group_key,
 )
-from backend.models.accounting_rule import AccountingRule, TriggerType
+from backend.models.accounting_rule import AccountingRule, AccountingRuleEntry, TriggerType
 from backend.models.bank import Deposit, DepositType
-from backend.models.invoice import Invoice, InvoiceLabel, InvoiceType
+from backend.models.invoice import Invoice, InvoiceLabel, InvoiceLine, InvoiceType
 from backend.models.payment import Payment, PaymentMethod
 from backend.services.fiscal_year_service import find_fiscal_year_id_for_date
 
@@ -65,9 +66,34 @@ async def _apply_rule(
     group_key: str | None = None,
 ) -> list[AccountingEntry]:
     """Create accounting entries for all rule_entries of a rule."""
+    return await _apply_rule_entries(
+        db,
+        rule.entries,
+        amount,
+        entry_date,
+        context,
+        source_type,
+        source_id,
+        fiscal_year_id,
+        group_key,
+    )
+
+
+async def _apply_rule_entries(
+    db: AsyncSession,
+    rule_entries: Sequence[AccountingRuleEntry],
+    amount: Decimal,
+    entry_date: date,
+    context: Mapping[str, object],
+    source_type: EntrySourceType | None,
+    source_id: int | None,
+    fiscal_year_id: int | None,
+    group_key: str | None = None,
+) -> list[AccountingEntry]:
+    """Create accounting entries for a selected subset of rule entries."""
     created: list[AccountingEntry] = []
     resolved_group_key = group_key or build_entry_group_key(source_type, source_id)
-    for rule_entry in rule.entries:
+    for rule_entry in rule_entries:
         entry_number = await _next_entry_number(db)
         label = _render_template(rule_entry.description_template, context)
 
@@ -90,6 +116,102 @@ async def _apply_rule(
         await db.flush()  # ensure COUNT is accurate for the next entry in the loop
         created.append(entry)
 
+    return created
+
+
+def _normalize_invoice_line_text(value: str) -> str:
+    normalized = unicodedata.normalize("NFKD", value.casefold())
+    return "".join(character for character in normalized if not unicodedata.combining(character))
+
+
+def _classify_client_invoice_line(line: InvoiceLine) -> InvoiceLabel | None:
+    if not (text := _normalize_invoice_line_text(line.description)):
+        return None
+    return (
+        InvoiceLabel.ADHESION
+        if "adhesion" in text
+        else InvoiceLabel.CS
+        if "cours" in text or "soutien" in text
+        else None
+    )
+
+
+async def _generate_split_client_invoice_entries(
+    db: AsyncSession,
+    invoice: Invoice,
+    *,
+    context: Mapping[str, object],
+    fiscal_year_id: int | None,
+) -> list[AccountingEntry] | None:
+    if invoice.label != InvoiceLabel.CS_ADHESION or len(invoice.lines) < 2:
+        return None
+
+    grouped_amounts: dict[InvoiceLabel, Decimal] = {}
+    for line in invoice.lines:
+        component_label = _classify_client_invoice_line(line)
+        if component_label is None:
+            return None
+        grouped_amounts[component_label] = grouped_amounts.get(
+            component_label,
+            Decimal("0"),
+        ) + Decimal(str(line.amount))
+
+    if set(grouped_amounts) != {InvoiceLabel.CS, InvoiceLabel.ADHESION}:
+        return None
+
+    total_amount = sum(grouped_amounts.values(), Decimal("0"))
+    if total_amount != Decimal(str(invoice.total_amount)):
+        return None
+
+    cs_a_rule = await _get_rule(db, TriggerType.INVOICE_CLIENT_CS_A)
+    cs_rule = await _get_rule(db, TriggerType.INVOICE_CLIENT_CS)
+    adhesion_rule = await _get_rule(db, TriggerType.INVOICE_CLIENT_A)
+    if cs_a_rule is None or cs_rule is None or adhesion_rule is None:
+        return None
+
+    debit_entries = [entry for entry in cs_a_rule.entries if entry.side == "debit"]
+    cs_credit_entries = [entry for entry in cs_rule.entries if entry.side == "credit"]
+    adhesion_credit_entries = [entry for entry in adhesion_rule.entries if entry.side == "credit"]
+    if not debit_entries or not cs_credit_entries or not adhesion_credit_entries:
+        return None
+
+    created: list[AccountingEntry] = []
+    created.extend(
+        await _apply_rule_entries(
+            db,
+            debit_entries,
+            total_amount,
+            invoice.date,
+            context,
+            EntrySourceType.INVOICE,
+            invoice.id,
+            fiscal_year_id,
+        )
+    )
+    created.extend(
+        await _apply_rule_entries(
+            db,
+            cs_credit_entries,
+            grouped_amounts[InvoiceLabel.CS],
+            invoice.date,
+            context,
+            EntrySourceType.INVOICE,
+            invoice.id,
+            fiscal_year_id,
+        )
+    )
+    created.extend(
+        await _apply_rule_entries(
+            db,
+            adhesion_credit_entries,
+            grouped_amounts[InvoiceLabel.ADHESION],
+            invoice.date,
+            context,
+            EntrySourceType.INVOICE,
+            invoice.id,
+            fiscal_year_id,
+        )
+    )
     return created
 
 
@@ -170,12 +292,10 @@ async def generate_entries_for_invoice(
             None: TriggerType.INVOICE_CLIENT_GENERAL,
         }
         trigger = label_map.get(invoice.label, TriggerType.INVOICE_CLIENT_GENERAL)
+    elif invoice.label == InvoiceLabel.CS:
+        trigger = TriggerType.INVOICE_FOURNISSEUR_SUBCONTRACTING
     else:
-        # Fournisseur — use CS as proxy for sous-traitance (label-based heuristic)
-        if invoice.label == InvoiceLabel.CS:
-            trigger = TriggerType.INVOICE_FOURNISSEUR_SUBCONTRACTING
-        else:
-            trigger = TriggerType.INVOICE_FOURNISSEUR_GENERAL
+        trigger = TriggerType.INVOICE_FOURNISSEUR_GENERAL
 
     rule = await _get_rule(db, trigger)
     if rule is None:
@@ -189,6 +309,16 @@ async def generate_entries_for_invoice(
         "amount": str(invoice.total_amount),
         "date": str(invoice.date),
     }
+
+    split_entries = await _generate_split_client_invoice_entries(
+        db,
+        invoice,
+        context=context,
+        fiscal_year_id=fiscal_year_id,
+    )
+    if split_entries is not None:
+        await db.flush()
+        return split_entries
 
     entries = await _apply_rule(
         db,

--- a/backend/services/excel_import.py
+++ b/backend/services/excel_import.py
@@ -1496,11 +1496,13 @@ async def _import_contacts_sheet(db: AsyncSession, ws: Any, result: ImportResult
 async def _import_invoices_sheet(db: AsyncSession, ws: Any, result: ImportResult) -> None:
     """Import invoices from a sheet with flexible column detection."""
     from sqlalchemy import select  # noqa: PLC0415
+    from sqlalchemy.orm import selectinload  # noqa: PLC0415
 
     from backend.models.contact import Contact, ContactType  # noqa: PLC0415
     from backend.models.invoice import (  # noqa: PLC0415
         Invoice,
         InvoiceLabel,
+        InvoiceLine,
         InvoiceStatus,
         InvoiceType,
     )
@@ -1609,6 +1611,26 @@ async def _import_invoices_sheet(db: AsyncSession, ws: Any, result: ImportResult
             label=InvoiceLabel(invoice_row.label),
         )
         db.add(invoice)
+        await db.flush()
+        if invoice_row.course_amount is not None and invoice_row.adhesion_amount is not None:
+            db.add_all(
+                [
+                    InvoiceLine(
+                        invoice_id=invoice.id,
+                        description="Cours de soutien",
+                        quantity=Decimal("1"),
+                        unit_price=invoice_row.course_amount,
+                        amount=invoice_row.course_amount,
+                    ),
+                    InvoiceLine(
+                        invoice_id=invoice.id,
+                        description="Adhesion annuelle",
+                        quantity=Decimal("1"),
+                        unit_price=invoice_row.adhesion_amount,
+                        amount=invoice_row.adhesion_amount,
+                    ),
+                ]
+            )
         created_invoices.append(invoice)
         logger.debug(
             "Row %d — invoice '%s' queued (contact_id=%d, amount=%s)",
@@ -1647,7 +1669,18 @@ async def _import_invoices_sheet(db: AsyncSession, ws: Any, result: ImportResult
 
         for inv_obj in created_invoices:
             try:
-                entries = await generate_entries_for_invoice(db, inv_obj)
+                refreshed_invoice = (
+                    (
+                        await db.execute(
+                            select(Invoice)
+                            .where(Invoice.id == inv_obj.id)
+                            .options(selectinload(Invoice.lines))
+                        )
+                    )
+                    .scalars()
+                    .one()
+                )
+                entries = await generate_entries_for_invoice(db, refreshed_invoice)
                 result.entries_created += len(entries)
             except Exception as e:
                 logger.debug("Accounting entries skipped for invoice '%s': %s", inv_obj.number, e)

--- a/backend/services/excel_import.py
+++ b/backend/services/excel_import.py
@@ -1609,6 +1609,9 @@ async def _import_invoices_sheet(db: AsyncSession, ws: Any, result: ImportResult
             paid_amount=Decimal("0"),
             status=InvoiceStatus.SENT,
             label=InvoiceLabel(invoice_row.label),
+            has_explicit_breakdown=(
+                invoice_row.course_amount is not None and invoice_row.adhesion_amount is not None
+            ),
         )
         db.add(invoice)
         await db.flush()

--- a/backend/services/excel_import_parsers.py
+++ b/backend/services/excel_import_parsers.py
@@ -183,6 +183,14 @@ def parse_invoice_sheet(
     nom_idx = find_col_idx(col_map, "nom", "client", "adhérent", "adherent")
     numero_idx = find_invoice_number_idx(col_map, exclude_idx=date_idx)
     label_idx = find_col_idx(col_map, "motif", "libellé", "libelle", "type")
+    course_amount_idx = find_col_idx(col_map, "montant cours", "cours")
+    adhesion_amount_idx = find_col_idx(
+        col_map,
+        "montant adhésion",
+        "montant adhesion",
+        "adhésion",
+        "adhesion",
+    )
 
     missing_columns = invoice_missing_columns(
         date_idx=date_idx,
@@ -238,11 +246,38 @@ def parse_invoice_sheet(
         assert amount is not None
         assert invoice_date is not None
         raw_number = get_row_value(row, numero_idx)
+        normalized_label = normalize_invoice_label(get_row_value(row, label_idx))
         invoice_number: str | None = None
         if not isinstance(raw_number, (date, datetime)):
             candidate = parse_str(raw_number)
             if candidate and not _DATE_LIKE_TEXT_RE.match(candidate):
                 invoice_number = candidate
+
+        course_amount = parse_decimal(get_row_value(row, course_amount_idx))
+        adhesion_amount = parse_decimal(get_row_value(row, adhesion_amount_idx))
+        if normalized_label == "cs+a":
+            valid_course_amount = (
+                course_amount if course_amount is not None and course_amount > 0 else None
+            )
+            valid_adhesion_amount = (
+                adhesion_amount if adhesion_amount is not None and adhesion_amount > 0 else None
+            )
+            component_total = (valid_course_amount or Decimal("0")) + (
+                valid_adhesion_amount or Decimal("0")
+            )
+            if (
+                valid_course_amount is not None
+                and valid_adhesion_amount is not None
+                and component_total == amount
+            ):
+                course_amount = valid_course_amount
+                adhesion_amount = valid_adhesion_amount
+            else:
+                course_amount = None
+                adhesion_amount = None
+        else:
+            course_amount = None
+            adhesion_amount = None
 
         rows.append(
             NormalizedInvoiceRow(
@@ -251,7 +286,9 @@ def parse_invoice_sheet(
                 amount=amount,
                 contact_name=contact_name,
                 invoice_number=invoice_number,
-                label=normalize_invoice_label(get_row_value(row, label_idx)),
+                label=normalized_label,
+                course_amount=course_amount,
+                adhesion_amount=adhesion_amount,
             )
         )
 

--- a/backend/services/excel_import_parsers.py
+++ b/backend/services/excel_import_parsers.py
@@ -34,6 +34,7 @@ from backend.services.excel_import_policy import (
     ENTRY_MISSING_ACCOUNT_MESSAGE,
     ENTRY_SUSPICIOUS_DATE_MESSAGE,
     INVOICE_INVALID_AMOUNT_MESSAGE,
+    INVOICE_INVALID_COMPONENT_BREAKDOWN_MESSAGE,
     INVOICE_INVALID_DATE_MESSAGE,
     INVOICE_REQUIRED_CONTACT_MESSAGE,
     INVOICE_TOTAL_MESSAGE,
@@ -140,6 +141,10 @@ def _parse_salary_month(value: Any) -> str | None:
     if match is None:
         return None
     return f"{match.group(1)}-{match.group(2)}"
+
+
+def _has_explicit_component_value(value: Any) -> bool:
+    return parse_str(value) != ""
 
 
 def _salary_decimal_or_zero(value: Any) -> Decimal:
@@ -253,23 +258,38 @@ def parse_invoice_sheet(
             if candidate and not _DATE_LIKE_TEXT_RE.match(candidate):
                 invoice_number = candidate
 
-        course_amount = parse_decimal(get_row_value(row, course_amount_idx))
-        adhesion_amount = parse_decimal(get_row_value(row, adhesion_amount_idx))
+        raw_course_amount = get_row_value(row, course_amount_idx)
+        raw_adhesion_amount = get_row_value(row, adhesion_amount_idx)
+        course_amount = parse_decimal(raw_course_amount)
+        adhesion_amount = parse_decimal(raw_adhesion_amount)
         if normalized_label == "cs+a":
-            valid_course_amount = (
-                course_amount if course_amount is not None and course_amount > 0 else None
-            )
-            valid_adhesion_amount = (
-                adhesion_amount if adhesion_amount is not None and adhesion_amount > 0 else None
-            )
-            component_total = (valid_course_amount or Decimal("0")) + (
-                valid_adhesion_amount or Decimal("0")
-            )
-            if (
-                valid_course_amount is not None
-                and valid_adhesion_amount is not None
-                and component_total == amount
-            ):
+            has_explicit_breakdown = _has_explicit_component_value(
+                raw_course_amount
+            ) or _has_explicit_component_value(raw_adhesion_amount)
+            if has_explicit_breakdown:
+                valid_course_amount = (
+                    course_amount if course_amount is not None and course_amount >= 0 else None
+                )
+                valid_adhesion_amount = (
+                    adhesion_amount
+                    if adhesion_amount is not None and adhesion_amount >= 0
+                    else None
+                )
+                component_total = (valid_course_amount or Decimal("0")) + (
+                    valid_adhesion_amount or Decimal("0")
+                )
+                if (
+                    valid_course_amount is None
+                    or valid_adhesion_amount is None
+                    or component_total != amount
+                ):
+                    issues.append(
+                        make_validation_issue(
+                            source_row_number,
+                            [INVOICE_INVALID_COMPONENT_BREAKDOWN_MESSAGE],
+                        )
+                    )
+                    continue
                 course_amount = valid_course_amount
                 adhesion_amount = valid_adhesion_amount
             else:

--- a/backend/services/excel_import_policy.py
+++ b/backend/services/excel_import_policy.py
@@ -51,6 +51,9 @@ GESTION_UNKNOWN_STRUCTURE_MESSAGE = "Structure non reconnue, feuille ignoree par
 INVOICE_AMBIGUOUS_CONTACT_MESSAGE = "client ambigu : plusieurs contacts correspondent"
 INVOICE_INVALID_AMOUNT_MESSAGE = "montant manquant ou invalide"
 INVOICE_INVALID_DATE_MESSAGE = "date manquante ou invalide"
+INVOICE_INVALID_COMPONENT_BREAKDOWN_MESSAGE = (
+    "ventilation cours/adhesion incoherente avec le montant total"
+)
 INVOICE_REQUIRED_COLUMNS = ("date", "montant", "client")
 INVOICE_REQUIRED_CONTACT_MESSAGE = "client manquant"
 INVOICE_TOTAL_MESSAGE = "ligne de total ignoree"
@@ -127,6 +130,7 @@ _ISSUE_CATEGORY_BY_KIND_AND_MESSAGE = {
     "invoices": {
         INVOICE_AMBIGUOUS_CONTACT_MESSAGE: "invoice-ambiguous-contact",
         INVOICE_INVALID_AMOUNT_MESSAGE: "invoice-invalid-amount",
+        INVOICE_INVALID_COMPONENT_BREAKDOWN_MESSAGE: "invoice-invalid-component-breakdown",
         INVOICE_INVALID_DATE_MESSAGE: "invoice-invalid-date",
         INVOICE_REQUIRED_CONTACT_MESSAGE: "invoice-missing-contact",
     },

--- a/backend/services/excel_import_types.py
+++ b/backend/services/excel_import_types.py
@@ -42,6 +42,8 @@ class NormalizedInvoiceRow:
     contact_name: str
     invoice_number: str | None
     label: str
+    course_amount: Decimal | None = None
+    adhesion_amount: Decimal | None = None
 
 
 @dataclass(slots=True)

--- a/backend/services/invoice.py
+++ b/backend/services/invoice.py
@@ -186,6 +186,7 @@ async def update_invoice(db: AsyncSession, invoice: Invoice, payload: InvoiceUpd
         for existing_line in list(invoice.lines):
             await db.delete(existing_line)
         await db.flush()
+        invoice.has_explicit_breakdown = False
         new_lines = []
         for ln in payload.lines:
             line = InvoiceLine(

--- a/doc/backlog.md
+++ b/doc/backlog.md
@@ -66,7 +66,6 @@ Tout sujet concret qui doit survivre au-delà de la séance en cours doit être 
 | BL-022 | 2026-04-13 | Évolution | Utilisateurs / Sécurité | P1 | Renforcer la gestion des utilisateurs avec des rôles métier plus clairs, la création et l'administration des comptes, l'autonomie sur le profil et un socle de sécurité de compte plus complet |
 | BL-024 | 2026-04-13 | Correction | Paiements / Banque | P1 | Clarifier le workflow cible de saisie des paiements et corriger l'automatisme qui remet en banque les paiements `espèces` et `virement` dès leur encodage |
 | BL-027 | 2026-04-15 | Évolution | Import Excel / Trésorerie | P1 | Gérer une ouverture du système explicite pour Banque et Caisse sur le premier exercice importé |
-| BL-028 | 2026-04-16 | Correction | Comptabilité / Factures clients | P1 | Ventiler les factures clients mixtes de type `cs+a` sur les mêmes comptes produits que dans Excel quand l'information source le permet |
 
 ## Détail des sujets
 
@@ -156,7 +155,7 @@ Tout sujet concret qui doit survivre au-delà de la séance en cours doit être 
 
 ### BL-028 — Ventiler les factures clients mixtes `cs+a` comme dans la comptabilité Excel
 
-- **Dates** : `created=2026-04-16`
+- **Dates** : `created=2026-04-16`, `started=2026-04-16`, `completed=2026-04-16`
 - **Pourquoi** : pendant `BL-026`, il apparaît que certaines factures clients historiques, comme `2024-0186`, sont ventilées dans Excel sur plusieurs comptes produits parce qu'elles mélangent des lignes de cours (`cs`) et d'adhésion (`a`). Aujourd'hui, Solde ne reproduit pas forcément cette ventilation fine, ce qui gêne le rapprochement comptable par compte et ne reflète pas totalement la réalité comptable attendue.
 - **Résultat attendu** : quand l'information source de `Gestion` permet d'identifier une facture mixte, Solde doit générer la même ventilation comptable par compte produit que celle attendue dans Excel, au lieu de s'appuyer uniquement sur un total global de facture.
 - **Périmètre initial** :
@@ -166,6 +165,7 @@ Tout sujet concret qui doit survivre au-delà de la séance en cours doit être 
 	- ajouter une couverture de tests ciblée sur au moins un cas réel de facture mixte.
 - **Critère d'acceptation** : sur un cas comme `2024-0186`, les écritures générées par Solde portent les mêmes montants sur les mêmes comptes produits que la comptabilité Excel de référence, sans casser les cas simples mono-produit.
 - **Point d'attention** : ce sujet est distinct de `BL-008` ; ici l'objectif est d'aligner le comportement comptable réel de Solde, pas seulement de mieux tolérer un écart dans l'outil de comparaison.
+- **Livré parce que** : l'import `Gestion` sait désormais exploiter des colonnes explicites `cours` / `adhésion` pour créer des lignes de facture sur les cas `cs+a`, et le moteur comptable ventile alors les produits sur `706110` et `756000` au lieu d'un seul produit global, avec couverture unitaire et d'intégration sur le cas type `2024-0186`.
 
 ### BL-009 — Enrichir le plan comptable par défaut à partir des imports réels
 
@@ -412,6 +412,7 @@ Tout sujet concret qui doit survivre au-delà de la séance en cours doit être 
 - **BL-018** — `created=2026-04-13`, `started=2026-04-14`, `completed=2026-04-14` — Les écrans de liste principaux partagent maintenant un socle commun de tri, filtres et compteurs d'état, avec filtres de date FR/ISO et exclusion explicite des tableaux fixes `bilan` / `résultat`.
 - **BL-023** — `created=2026-04-13`, `started=2026-04-14`, `completed=2026-04-14` — Les rôles métier `Gestionnaire` / `Comptable` / `Administrateur` sont maintenant alignés entre docs, navigation, guards frontend et permissions backend, avec séparation visible `Gestion` / `Comptabilité` et couverture de test ciblée.
 - **BL-026** — `created=2026-04-15`, `started=2026-04-15`, `completed=2026-04-16` — Le ticket a livré un cadrage de recette et un constat exploitable sur la reprise `2024`, puis a été clos une fois les écarts résiduels requalifiés en différences de modélisation assumées ou en suites dédiées (`BL-008`, `BL-028`).
+- **BL-028** — `created=2026-04-16`, `started=2026-04-16`, `completed=2026-04-16` — Les factures clients mixtes `cs+a` sont désormais ventilées sur plusieurs comptes produits quand la feuille `Factures` fournit explicitement les composantes `cours` et `adhésion`, avec lignes de facture importées et génération comptable alignée sur la cible Excel.
 - **BL-012** — `created=2026-04-12`, `completed=2026-04-12` — La liste des paiements affiche la référence métier et permet l'édition directe.
 - **BL-013** — `created=2026-04-12`, `completed=2026-04-12` — Le journal de caisse propose désormais référence, détail et édition directe.
 - **BL-014** — `created=2026-04-12`, `completed=2026-04-12` — Le journal comptable est enrichi pour la lecture métier, le détail et la navigation vers les factures.

--- a/tests/integration/test_import_api.py
+++ b/tests/integration/test_import_api.py
@@ -359,6 +359,89 @@ async def test_preview_and_import_gestion_accept_payment_matched_by_contact(
 
 @pytest.mark.asyncio
 @pytest.mark.skipif(not OPENPYXL_AVAILABLE, reason="openpyxl not installed")
+async def test_import_gestion_splits_cs_a_invoice_when_component_columns_exist(
+    client: AsyncClient,
+    auth_headers: dict,
+    db_session,
+) -> None:
+    from sqlalchemy.orm import selectinload
+
+    from backend.models.accounting_entry import AccountingEntry, EntrySourceType
+    from backend.models.invoice import Invoice
+    from backend.services.accounting_engine import seed_default_rules
+
+    await seed_default_rules(db_session)
+
+    content = _make_multi_sheet_xlsx(
+        {
+            "Factures": (
+                [
+                    "Date facture",
+                    "Réf facture",
+                    "Client",
+                    "Montant",
+                    "Montant cours",
+                    "Montant adhésion",
+                    "Type",
+                ],
+                [["2024-08-26", "2024-0186", "Alexandre ELEZI", 160, 130, 30, "cs+a"]],
+            ),
+        }
+    )
+
+    import_response = await client.post(
+        "/api/import/excel/gestion",
+        files={"file": ("Gestion 2024.xlsx", content, _XLSX_MIME)},
+        headers=auth_headers,
+    )
+
+    assert import_response.status_code == 200
+    import_data = import_response.json()
+    assert import_data["invoices_created"] == 1
+    assert import_data["entries_created"] == 3
+
+    invoice = (
+        (
+            await db_session.execute(
+                select(Invoice)
+                .where(Invoice.number == "2024-0186")
+                .options(selectinload(Invoice.lines))
+            )
+        )
+        .scalars()
+        .one()
+    )
+    assert [(line.description, line.amount) for line in invoice.lines] == [
+        ("Cours de soutien", Decimal("130.00")),
+        ("Adhesion annuelle", Decimal("30.00")),
+    ]
+
+    entries = (
+        (
+            await db_session.execute(
+                select(AccountingEntry)
+                .where(AccountingEntry.source_type == EntrySourceType.INVOICE)
+                .where(AccountingEntry.source_id == invoice.id)
+                .order_by(AccountingEntry.entry_number.asc())
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(entries) == 3
+    assert any(
+        entry.account_number == "411100" and entry.debit == Decimal("160.00") for entry in entries
+    )
+    assert any(
+        entry.account_number == "706110" and entry.credit == Decimal("130.00") for entry in entries
+    )
+    assert any(
+        entry.account_number == "756000" and entry.credit == Decimal("30.00") for entry in entries
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not OPENPYXL_AVAILABLE, reason="openpyxl not installed")
 async def test_preview_and_import_gestion_create_supplier_invoice_and_payment_from_bank_row(
     client: AsyncClient,
     auth_headers: dict,

--- a/tests/integration/test_import_api.py
+++ b/tests/integration/test_import_api.py
@@ -415,6 +415,7 @@ async def test_import_gestion_splits_cs_a_invoice_when_component_columns_exist(
         ("Cours de soutien", Decimal("130.00")),
         ("Adhesion annuelle", Decimal("30.00")),
     ]
+    assert invoice.has_explicit_breakdown is True
 
     entries = (
         (
@@ -437,6 +438,47 @@ async def test_import_gestion_splits_cs_a_invoice_when_component_columns_exist(
     )
     assert any(
         entry.account_number == "756000" and entry.credit == Decimal("30.00") for entry in entries
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not OPENPYXL_AVAILABLE, reason="openpyxl not installed")
+async def test_preview_gestion_blocks_inconsistent_cs_a_component_columns(
+    client: AsyncClient,
+    auth_headers: dict,
+) -> None:
+    content = _make_multi_sheet_xlsx(
+        {
+            "Factures": (
+                [
+                    "Date facture",
+                    "Réf facture",
+                    "Client",
+                    "Montant",
+                    "Montant cours",
+                    "Montant adhésion",
+                    "Type",
+                ],
+                [["2024-08-26", "2024-0186", "Alexandre ELEZI", 160, 120, 30, "cs+a"]],
+            ),
+        }
+    )
+
+    preview_response = await client.post(
+        "/api/import/excel/gestion/preview",
+        files={"file": ("Gestion 2024.xlsx", content, _XLSX_MIME)},
+        headers=auth_headers,
+    )
+
+    assert preview_response.status_code == 200
+    preview_data = preview_response.json()
+    sheets = {sheet["name"]: sheet for sheet in preview_data["sheets"]}
+    assert preview_data["can_import"] is False
+    assert preview_data["estimated_invoices"] == 0
+    assert sheets["Factures"]["rows"] == 0
+    assert any(
+        "ventilation cours/adhesion incoherente" in error.lower()
+        for error in sheets["Factures"]["errors"]
     )
 
 

--- a/tests/unit/test_accounting_engine.py
+++ b/tests/unit/test_accounting_engine.py
@@ -81,6 +81,7 @@ async def _make_invoice(
     label: InvoiceLabel | None = InvoiceLabel.CS,
     total: Decimal = Decimal("100.00"),
     lines: list[tuple[str, Decimal]] | None = None,
+    has_explicit_breakdown: bool = False,
 ) -> Invoice:
     invoice_total = sum((amount for _, amount in lines), Decimal("0")) if lines else total
     inv = Invoice(
@@ -92,6 +93,7 @@ async def _make_invoice(
         paid_amount=Decimal("0"),
         status=InvoiceStatus.SENT,
         label=label,
+        has_explicit_breakdown=has_explicit_breakdown,
     )
     db.add(inv)
     await db.flush()
@@ -287,6 +289,7 @@ class TestGenerateEntriesForInvoice:
                 ("Cours de soutien", Decimal("130.00")),
                 ("Adhesion annuelle", Decimal("30.00")),
             ],
+            has_explicit_breakdown=True,
         )
 
         entries = await generate_entries_for_invoice(db_session, inv)
@@ -318,6 +321,89 @@ class TestGenerateEntriesForInvoice:
         assert len(entries) == 2
         assert any(
             entry.account_number == "706110" and entry.credit == Decimal("100.00")
+            for entry in entries
+        )
+
+    @pytest.mark.asyncio
+    async def test_client_cs_a_manual_lines_do_not_trigger_split(
+        self, db_session: AsyncSession
+    ) -> None:
+        await _seed_one_rule(db_session, TriggerType.INVOICE_CLIENT_CS_A, "411100", "706110")
+        await _seed_one_rule(db_session, TriggerType.INVOICE_CLIENT_CS, "411100", "706110")
+        await _seed_one_rule(db_session, TriggerType.INVOICE_CLIENT_A, "411100", "756000")
+        inv = await _make_invoice(
+            db_session,
+            label=InvoiceLabel.CS_ADHESION,
+            lines=[
+                ("Cours de soutien", Decimal("130.00")),
+                ("Adhesion annuelle", Decimal("30.00")),
+            ],
+        )
+
+        entries = await generate_entries_for_invoice(db_session, inv)
+
+        assert len(entries) == 2
+        assert any(
+            entry.account_number == "706110" and entry.credit == Decimal("160.00")
+            for entry in entries
+        )
+        assert all(entry.account_number != "756000" or entry.credit <= 0 for entry in entries)
+
+    @pytest.mark.asyncio
+    async def test_client_cs_a_explicit_breakdown_skips_zero_credit_entry(
+        self, db_session: AsyncSession
+    ) -> None:
+        await _seed_one_rule(db_session, TriggerType.INVOICE_CLIENT_CS_A, "411100", "706110")
+        await _seed_one_rule(db_session, TriggerType.INVOICE_CLIENT_CS, "411100", "706110")
+        await _seed_one_rule(db_session, TriggerType.INVOICE_CLIENT_A, "411100", "756000")
+        inv = await _make_invoice(
+            db_session,
+            label=InvoiceLabel.CS_ADHESION,
+            lines=[
+                ("Cours de soutien", Decimal("160.00")),
+                ("Adhesion annuelle", Decimal("0.00")),
+            ],
+            has_explicit_breakdown=True,
+        )
+
+        entries = await generate_entries_for_invoice(db_session, inv)
+
+        assert len(entries) == 2
+        assert any(
+            entry.account_number == "411100" and entry.debit == Decimal("160.00")
+            for entry in entries
+        )
+        assert any(
+            entry.account_number == "706110" and entry.credit == Decimal("160.00")
+            for entry in entries
+        )
+        assert all(entry.account_number != "756000" for entry in entries)
+
+    @pytest.mark.asyncio
+    async def test_client_cs_a_explicit_breakdown_with_zero_component_does_not_require_unused_rule(
+        self, db_session: AsyncSession
+    ) -> None:
+        await _seed_one_rule(db_session, TriggerType.INVOICE_CLIENT_CS_A, "411100", "706110")
+        await _seed_one_rule(db_session, TriggerType.INVOICE_CLIENT_CS, "411100", "706110")
+        inv = await _make_invoice(
+            db_session,
+            label=InvoiceLabel.CS_ADHESION,
+            lines=[
+                ("Cours de soutien", Decimal("160.00")),
+                ("Adhesion annuelle", Decimal("0.00")),
+            ],
+            has_explicit_breakdown=True,
+        )
+
+        entries = await generate_entries_for_invoice(db_session, inv)
+
+        assert len(entries) == 2
+        assert any(
+            entry.account_number == "411100" and entry.debit == Decimal("160.00")
+            for entry in entries
+        )
+        assert any(
+            entry.account_number == "706110" and entry.credit == Decimal("160.00")
             for entry in entries
         )
 

--- a/tests/unit/test_accounting_engine.py
+++ b/tests/unit/test_accounting_engine.py
@@ -6,7 +6,9 @@ from datetime import date
 from decimal import Decimal
 
 import pytest
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from backend.models.accounting_entry import EntrySourceType
 from backend.models.accounting_rule import (
@@ -19,7 +21,7 @@ from backend.models.accounting_rule import (
 from backend.models.bank import Deposit, DepositType
 from backend.models.contact import Contact, ContactType
 from backend.models.fiscal_year import FiscalYear, FiscalYearStatus
-from backend.models.invoice import Invoice, InvoiceLabel, InvoiceStatus, InvoiceType
+from backend.models.invoice import Invoice, InvoiceLabel, InvoiceLine, InvoiceStatus, InvoiceType
 from backend.models.payment import Payment, PaymentMethod
 from backend.models.salary import Salary
 from backend.services.accounting_engine import (
@@ -78,21 +80,36 @@ async def _make_invoice(
     inv_type: InvoiceType = InvoiceType.CLIENT,
     label: InvoiceLabel | None = InvoiceLabel.CS,
     total: Decimal = Decimal("100.00"),
+    lines: list[tuple[str, Decimal]] | None = None,
 ) -> Invoice:
+    invoice_total = sum((amount for _, amount in lines), Decimal("0")) if lines else total
     inv = Invoice(
         number="2024-C-0001",
         type=inv_type,
         contact_id=1,
         date=date(2024, 1, 15),
-        total_amount=total,
+        total_amount=invoice_total,
         paid_amount=Decimal("0"),
         status=InvoiceStatus.SENT,
         label=label,
     )
     db.add(inv)
+    await db.flush()
+    for description, amount in lines or []:
+        db.add(
+            InvoiceLine(
+                invoice_id=inv.id,
+                description=description,
+                quantity=Decimal("1"),
+                unit_price=amount,
+                amount=amount,
+            )
+        )
     await db.commit()
-    await db.refresh(inv)
-    return inv
+    result = await db.execute(
+        select(Invoice).where(Invoice.id == inv.id).options(selectinload(Invoice.lines))
+    )
+    return result.scalar_one()
 
 
 async def _make_payment(
@@ -257,6 +274,52 @@ class TestGenerateEntriesForInvoice:
         inv = await _make_invoice(db_session, label=InvoiceLabel.CS_ADHESION)
         entries = await generate_entries_for_invoice(db_session, inv)
         assert len(entries) == 2
+
+    @pytest.mark.asyncio
+    async def test_client_cs_a_lines_split_credit_accounts(self, db_session: AsyncSession) -> None:
+        await _seed_one_rule(db_session, TriggerType.INVOICE_CLIENT_CS_A, "411100", "706110")
+        await _seed_one_rule(db_session, TriggerType.INVOICE_CLIENT_CS, "411100", "706110")
+        await _seed_one_rule(db_session, TriggerType.INVOICE_CLIENT_A, "411100", "756000")
+        inv = await _make_invoice(
+            db_session,
+            label=InvoiceLabel.CS_ADHESION,
+            lines=[
+                ("Cours de soutien", Decimal("130.00")),
+                ("Adhesion annuelle", Decimal("30.00")),
+            ],
+        )
+
+        entries = await generate_entries_for_invoice(db_session, inv)
+
+        assert len(entries) == 3
+        debit = next(entry for entry in entries if entry.debit > 0)
+        assert debit.account_number == "411100"
+        assert debit.debit == Decimal("160.00")
+        assert {entry.account_number: entry.credit for entry in entries if entry.credit > 0} == {
+            "706110": Decimal("130.00"),
+            "756000": Decimal("30.00"),
+        }
+
+    @pytest.mark.asyncio
+    async def test_client_cs_a_unclassified_lines_fall_back_to_default_rule(
+        self, db_session: AsyncSession
+    ) -> None:
+        await _seed_one_rule(db_session, TriggerType.INVOICE_CLIENT_CS_A, "411100", "706110")
+        await _seed_one_rule(db_session, TriggerType.INVOICE_CLIENT_CS, "411100", "706110")
+        await _seed_one_rule(db_session, TriggerType.INVOICE_CLIENT_A, "411100", "756000")
+        inv = await _make_invoice(
+            db_session,
+            label=InvoiceLabel.CS_ADHESION,
+            lines=[("Pack rentree", Decimal("100.00"))],
+        )
+
+        entries = await generate_entries_for_invoice(db_session, inv)
+
+        assert len(entries) == 2
+        assert any(
+            entry.account_number == "706110" and entry.credit == Decimal("100.00")
+            for entry in entries
+        )
 
     @pytest.mark.asyncio
     async def test_client_general_label(self, db_session: AsyncSession) -> None:

--- a/tests/unit/test_excel_import_parsers.py
+++ b/tests/unit/test_excel_import_parsers.py
@@ -82,6 +82,34 @@ def test_parse_invoice_sheet_blocks_missing_or_invalid_invoice_date() -> None:
     ]
 
 
+def test_parse_invoice_sheet_extracts_optional_cs_a_components() -> None:
+    sheet = _make_sheet(
+        "Factures",
+        [
+            [
+                "Date facture",
+                "Réf facture",
+                "Client",
+                "Montant",
+                "Montant cours",
+                "Montant adhésion",
+                "Type",
+            ],
+            ["2025-08-01", "2025-0142", "Christine LOPES", 160, 130, 30, "CS+A"],
+        ],
+    )
+
+    parsed_sheet, rows, issues, ignored_issues = parse_invoice_sheet(sheet)
+
+    assert parsed_sheet is not None
+    assert issues == []
+    assert ignored_issues == []
+    assert len(rows) == 1
+    assert rows[0].label == "cs+a"
+    assert rows[0].course_amount == Decimal("130")
+    assert rows[0].adhesion_amount == Decimal("30")
+
+
 def test_parse_payment_sheet_normalizes_payment_fields() -> None:
     sheet = _make_sheet(
         "Paiements",

--- a/tests/unit/test_excel_import_parsers.py
+++ b/tests/unit/test_excel_import_parsers.py
@@ -20,10 +20,12 @@ from backend.services.excel_import_policy import (
     BANK_BALANCE_DESCRIPTION_MESSAGE,
     CASH_INITIAL_BALANCE_MESSAGE,
     CASH_PENDING_DEPOSIT_MESSAGE,
+    INVOICE_INVALID_COMPONENT_BREAKDOWN_MESSAGE,
     INVOICE_INVALID_DATE_MESSAGE,
     INVOICE_TOTAL_MESSAGE,
     ZERO_JOURNAL_ENTRY_MESSAGE,
 )
+from backend.services.excel_import_types import RowValidationIssue
 
 
 def _make_sheet(title: str, rows: list[list[object | None]]) -> Worksheet:
@@ -108,6 +110,63 @@ def test_parse_invoice_sheet_extracts_optional_cs_a_components() -> None:
     assert rows[0].label == "cs+a"
     assert rows[0].course_amount == Decimal("130")
     assert rows[0].adhesion_amount == Decimal("30")
+
+
+def test_parse_invoice_sheet_accepts_zero_value_cs_a_component() -> None:
+    sheet = _make_sheet(
+        "Factures",
+        [
+            [
+                "Date facture",
+                "Réf facture",
+                "Client",
+                "Montant",
+                "Montant cours",
+                "Montant adhésion",
+                "Type",
+            ],
+            ["2025-08-01", "2025-0142", "Christine LOPES", 160, 160, 0, "CS+A"],
+        ],
+    )
+
+    parsed_sheet, rows, issues, ignored_issues = parse_invoice_sheet(sheet)
+
+    assert parsed_sheet is not None
+    assert issues == []
+    assert ignored_issues == []
+    assert len(rows) == 1
+    assert rows[0].course_amount == Decimal("160")
+    assert rows[0].adhesion_amount == Decimal("0")
+
+
+def test_parse_invoice_sheet_blocks_inconsistent_explicit_cs_a_components() -> None:
+    sheet = _make_sheet(
+        "Factures",
+        [
+            [
+                "Date facture",
+                "Réf facture",
+                "Client",
+                "Montant",
+                "Montant cours",
+                "Montant adhésion",
+                "Type",
+            ],
+            ["2025-08-01", "2025-0142", "Christine LOPES", 160, 120, 30, "CS+A"],
+        ],
+    )
+
+    parsed_sheet, rows, issues, ignored_issues = parse_invoice_sheet(sheet)
+
+    assert parsed_sheet is not None
+    assert rows == []
+    assert ignored_issues == []
+    assert issues == [
+        RowValidationIssue(
+            source_row_number=2,
+            message=INVOICE_INVALID_COMPONENT_BREAKDOWN_MESSAGE,
+        )
+    ]
 
 
 def test_parse_payment_sheet_normalizes_payment_fields() -> None:


### PR DESCRIPTION
This PR aligns mixed client invoice accounting with the historical Excel target when the source sheet provides explicit course and membership amounts.

- parse optional `Montant cours` and `Montant adhésion` columns from the Gestion invoices sheet
- create invoice lines for mixed `cs+a` imports when both components are explicit and consistent with the invoice total
- split generated accounting entries across the dedicated revenue accounts instead of a single global revenue line
- add unit and integration coverage for parser, accounting engine, and import flow

Checks performed:
- `ruff check .`
- `ruff format --check .`
- `mypy .`
- `pytest tests/`
- `npx prettier --check src/`
- `npx vue-tsc --noEmit -p tsconfig.app.json`
- `npx vue-tsc --noEmit`
- `npx eslint src/`
- `npx vitest run`

## Summary by Sourcery

Handle mixed `cs+a` client invoices by importing explicit course/membership components from Gestion Excel and generating split accounting entries aligned with dedicated revenue accounts.

New Features:
- Support optional course and membership amount columns in Gestion invoice Excel sheets and carry them through normalized invoice rows.
- Create invoice line items for mixed `cs+a` client invoices when both course and membership amounts are present and consistent with the invoice total.
- Generate accounting entries for mixed `cs+a` client invoices that split revenue across the course and membership product accounts instead of a single aggregated revenue line.

Enhancements:
- Refactor the accounting engine to apply accounting rules to arbitrary subsets of rule entries, enabling reuse for split invoice handling.
- Adjust invoice import logic to reload created invoices with their lines before generating accounting entries, ensuring correct use of imported line details.

Documentation:
- Document completion of backlog item BL-028 in the backlog and changelog, describing the new handling of mixed `cs+a` client invoices.

Tests:
- Add unit tests for the accounting engine to cover split credit entries and fallbacks for mixed `cs+a` invoices with or without classifiable lines.
- Add parser unit tests to validate extraction of optional course and membership components from Gestion invoice sheets.
- Add integration tests for the Gestion Excel import flow to verify invoice line creation and split accounting entries for mixed `cs+a` invoices.