### PR TITLE
feat: derive client invoice split from entered lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Ce projet respecte le [Versionnage sémantique](https://semver.org/lang/fr/).
 **Backend**
 - `excel_import.py` : support des feuilles Caisse (`caisse`/`cash`) et Banque (`banque`/`bank`/`relev`) dans l'import Excel de gestion ; déduplication des numéros de factures dans le même batch ; création automatique du contact si absent (plutôt que saut de ligne silencieux)
 - sécurité et robustesse revues après commentaires de PR : secret JWT obligatoire hors dev/test, conversion propre des erreurs d'édition manuelle en réponses HTTP, metadata Alembic complétée pour l'autogénération
+- factures clients mixtes `cs+a` : quand la feuille `Factures` expose des montants distincts `cours` et `adhésion`, l'import historique crée les lignes de facture correspondantes et la génération comptable ventile désormais les produits sur les comptes dédiés au lieu d'un seul produit global
 
 **Frontend — bugfixes interface**
 - `index.html` : correction de `<\/script>` → `</script>` (artefact d'échappement introduit lors de la création du fichier)

--- a/backend/alembic/versions/0014_add_invoice_explicit_breakdown_flag.py
+++ b/backend/alembic/versions/0014_add_invoice_explicit_breakdown_flag.py
@@ -1,0 +1,26 @@
+"""Migration 0014 - add invoice explicit breakdown flag."""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0014"
+down_revision = "0013"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("invoices") as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "has_explicit_breakdown",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.false(),
+            )
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("invoices") as batch_op:
+        batch_op.drop_column("has_explicit_breakdown")

--- a/backend/alembic/versions/0015_add_invoice_line_type.py
+++ b/backend/alembic/versions/0015_add_invoice_line_type.py
@@ -1,0 +1,19 @@
+"""Migration 0015 - add invoice line type."""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0015"
+down_revision = "0014"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("invoice_lines") as batch_op:
+        batch_op.add_column(sa.Column("line_type", sa.String(length=20), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("invoice_lines") as batch_op:
+        batch_op.drop_column("line_type")

--- a/backend/database.py
+++ b/backend/database.py
@@ -24,12 +24,11 @@ class Base(DeclarativeBase):
 def _build_engine(database_url: str | None = None) -> AsyncEngine:
     """Create async SQLAlchemy engine with WAL journal mode."""
     url = database_url or get_settings().database_url
-    engine = create_async_engine(
+    return create_async_engine(
         url,
-        echo=get_settings().debug,
+        echo=False,
         connect_args={"check_same_thread": False},
     )
-    return engine
 
 
 # Module-level engine and session factory

--- a/backend/main.py
+++ b/backend/main.py
@@ -50,6 +50,7 @@ logging.config.dictConfig(
             "console": {
                 "class": "logging.StreamHandler",
                 "formatter": "default",
+                "level": "INFO",
             },
             "file": {
                 "class": "logging.handlers.RotatingFileHandler",
@@ -58,6 +59,7 @@ logging.config.dictConfig(
                 "backupCount": 3,
                 "encoding": "utf-8",
                 "formatter": "default",
+                "level": "DEBUG",
             },
         },
         "loggers": {
@@ -66,10 +68,25 @@ logging.config.dictConfig(
                 "level": "DEBUG",
                 "propagate": False,
             },
+            "sqlalchemy.engine": {
+                "handlers": ["file"],
+                "level": "INFO" if get_settings().debug else "WARNING",
+                "propagate": False,
+            },
+            "uvicorn.access": {
+                "handlers": ["console", "file"],
+                "level": "INFO",
+                "propagate": False,
+            },
+            "uvicorn.error": {
+                "handlers": ["console", "file"],
+                "level": "INFO",
+                "propagate": False,
+            },
         },
         "root": {
             "handlers": ["console"],
-            "level": "INFO",
+            "level": "WARNING",
         },
     }
 )

--- a/backend/models/invoice.py
+++ b/backend/models/invoice.py
@@ -6,7 +6,7 @@ from datetime import date, datetime
 from decimal import Decimal
 from enum import StrEnum
 
-from sqlalchemy import Boolean, Date, DateTime, ForeignKey, Numeric, String, Text, func
+from sqlalchemy import Boolean, Date, DateTime, ForeignKey, Numeric, String, Text, false, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from backend.database import Base
@@ -122,7 +122,7 @@ class Invoice(Base):
         Numeric(10, 2), nullable=False, default=Decimal("0")
     )
     has_explicit_breakdown: Mapped[bool] = mapped_column(
-        Boolean, nullable=False, default=False, server_default="0"
+        Boolean, nullable=False, default=False, server_default=false()
     )
     status: Mapped[InvoiceStatus] = mapped_column(
         String(20), nullable=False, default=InvoiceStatus.DRAFT, index=True

--- a/backend/models/invoice.py
+++ b/backend/models/invoice.py
@@ -28,6 +28,12 @@ class InvoiceLabel(StrEnum):
     GENERAL = "general"
 
 
+class InvoiceLineType(StrEnum):
+    COURSE = "cours"
+    ADHESION = "adhesion"
+    OTHER = "autres"
+
+
 class InvoiceStatus(StrEnum):
     DRAFT = "draft"
     SENT = "sent"
@@ -35,6 +41,66 @@ class InvoiceStatus(StrEnum):
     PARTIAL = "partial"
     OVERDUE = "overdue"
     DISPUTED = "disputed"
+
+
+def _normalize_invoice_line_text(value: str) -> str:
+    normalized = value.casefold()
+    replacements = {
+        "é": "e",
+        "è": "e",
+        "ê": "e",
+        "ë": "e",
+        "à": "a",
+        "â": "a",
+        "ä": "a",
+        "î": "i",
+        "ï": "i",
+        "ô": "o",
+        "ö": "o",
+        "ù": "u",
+        "û": "u",
+        "ü": "u",
+        "ç": "c",
+    }
+    for source, target in replacements.items():
+        normalized = normalized.replace(source, target)
+    return normalized
+
+
+def infer_client_line_type(
+    description: str,
+    fallback_label: InvoiceLabel | None = None,
+) -> InvoiceLineType:
+    text = _normalize_invoice_line_text(description)
+    if "adhesion" in text:
+        return InvoiceLineType.ADHESION
+    if "cours" in text or "soutien" in text:
+        return InvoiceLineType.COURSE
+    if fallback_label == InvoiceLabel.CS:
+        return InvoiceLineType.COURSE
+    if fallback_label == InvoiceLabel.ADHESION:
+        return InvoiceLineType.ADHESION
+    return InvoiceLineType.OTHER
+
+
+def derive_client_invoice_label(line_types: set[InvoiceLineType]) -> InvoiceLabel:
+    if not line_types or InvoiceLineType.OTHER in line_types:
+        return InvoiceLabel.GENERAL
+    if line_types == {InvoiceLineType.COURSE}:
+        return InvoiceLabel.CS
+    if line_types == {InvoiceLineType.ADHESION}:
+        return InvoiceLabel.ADHESION
+    if line_types == {InvoiceLineType.COURSE, InvoiceLineType.ADHESION}:
+        return InvoiceLabel.CS_ADHESION
+    return InvoiceLabel.GENERAL
+
+
+def default_client_line_description(line_type: InvoiceLineType) -> str:
+    return {
+        InvoiceLineType.COURSE: "Cours de soutien",
+        InvoiceLineType.ADHESION: "Adhesion annuelle",
+        InvoiceLineType.OTHER: "Autres prestations",
+    }[line_type]
 
 
 class Invoice(Base):
@@ -81,6 +147,7 @@ class InvoiceLine(Base):
     id: Mapped[int] = mapped_column(primary_key=True, index=True)
     invoice_id: Mapped[int] = mapped_column(ForeignKey("invoices.id"), nullable=False, index=True)
     description: Mapped[str] = mapped_column(String(500), nullable=False)
+    line_type: Mapped[InvoiceLineType | None] = mapped_column(String(20), nullable=True)
     quantity: Mapped[_Decimal] = mapped_column(Numeric(10, 3), nullable=False, default=Decimal("1"))
     unit_price: Mapped[_Decimal] = mapped_column(
         Numeric(10, 2), nullable=False, default=Decimal("0")

--- a/backend/models/invoice.py
+++ b/backend/models/invoice.py
@@ -6,7 +6,7 @@ from datetime import date, datetime
 from decimal import Decimal
 from enum import StrEnum
 
-from sqlalchemy import Date, DateTime, ForeignKey, Numeric, String, Text, func
+from sqlalchemy import Boolean, Date, DateTime, ForeignKey, Numeric, String, Text, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from backend.database import Base
@@ -54,6 +54,9 @@ class Invoice(Base):
     )
     paid_amount: Mapped[_Decimal] = mapped_column(
         Numeric(10, 2), nullable=False, default=Decimal("0")
+    )
+    has_explicit_breakdown: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default="0"
     )
     status: Mapped[InvoiceStatus] = mapped_column(
         String(20), nullable=False, default=InvoiceStatus.DRAFT, index=True

--- a/backend/schemas/invoice.py
+++ b/backend/schemas/invoice.py
@@ -5,13 +5,14 @@ from __future__ import annotations
 import datetime
 from decimal import Decimal
 
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, field_validator, model_validator
 
-from backend.models.invoice import InvoiceLabel, InvoiceStatus, InvoiceType
+from backend.models.invoice import InvoiceLabel, InvoiceLineType, InvoiceStatus, InvoiceType
 
 
 class InvoiceLineBase(BaseModel):
     description: str
+    line_type: InvoiceLineType | None = None
     quantity: Decimal = Decimal("1")
     unit_price: Decimal = Decimal("0")
 
@@ -28,14 +29,6 @@ class InvoiceLineBase(BaseModel):
         if v <= 0:
             raise ValueError("quantity must be positive")
         return v
-
-    @field_validator("unit_price")
-    @classmethod
-    def unit_price_non_negative(cls, v: Decimal) -> Decimal:
-        if v < 0:
-            raise ValueError("unit_price must be non-negative")
-        return v
-
 
 class InvoiceLineCreate(InvoiceLineBase):
     pass
@@ -70,6 +63,18 @@ class InvoiceCreate(InvoiceBase):
             raise ValueError("total_amount must be non-negative")
         return v
 
+    @model_validator(mode="after")
+    def validate_client_total(self) -> InvoiceCreate:
+        if self.type != InvoiceType.CLIENT or not self.lines:
+            return self
+        computed_total = sum(
+            (line.quantity * line.unit_price for line in self.lines),
+            start=Decimal("0"),
+        )
+        if computed_total < 0:
+            raise ValueError("client invoice total must not be negative")
+        return self
+
 
 class InvoiceUpdate(BaseModel):
     """All fields optional for partial update."""
@@ -82,6 +87,18 @@ class InvoiceUpdate(BaseModel):
     reference: str | None = None
     lines: list[InvoiceLineCreate] | None = None
     total_amount: Decimal | None = None
+
+    @model_validator(mode="after")
+    def validate_client_total(self) -> InvoiceUpdate:
+        if self.lines is None:
+            return self
+        computed_total = sum(
+            (line.quantity * line.unit_price for line in self.lines),
+            start=Decimal("0"),
+        )
+        if computed_total < 0:
+            raise ValueError("client invoice total must not be negative")
+        return self
 
 
 class InvoiceStatusUpdate(BaseModel):

--- a/backend/schemas/invoice.py
+++ b/backend/schemas/invoice.py
@@ -30,6 +30,7 @@ class InvoiceLineBase(BaseModel):
             raise ValueError("quantity must be positive")
         return v
 
+
 class InvoiceLineCreate(InvoiceLineBase):
     pass
 

--- a/backend/services/accounting_engine.py
+++ b/backend/services/accounting_engine.py
@@ -8,7 +8,6 @@ received, deposit created, etc.).
 from __future__ import annotations
 
 import re
-import unicodedata
 from collections.abc import Mapping, Sequence
 from datetime import date
 from decimal import Decimal
@@ -25,7 +24,15 @@ from backend.models.accounting_entry import (
 )
 from backend.models.accounting_rule import AccountingRule, AccountingRuleEntry, TriggerType
 from backend.models.bank import Deposit, DepositType
-from backend.models.invoice import Invoice, InvoiceLabel, InvoiceLine, InvoiceType
+from backend.models.invoice import (
+    Invoice,
+    InvoiceLabel,
+    InvoiceLine,
+    InvoiceLineType,
+    InvoiceType,
+    derive_client_invoice_label,
+    infer_client_line_type,
+)
 from backend.models.payment import Payment, PaymentMethod
 from backend.services.fiscal_year_service import find_fiscal_year_id_for_date
 
@@ -119,21 +126,28 @@ async def _apply_rule_entries(
     return created
 
 
-def _normalize_invoice_line_text(value: str) -> str:
-    normalized = unicodedata.normalize("NFKD", value.casefold())
-    return "".join(character for character in normalized if not unicodedata.combining(character))
+def _resolve_client_invoice_line_type(
+    line: InvoiceLine,
+    fallback_label: InvoiceLabel | None,
+) -> InvoiceLineType:
+    return line.line_type or infer_client_line_type(line.description, fallback_label)
 
 
-def _classify_client_invoice_line(line: InvoiceLine) -> InvoiceLabel | None:
-    if not (text := _normalize_invoice_line_text(line.description)):
-        return None
-    return (
-        InvoiceLabel.ADHESION
-        if "adhesion" in text
-        else InvoiceLabel.CS
-        if "cours" in text or "soutien" in text
-        else None
-    )
+def _trigger_for_client_line_type(line_type: InvoiceLineType) -> TriggerType:
+    return {
+        InvoiceLineType.COURSE: TriggerType.INVOICE_CLIENT_CS,
+        InvoiceLineType.ADHESION: TriggerType.INVOICE_CLIENT_A,
+        InvoiceLineType.OTHER: TriggerType.INVOICE_CLIENT_GENERAL,
+    }[line_type]
+
+
+def _trigger_for_client_invoice_label(label: InvoiceLabel) -> TriggerType:
+    return {
+        InvoiceLabel.CS: TriggerType.INVOICE_CLIENT_CS,
+        InvoiceLabel.ADHESION: TriggerType.INVOICE_CLIENT_A,
+        InvoiceLabel.CS_ADHESION: TriggerType.INVOICE_CLIENT_CS_A,
+        InvoiceLabel.GENERAL: TriggerType.INVOICE_CLIENT_GENERAL,
+    }[label]
 
 
 async def _generate_split_client_invoice_entries(
@@ -143,65 +157,46 @@ async def _generate_split_client_invoice_entries(
     context: Mapping[str, object],
     fiscal_year_id: int | None,
 ) -> list[AccountingEntry] | None:
-    if (
-        invoice.label != InvoiceLabel.CS_ADHESION
-        or not invoice.has_explicit_breakdown
-        or len(invoice.lines) < 2
-    ):
+    if invoice.type != InvoiceType.CLIENT or not invoice.lines:
         return None
 
-    grouped_amounts: dict[InvoiceLabel, Decimal] = {}
+    grouped_amounts: dict[InvoiceLineType, Decimal] = {
+        InvoiceLineType.COURSE: Decimal("0"),
+        InvoiceLineType.ADHESION: Decimal("0"),
+        InvoiceLineType.OTHER: Decimal("0"),
+    }
     for line in invoice.lines:
-        component_label = _classify_client_invoice_line(line)
-        if component_label is None:
-            return None
-        grouped_amounts[component_label] = grouped_amounts.get(
-            component_label,
-            Decimal("0"),
-        ) + Decimal(str(line.amount))
-
-    if set(grouped_amounts) != {InvoiceLabel.CS, InvoiceLabel.ADHESION}:
-        return None
+        component_type = _resolve_client_invoice_line_type(line, invoice.label)
+        grouped_amounts[component_type] += Decimal(str(line.amount))
 
     total_amount = sum(grouped_amounts.values(), Decimal("0"))
     if total_amount != Decimal(str(invoice.total_amount)):
         return None
+    if total_amount <= 0:
+        return []
 
-    cs_a_rule = await _get_rule(db, TriggerType.INVOICE_CLIENT_CS_A)
-    cs_rule = (
-        await _get_rule(db, TriggerType.INVOICE_CLIENT_CS)
-        if grouped_amounts[InvoiceLabel.CS] > 0
-        else None
-    )
-    adhesion_rule = (
-        await _get_rule(db, TriggerType.INVOICE_CLIENT_A)
-        if grouped_amounts[InvoiceLabel.ADHESION] > 0
-        else None
-    )
-    if cs_a_rule is None:
-        return None
-    if grouped_amounts[InvoiceLabel.CS] > 0 and cs_rule is None:
-        return None
-    if grouped_amounts[InvoiceLabel.ADHESION] > 0 and adhesion_rule is None:
+    positive_line_types = {
+        line_type for line_type, amount in grouped_amounts.items() if amount > 0
+    }
+    derived_label = derive_client_invoice_label(positive_line_types)
+
+    debit_rule = await _get_rule(db, _trigger_for_client_invoice_label(derived_label))
+    if debit_rule is None:
         return None
 
-    debit_entries = [entry for entry in cs_a_rule.entries if entry.side == "debit"]
-    cs_credit_entries = [
-        entry
-        for entry in (cs_rule.entries if cs_rule is not None else [])
-        if entry.side == "credit"
-    ]
-    adhesion_credit_entries = [
-        entry
-        for entry in (adhesion_rule.entries if adhesion_rule is not None else [])
-        if entry.side == "credit"
-    ]
+    debit_entries = [entry for entry in debit_rule.entries if entry.side == "debit"]
     if not debit_entries:
         return None
-    if grouped_amounts[InvoiceLabel.CS] > 0 and not cs_credit_entries:
-        return None
-    if grouped_amounts[InvoiceLabel.ADHESION] > 0 and not adhesion_credit_entries:
-        return None
+
+    credit_entries_by_type: dict[InvoiceLineType, Sequence[AccountingRuleEntry]] = {}
+    for line_type in positive_line_types:
+        component_rule = await _get_rule(db, _trigger_for_client_line_type(line_type))
+        if component_rule is None:
+            return None
+        credit_entries = [entry for entry in component_rule.entries if entry.side == "credit"]
+        if not credit_entries:
+            return None
+        credit_entries_by_type[line_type] = credit_entries
 
     created: list[AccountingEntry] = []
     created.extend(
@@ -216,25 +211,12 @@ async def _generate_split_client_invoice_entries(
             fiscal_year_id,
         )
     )
-    if grouped_amounts[InvoiceLabel.CS] > 0:
+    for line_type in sorted(positive_line_types, key=lambda value: value.value):
         created.extend(
             await _apply_rule_entries(
                 db,
-                cs_credit_entries,
-                grouped_amounts[InvoiceLabel.CS],
-                invoice.date,
-                context,
-                EntrySourceType.INVOICE,
-                invoice.id,
-                fiscal_year_id,
-            )
-        )
-    if grouped_amounts[InvoiceLabel.ADHESION] > 0:
-        created.extend(
-            await _apply_rule_entries(
-                db,
-                adhesion_credit_entries,
-                grouped_amounts[InvoiceLabel.ADHESION],
+                credit_entries_by_type[line_type],
+                grouped_amounts[line_type],
                 invoice.date,
                 context,
                 EntrySourceType.INVOICE,
@@ -313,24 +295,6 @@ async def generate_entries_for_invoice(
     Determines trigger type from invoice.type + invoice.label.
     Returns an empty list if no matching active rule exists.
     """
-    if invoice.type == InvoiceType.CLIENT:
-        label_map: dict[InvoiceLabel | None, TriggerType] = {
-            InvoiceLabel.CS: TriggerType.INVOICE_CLIENT_CS,
-            InvoiceLabel.ADHESION: TriggerType.INVOICE_CLIENT_A,
-            InvoiceLabel.CS_ADHESION: TriggerType.INVOICE_CLIENT_CS_A,
-            InvoiceLabel.GENERAL: TriggerType.INVOICE_CLIENT_GENERAL,
-            None: TriggerType.INVOICE_CLIENT_GENERAL,
-        }
-        trigger = label_map.get(invoice.label, TriggerType.INVOICE_CLIENT_GENERAL)
-    elif invoice.label == InvoiceLabel.CS:
-        trigger = TriggerType.INVOICE_FOURNISSEUR_SUBCONTRACTING
-    else:
-        trigger = TriggerType.INVOICE_FOURNISSEUR_GENERAL
-
-    rule = await _get_rule(db, trigger)
-    if rule is None:
-        return []
-
     fiscal_year_id = await find_fiscal_year_id_for_date(db, invoice.date)
     context = {
         "number": invoice.number,
@@ -349,6 +313,24 @@ async def generate_entries_for_invoice(
     if split_entries is not None:
         await db.flush()
         return split_entries
+
+    if invoice.type == InvoiceType.CLIENT:
+        label_map: dict[InvoiceLabel | None, TriggerType] = {
+            InvoiceLabel.CS: TriggerType.INVOICE_CLIENT_CS,
+            InvoiceLabel.ADHESION: TriggerType.INVOICE_CLIENT_A,
+            InvoiceLabel.CS_ADHESION: TriggerType.INVOICE_CLIENT_CS_A,
+            InvoiceLabel.GENERAL: TriggerType.INVOICE_CLIENT_GENERAL,
+            None: TriggerType.INVOICE_CLIENT_GENERAL,
+        }
+        trigger = label_map.get(invoice.label, TriggerType.INVOICE_CLIENT_GENERAL)
+    elif invoice.label == InvoiceLabel.CS:
+        trigger = TriggerType.INVOICE_FOURNISSEUR_SUBCONTRACTING
+    else:
+        trigger = TriggerType.INVOICE_FOURNISSEUR_GENERAL
+
+    rule = await _get_rule(db, trigger)
+    if rule is None:
+        return []
 
     entries = await _apply_rule(
         db,

--- a/backend/services/accounting_engine.py
+++ b/backend/services/accounting_engine.py
@@ -143,7 +143,11 @@ async def _generate_split_client_invoice_entries(
     context: Mapping[str, object],
     fiscal_year_id: int | None,
 ) -> list[AccountingEntry] | None:
-    if invoice.label != InvoiceLabel.CS_ADHESION or len(invoice.lines) < 2:
+    if (
+        invoice.label != InvoiceLabel.CS_ADHESION
+        or not invoice.has_explicit_breakdown
+        or len(invoice.lines) < 2
+    ):
         return None
 
     grouped_amounts: dict[InvoiceLabel, Decimal] = {}
@@ -164,15 +168,39 @@ async def _generate_split_client_invoice_entries(
         return None
 
     cs_a_rule = await _get_rule(db, TriggerType.INVOICE_CLIENT_CS_A)
-    cs_rule = await _get_rule(db, TriggerType.INVOICE_CLIENT_CS)
-    adhesion_rule = await _get_rule(db, TriggerType.INVOICE_CLIENT_A)
-    if cs_a_rule is None or cs_rule is None or adhesion_rule is None:
+    cs_rule = (
+        await _get_rule(db, TriggerType.INVOICE_CLIENT_CS)
+        if grouped_amounts[InvoiceLabel.CS] > 0
+        else None
+    )
+    adhesion_rule = (
+        await _get_rule(db, TriggerType.INVOICE_CLIENT_A)
+        if grouped_amounts[InvoiceLabel.ADHESION] > 0
+        else None
+    )
+    if cs_a_rule is None:
+        return None
+    if grouped_amounts[InvoiceLabel.CS] > 0 and cs_rule is None:
+        return None
+    if grouped_amounts[InvoiceLabel.ADHESION] > 0 and adhesion_rule is None:
         return None
 
     debit_entries = [entry for entry in cs_a_rule.entries if entry.side == "debit"]
-    cs_credit_entries = [entry for entry in cs_rule.entries if entry.side == "credit"]
-    adhesion_credit_entries = [entry for entry in adhesion_rule.entries if entry.side == "credit"]
-    if not debit_entries or not cs_credit_entries or not adhesion_credit_entries:
+    cs_credit_entries = [
+        entry
+        for entry in (cs_rule.entries if cs_rule is not None else [])
+        if entry.side == "credit"
+    ]
+    adhesion_credit_entries = [
+        entry
+        for entry in (adhesion_rule.entries if adhesion_rule is not None else [])
+        if entry.side == "credit"
+    ]
+    if not debit_entries:
+        return None
+    if grouped_amounts[InvoiceLabel.CS] > 0 and not cs_credit_entries:
+        return None
+    if grouped_amounts[InvoiceLabel.ADHESION] > 0 and not adhesion_credit_entries:
         return None
 
     created: list[AccountingEntry] = []
@@ -188,30 +216,32 @@ async def _generate_split_client_invoice_entries(
             fiscal_year_id,
         )
     )
-    created.extend(
-        await _apply_rule_entries(
-            db,
-            cs_credit_entries,
-            grouped_amounts[InvoiceLabel.CS],
-            invoice.date,
-            context,
-            EntrySourceType.INVOICE,
-            invoice.id,
-            fiscal_year_id,
+    if grouped_amounts[InvoiceLabel.CS] > 0:
+        created.extend(
+            await _apply_rule_entries(
+                db,
+                cs_credit_entries,
+                grouped_amounts[InvoiceLabel.CS],
+                invoice.date,
+                context,
+                EntrySourceType.INVOICE,
+                invoice.id,
+                fiscal_year_id,
+            )
         )
-    )
-    created.extend(
-        await _apply_rule_entries(
-            db,
-            adhesion_credit_entries,
-            grouped_amounts[InvoiceLabel.ADHESION],
-            invoice.date,
-            context,
-            EntrySourceType.INVOICE,
-            invoice.id,
-            fiscal_year_id,
+    if grouped_amounts[InvoiceLabel.ADHESION] > 0:
+        created.extend(
+            await _apply_rule_entries(
+                db,
+                adhesion_credit_entries,
+                grouped_amounts[InvoiceLabel.ADHESION],
+                invoice.date,
+                context,
+                EntrySourceType.INVOICE,
+                invoice.id,
+                fiscal_year_id,
+            )
         )
-    )
     return created
 
 

--- a/backend/services/accounting_engine.py
+++ b/backend/services/accounting_engine.py
@@ -8,7 +8,8 @@ received, deposit created, etc.).
 from __future__ import annotations
 
 import re
-from collections.abc import Mapping
+import unicodedata
+from collections.abc import Mapping, Sequence
 from datetime import date
 from decimal import Decimal
 from typing import TYPE_CHECKING, cast
@@ -22,9 +23,9 @@ from backend.models.accounting_entry import (
     EntrySourceType,
     build_entry_group_key,
 )
-from backend.models.accounting_rule import AccountingRule, TriggerType
+from backend.models.accounting_rule import AccountingRule, AccountingRuleEntry, TriggerType
 from backend.models.bank import Deposit, DepositType
-from backend.models.invoice import Invoice, InvoiceLabel, InvoiceType
+from backend.models.invoice import Invoice, InvoiceLabel, InvoiceLine, InvoiceType
 from backend.models.payment import Payment, PaymentMethod
 from backend.services.fiscal_year_service import find_fiscal_year_id_for_date
 
@@ -65,9 +66,34 @@ async def _apply_rule(
     group_key: str | None = None,
 ) -> list[AccountingEntry]:
     """Create accounting entries for all rule_entries of a rule."""
+    return await _apply_rule_entries(
+        db,
+        rule.entries,
+        amount,
+        entry_date,
+        context,
+        source_type,
+        source_id,
+        fiscal_year_id,
+        group_key,
+    )
+
+
+async def _apply_rule_entries(
+    db: AsyncSession,
+    rule_entries: Sequence[AccountingRuleEntry],
+    amount: Decimal,
+    entry_date: date,
+    context: Mapping[str, object],
+    source_type: EntrySourceType | None,
+    source_id: int | None,
+    fiscal_year_id: int | None,
+    group_key: str | None = None,
+) -> list[AccountingEntry]:
+    """Create accounting entries for a selected subset of rule entries."""
     created: list[AccountingEntry] = []
     resolved_group_key = group_key or build_entry_group_key(source_type, source_id)
-    for rule_entry in rule.entries:
+    for rule_entry in rule_entries:
         entry_number = await _next_entry_number(db)
         label = _render_template(rule_entry.description_template, context)
 
@@ -90,6 +116,102 @@ async def _apply_rule(
         await db.flush()  # ensure COUNT is accurate for the next entry in the loop
         created.append(entry)
 
+    return created
+
+
+def _normalize_invoice_line_text(value: str) -> str:
+    normalized = unicodedata.normalize("NFKD", value.casefold())
+    return "".join(character for character in normalized if not unicodedata.combining(character))
+
+
+def _classify_client_invoice_line(line: InvoiceLine) -> InvoiceLabel | None:
+    if not (text := _normalize_invoice_line_text(line.description)):
+        return None
+    return (
+        InvoiceLabel.ADHESION
+        if "adhesion" in text
+        else InvoiceLabel.CS
+        if "cours" in text or "soutien" in text
+        else None
+    )
+
+
+async def _generate_split_client_invoice_entries(
+    db: AsyncSession,
+    invoice: Invoice,
+    *,
+    context: Mapping[str, object],
+    fiscal_year_id: int | None,
+) -> list[AccountingEntry] | None:
+    if invoice.label != InvoiceLabel.CS_ADHESION or len(invoice.lines) < 2:
+        return None
+
+    grouped_amounts: dict[InvoiceLabel, Decimal] = {}
+    for line in invoice.lines:
+        component_label = _classify_client_invoice_line(line)
+        if component_label is None:
+            return None
+        grouped_amounts[component_label] = grouped_amounts.get(
+            component_label,
+            Decimal("0"),
+        ) + Decimal(str(line.amount))
+
+    if set(grouped_amounts) != {InvoiceLabel.CS, InvoiceLabel.ADHESION}:
+        return None
+
+    total_amount = sum(grouped_amounts.values(), Decimal("0"))
+    if total_amount != Decimal(str(invoice.total_amount)):
+        return None
+
+    cs_a_rule = await _get_rule(db, TriggerType.INVOICE_CLIENT_CS_A)
+    cs_rule = await _get_rule(db, TriggerType.INVOICE_CLIENT_CS)
+    adhesion_rule = await _get_rule(db, TriggerType.INVOICE_CLIENT_A)
+    if cs_a_rule is None or cs_rule is None or adhesion_rule is None:
+        return None
+
+    debit_entries = [entry for entry in cs_a_rule.entries if entry.side == "debit"]
+    cs_credit_entries = [entry for entry in cs_rule.entries if entry.side == "credit"]
+    adhesion_credit_entries = [entry for entry in adhesion_rule.entries if entry.side == "credit"]
+    if not debit_entries or not cs_credit_entries or not adhesion_credit_entries:
+        return None
+
+    created: list[AccountingEntry] = []
+    created.extend(
+        await _apply_rule_entries(
+            db,
+            debit_entries,
+            total_amount,
+            invoice.date,
+            context,
+            EntrySourceType.INVOICE,
+            invoice.id,
+            fiscal_year_id,
+        )
+    )
+    created.extend(
+        await _apply_rule_entries(
+            db,
+            cs_credit_entries,
+            grouped_amounts[InvoiceLabel.CS],
+            invoice.date,
+            context,
+            EntrySourceType.INVOICE,
+            invoice.id,
+            fiscal_year_id,
+        )
+    )
+    created.extend(
+        await _apply_rule_entries(
+            db,
+            adhesion_credit_entries,
+            grouped_amounts[InvoiceLabel.ADHESION],
+            invoice.date,
+            context,
+            EntrySourceType.INVOICE,
+            invoice.id,
+            fiscal_year_id,
+        )
+    )
     return created
 
 
@@ -170,12 +292,10 @@ async def generate_entries_for_invoice(
             None: TriggerType.INVOICE_CLIENT_GENERAL,
         }
         trigger = label_map.get(invoice.label, TriggerType.INVOICE_CLIENT_GENERAL)
+    elif invoice.label == InvoiceLabel.CS:
+        trigger = TriggerType.INVOICE_FOURNISSEUR_SUBCONTRACTING
     else:
-        # Fournisseur — use CS as proxy for sous-traitance (label-based heuristic)
-        if invoice.label == InvoiceLabel.CS:
-            trigger = TriggerType.INVOICE_FOURNISSEUR_SUBCONTRACTING
-        else:
-            trigger = TriggerType.INVOICE_FOURNISSEUR_GENERAL
+        trigger = TriggerType.INVOICE_FOURNISSEUR_GENERAL
 
     rule = await _get_rule(db, trigger)
     if rule is None:
@@ -189,6 +309,16 @@ async def generate_entries_for_invoice(
         "amount": str(invoice.total_amount),
         "date": str(invoice.date),
     }
+
+    split_entries = await _generate_split_client_invoice_entries(
+        db,
+        invoice,
+        context=context,
+        fiscal_year_id=fiscal_year_id,
+    )
+    if split_entries is not None:
+        await db.flush()
+        return split_entries
 
     entries = await _apply_rule(
         db,

--- a/backend/services/accounting_engine.py
+++ b/backend/services/accounting_engine.py
@@ -175,9 +175,7 @@ async def _generate_split_client_invoice_entries(
     if total_amount <= 0:
         return []
 
-    positive_line_types = {
-        line_type for line_type, amount in grouped_amounts.items() if amount > 0
-    }
+    positive_line_types = {line_type for line_type, amount in grouped_amounts.items() if amount > 0}
     derived_label = derive_client_invoice_label(positive_line_types)
 
     debit_rule = await _get_rule(db, _trigger_for_client_invoice_label(derived_label))

--- a/backend/services/excel_import.py
+++ b/backend/services/excel_import.py
@@ -544,11 +544,7 @@ def _client_invoice_breakdown_from_entry_group(
     if revenue_total <= 0 or receivable_total != revenue_total:
         return None
 
-    return {
-        line_type: amount
-        for line_type, amount in breakdown.items()
-        if amount != Decimal("0")
-    }
+    return {line_type: amount for line_type, amount in breakdown.items() if amount != Decimal("0")}
 
 
 def _current_client_invoice_breakdown(invoice: Any) -> dict[Any, Decimal]:
@@ -558,11 +554,7 @@ def _current_client_invoice_breakdown(invoice: Any) -> dict[Any, Decimal]:
     for line in invoice.lines:
         line_type = line.line_type or infer_client_line_type(line.description, invoice.label)
         breakdown[line_type] = breakdown.get(line_type, Decimal("0")) + Decimal(str(line.amount))
-    return {
-        line_type: amount
-        for line_type, amount in breakdown.items()
-        if amount != Decimal("0")
-    }
+    return {line_type: amount for line_type, amount in breakdown.items() if amount != Decimal("0")}
 
 
 def _can_clarify_existing_client_invoice(invoice: Any) -> bool:
@@ -580,6 +572,7 @@ def _can_clarify_existing_client_invoice(invoice: Any) -> bool:
 async def _find_clarifiable_existing_client_invoice(
     db: AsyncSession,
     entry_rows: list[NormalizedEntryRow],
+    existing_client_invoices_by_number: dict[str, Any] | None = None,
 ) -> Any | None:
     from sqlalchemy import select  # noqa: PLC0415
     from sqlalchemy.orm import selectinload  # noqa: PLC0415
@@ -597,12 +590,16 @@ async def _find_clarifiable_existing_client_invoice(
     if breakdown is None:
         return None
 
-    invoice_result = await db.execute(
-        select(Invoice)
-        .where(Invoice.type == InvoiceType.CLIENT, Invoice.number == reference)
-        .options(selectinload(Invoice.lines))
-    )
-    invoice = invoice_result.scalar_one_or_none()
+    if existing_client_invoices_by_number is None:
+        invoice_result = await db.execute(
+            select(Invoice)
+            .where(Invoice.type == InvoiceType.CLIENT, Invoice.number == reference)
+            .options(selectinload(Invoice.lines))
+        )
+        invoice = invoice_result.scalar_one_or_none()
+    else:
+        invoice = existing_client_invoices_by_number.get(_normalize_text(reference))
+
     if invoice is None or not _can_clarify_existing_client_invoice(invoice):
         return None
 
@@ -620,6 +617,7 @@ async def _find_clarifiable_existing_client_invoice(
 async def _clarify_existing_client_invoice_from_entries(
     db: AsyncSession,
     entry_rows: list[NormalizedEntryRow],
+    existing_client_invoices_by_number: dict[str, Any] | None = None,
 ) -> Any | None:
     from sqlalchemy import delete  # noqa: PLC0415
 
@@ -632,7 +630,11 @@ async def _clarify_existing_client_invoice_from_entries(
     )
     from backend.services.accounting_engine import generate_entries_for_invoice  # noqa: PLC0415
 
-    invoice = await _find_clarifiable_existing_client_invoice(db, entry_rows)
+    invoice = await _find_clarifiable_existing_client_invoice(
+        db,
+        entry_rows,
+        existing_client_invoices_by_number,
+    )
     if invoice is None:
         return None
 
@@ -669,6 +671,24 @@ async def _clarify_existing_client_invoice_from_entries(
     await generate_entries_for_invoice(db, invoice)
     await db.flush()
     return invoice
+
+
+async def _load_existing_client_invoices_by_number(db: AsyncSession) -> dict[str, Any]:
+    from sqlalchemy import select  # noqa: PLC0415
+    from sqlalchemy.orm import selectinload  # noqa: PLC0415
+
+    from backend.models.invoice import Invoice, InvoiceType  # noqa: PLC0415
+
+    result = await db.execute(
+        select(Invoice)
+        .where(Invoice.type == InvoiceType.CLIENT)
+        .options(selectinload(Invoice.lines))
+    )
+    return {
+        _normalize_text(invoice.number): invoice
+        for invoice in result.scalars().all()
+        if invoice.number
+    }
 
 
 def _is_client_payment_entry_group(entry_rows: list[NormalizedEntryRow]) -> bool:
@@ -1843,11 +1863,7 @@ async def _import_invoices_sheet(db: AsyncSession, ws: Any, result: ImportResult
 
         invoice_lines = _build_client_invoice_lines_from_import_row(invoice_row)
         derived_label = derive_client_invoice_label(
-            {
-                line["line_type"]
-                for line in invoice_lines
-                if line["amount"] > 0
-            }
+            {line["line_type"] for line in invoice_lines if line["amount"] > 0}
         )
 
         invoice = Invoice(
@@ -2518,6 +2534,7 @@ async def _import_entries_sheet(db: AsyncSession, ws: Any, result: ImportResult)
 
     existing_entry_signatures = await _load_existing_accounting_entry_signatures(db)
     existing_invoice_numbers = await _load_existing_invoice_numbers(db)
+    existing_client_invoices_by_number = await _load_existing_client_invoices_by_number(db)
     existing_client_payment_signatures = await _load_existing_client_payment_reference_signatures(
         db
     )
@@ -2553,7 +2570,11 @@ async def _import_entries_sheet(db: AsyncSession, ws: Any, result: ImportResult)
             existing_invoice_numbers,
         )
         if existing_client_invoice_reference is not None:
-            clarified_invoice = await _clarify_existing_client_invoice_from_entries(db, entry_group)
+            clarified_invoice = await _clarify_existing_client_invoice_from_entries(
+                db,
+                entry_group,
+                existing_client_invoices_by_number,
+            )
             message = (
                 _CLIENT_INVOICE_CLARIFIED_MESSAGE
                 if clarified_invoice is not None
@@ -2902,6 +2923,7 @@ async def _add_comptabilite_existing_rows_preview(
     existing_supplier_payment_signatures = (
         await _load_existing_supplier_payment_reference_signatures(db)
     )
+    existing_client_invoices_by_number = await _load_existing_client_invoices_by_number(db)
     existing_salary_group_signatures = await _load_existing_salary_group_signatures(db)
     existing_generated_group_signatures = (
         await _load_existing_generated_accounting_group_signatures(db)
@@ -2938,7 +2960,11 @@ async def _add_comptabilite_existing_rows_preview(
                 existing_invoice_numbers,
             )
             if existing_client_invoice_reference is not None:
-                clarified_invoice = await _find_clarifiable_existing_client_invoice(db, entry_group)
+                clarified_invoice = await _find_clarifiable_existing_client_invoice(
+                    db,
+                    entry_group,
+                    existing_client_invoices_by_number,
+                )
                 for entry_row in entry_group:
                     _append_preview_ignored_issue(
                         preview,
@@ -3021,6 +3047,7 @@ async def _add_comptabilite_existing_rows_preview(
                         ),
                     )
                     preview.estimated_entries = max(0, preview.estimated_entries - 1)
+                index = next_index
                 continue
 
             for entry_row in entry_group:

--- a/backend/services/excel_import.py
+++ b/backend/services/excel_import.py
@@ -1496,11 +1496,13 @@ async def _import_contacts_sheet(db: AsyncSession, ws: Any, result: ImportResult
 async def _import_invoices_sheet(db: AsyncSession, ws: Any, result: ImportResult) -> None:
     """Import invoices from a sheet with flexible column detection."""
     from sqlalchemy import select  # noqa: PLC0415
+    from sqlalchemy.orm import selectinload  # noqa: PLC0415
 
     from backend.models.contact import Contact, ContactType  # noqa: PLC0415
     from backend.models.invoice import (  # noqa: PLC0415
         Invoice,
         InvoiceLabel,
+        InvoiceLine,
         InvoiceStatus,
         InvoiceType,
     )
@@ -1609,6 +1611,26 @@ async def _import_invoices_sheet(db: AsyncSession, ws: Any, result: ImportResult
             label=InvoiceLabel(invoice_row.label),
         )
         db.add(invoice)
+        await db.flush()
+        if invoice_row.course_amount is not None and invoice_row.adhesion_amount is not None:
+            db.add_all(
+                [
+                    InvoiceLine(
+                        invoice_id=invoice.id,
+                        description="Cours de soutien",
+                        quantity=Decimal("1"),
+                        unit_price=invoice_row.course_amount,
+                        amount=invoice_row.course_amount,
+                    ),
+                    InvoiceLine(
+                        invoice_id=invoice.id,
+                        description="Adhesion annuelle",
+                        quantity=Decimal("1"),
+                        unit_price=invoice_row.adhesion_amount,
+                        amount=invoice_row.adhesion_amount,
+                    ),
+                ]
+            )
         created_invoices.append(invoice)
         logger.debug(
             "Row %d — invoice '%s' queued (contact_id=%d, amount=%s)",
@@ -1647,7 +1669,18 @@ async def _import_invoices_sheet(db: AsyncSession, ws: Any, result: ImportResult
 
         for inv_obj in created_invoices:
             try:
-                entries = await generate_entries_for_invoice(db, inv_obj)
+                refreshed_invoice = (
+                    (
+                        await db.execute(
+                            select(Invoice)
+                            .where(Invoice.id == inv_obj.id)
+                            .options(selectinload(Invoice.lines))
+                        )
+                    )
+                    .scalars()
+                    .one()
+                )
+                entries = await generate_entries_for_invoice(db, refreshed_invoice)
                 result.entries_created += len(entries)
             except Exception as e:
                 logger.debug("Accounting entries skipped for invoice '%s': %s", inv_obj.number, e)

--- a/backend/services/excel_import.py
+++ b/backend/services/excel_import.py
@@ -202,6 +202,9 @@ _SALARY_MONTH_RE = re.compile(r"\b(20\d{2})[.-](\d{2})\b")
 _SALARY_TRAILING_INITIAL_RE = re.compile(r"\s+[a-z]$")
 _SALARY_ACCRUAL_ACCOUNT_PREFIXES = ("421", "431", "443", "641", "645")
 _SALARY_PAYMENT_ACCOUNT_PREFIXES = ("421", "512")
+_CLIENT_INVOICE_CLARIFIED_MESSAGE = (
+    "Facture client existante clarifiee a partir des ecritures comptables"
+)
 
 
 class _ImportSheetFailure(RuntimeError):
@@ -495,6 +498,179 @@ def _matching_existing_client_invoice_reference(
     return reference
 
 
+def _client_invoice_line_type_from_account_number(account_number: str) -> Any | None:
+    from backend.models.invoice import InvoiceLineType  # noqa: PLC0415
+
+    normalized_account_number = _normalize_text(account_number)
+    if normalized_account_number.startswith("706"):
+        return InvoiceLineType.COURSE
+    if normalized_account_number.startswith("756"):
+        return InvoiceLineType.ADHESION
+    if normalized_account_number.startswith("758"):
+        return InvoiceLineType.OTHER
+    return None
+
+
+def _client_invoice_breakdown_from_entry_group(
+    entry_rows: list[NormalizedEntryRow],
+) -> dict[Any, Decimal] | None:
+    from backend.models.invoice import InvoiceLineType  # noqa: PLC0415
+
+    if not _is_client_invoice_entry_group(entry_rows):
+        return None
+
+    breakdown: dict[Any, Decimal] = {
+        InvoiceLineType.COURSE: Decimal("0"),
+        InvoiceLineType.ADHESION: Decimal("0"),
+        InvoiceLineType.OTHER: Decimal("0"),
+    }
+    receivable_total = Decimal("0")
+    revenue_total = Decimal("0")
+
+    for entry_row in entry_rows:
+        normalized_account_number = _normalize_text(entry_row.account_number)
+        if normalized_account_number.startswith("411"):
+            receivable_total += entry_row.debit
+            continue
+        if entry_row.credit <= 0:
+            continue
+        if normalized_account_number.startswith(("70", "75")):
+            line_type = _client_invoice_line_type_from_account_number(entry_row.account_number)
+            if line_type is None:
+                return None
+            breakdown[line_type] += entry_row.credit
+            revenue_total += entry_row.credit
+
+    if revenue_total <= 0 or receivable_total != revenue_total:
+        return None
+
+    return {
+        line_type: amount
+        for line_type, amount in breakdown.items()
+        if amount != Decimal("0")
+    }
+
+
+def _current_client_invoice_breakdown(invoice: Any) -> dict[Any, Decimal]:
+    from backend.models.invoice import infer_client_line_type  # noqa: PLC0415
+
+    breakdown: dict[Any, Decimal] = {}
+    for line in invoice.lines:
+        line_type = line.line_type or infer_client_line_type(line.description, invoice.label)
+        breakdown[line_type] = breakdown.get(line_type, Decimal("0")) + Decimal(str(line.amount))
+    return {
+        line_type: amount
+        for line_type, amount in breakdown.items()
+        if amount != Decimal("0")
+    }
+
+
+def _can_clarify_existing_client_invoice(invoice: Any) -> bool:
+    from backend.models.invoice import InvoiceLineType, infer_client_line_type  # noqa: PLC0415
+
+    if not invoice.lines:
+        return False
+    current_line_types = {
+        line.line_type or infer_client_line_type(line.description, invoice.label)
+        for line in invoice.lines
+    }
+    return current_line_types == {InvoiceLineType.OTHER}
+
+
+async def _find_clarifiable_existing_client_invoice(
+    db: AsyncSession,
+    entry_rows: list[NormalizedEntryRow],
+) -> Any | None:
+    from sqlalchemy import select  # noqa: PLC0415
+    from sqlalchemy.orm import selectinload  # noqa: PLC0415
+
+    from backend.models.invoice import (  # noqa: PLC0415
+        Invoice,
+        InvoiceType,
+    )
+
+    reference = _single_client_invoice_reference(*(entry_row.label for entry_row in entry_rows))
+    if reference is None:
+        return None
+
+    breakdown = _client_invoice_breakdown_from_entry_group(entry_rows)
+    if breakdown is None:
+        return None
+
+    invoice_result = await db.execute(
+        select(Invoice)
+        .where(Invoice.type == InvoiceType.CLIENT, Invoice.number == reference)
+        .options(selectinload(Invoice.lines))
+    )
+    invoice = invoice_result.scalar_one_or_none()
+    if invoice is None or not _can_clarify_existing_client_invoice(invoice):
+        return None
+
+    current_breakdown = _current_client_invoice_breakdown(invoice)
+    if current_breakdown == breakdown:
+        return None
+
+    total_amount = sum(breakdown.values(), Decimal("0"))
+    if total_amount != Decimal(str(invoice.total_amount)):
+        return None
+
+    return invoice
+
+
+async def _clarify_existing_client_invoice_from_entries(
+    db: AsyncSession,
+    entry_rows: list[NormalizedEntryRow],
+) -> Any | None:
+    from sqlalchemy import delete  # noqa: PLC0415
+
+    from backend.models.accounting_entry import AccountingEntry, EntrySourceType  # noqa: PLC0415
+    from backend.models.invoice import (  # noqa: PLC0415
+        InvoiceLabel,
+        InvoiceLine,
+        default_client_line_description,
+        derive_client_invoice_label,
+    )
+    from backend.services.accounting_engine import generate_entries_for_invoice  # noqa: PLC0415
+
+    invoice = await _find_clarifiable_existing_client_invoice(db, entry_rows)
+    if invoice is None:
+        return None
+
+    breakdown = _client_invoice_breakdown_from_entry_group(entry_rows)
+    if breakdown is None:
+        return None
+
+    await db.execute(
+        delete(AccountingEntry).where(
+            AccountingEntry.source_type == EntrySourceType.INVOICE,
+            AccountingEntry.source_id == invoice.id,
+        )
+    )
+
+    invoice.lines.clear()
+    await db.flush()
+
+    positive_line_types = {line_type for line_type, amount in breakdown.items() if amount > 0}
+    invoice.label = derive_client_invoice_label(positive_line_types)
+    invoice.has_explicit_breakdown = len(breakdown) > 1 or invoice.label != InvoiceLabel.GENERAL
+    invoice.lines.extend(
+        InvoiceLine(
+            invoice_id=invoice.id,
+            description=default_client_line_description(line_type),
+            line_type=line_type,
+            quantity=Decimal("1"),
+            unit_price=amount,
+            amount=amount,
+        )
+        for line_type, amount in sorted(breakdown.items(), key=lambda item: item[0].value)
+    )
+
+    await db.flush()
+    await generate_entries_for_invoice(db, invoice)
+    await db.flush()
+    return invoice
+
+
 def _is_client_payment_entry_group(entry_rows: list[NormalizedEntryRow]) -> bool:
     has_receivable_credit = any(
         _normalize_text(entry_row.account_number).startswith("411") and entry_row.credit > 0
@@ -549,6 +725,71 @@ async def _load_existing_client_payment_reference_signatures(
                 )
             )
     return signatures
+
+
+def _build_client_invoice_lines_from_import_row(
+    invoice_row: NormalizedInvoiceRow,
+) -> list[dict[str, Any]]:
+    from backend.models.invoice import (  # noqa: PLC0415
+        InvoiceLabel,
+        InvoiceLineType,
+        default_client_line_description,
+    )
+
+    if invoice_row.course_amount is not None and invoice_row.adhesion_amount is not None:
+        return [
+            {
+                "description": default_client_line_description(InvoiceLineType.COURSE),
+                "line_type": InvoiceLineType.COURSE,
+                "amount": invoice_row.course_amount,
+            },
+            {
+                "description": default_client_line_description(InvoiceLineType.ADHESION),
+                "line_type": InvoiceLineType.ADHESION,
+                "amount": invoice_row.adhesion_amount,
+            },
+        ]
+
+    label = InvoiceLabel(invoice_row.label)
+    if label == InvoiceLabel.CS:
+        line_type = InvoiceLineType.COURSE
+    elif label == InvoiceLabel.ADHESION:
+        line_type = InvoiceLineType.ADHESION
+    else:
+        line_type = InvoiceLineType.OTHER
+
+    return [
+        {
+            "description": default_client_line_description(line_type),
+            "line_type": line_type,
+            "amount": invoice_row.amount,
+        }
+    ]
+
+
+def _merge_existing_client_invoice_entry_groups(
+    entry_groups: list[list[NormalizedEntryRow]],
+    start_index: int,
+    existing_invoice_numbers: set[str],
+) -> tuple[list[NormalizedEntryRow], int]:
+    merged_group = list(entry_groups[start_index])
+    reference = _matching_existing_client_invoice_reference(merged_group, existing_invoice_numbers)
+    if reference is None:
+        return merged_group, start_index + 1
+
+    next_index = start_index + 1
+    while next_index < len(entry_groups):
+        next_group = entry_groups[next_index]
+        next_reference = _matching_existing_client_invoice_reference(
+            next_group,
+            existing_invoice_numbers,
+        )
+        if next_reference != reference:
+            break
+        merged_group.extend(next_group)
+        next_index += 1
+
+    return merged_group, next_index
 
 
 def _matching_existing_client_payment_reference(
@@ -1501,10 +1742,10 @@ async def _import_invoices_sheet(db: AsyncSession, ws: Any, result: ImportResult
     from backend.models.contact import Contact, ContactType  # noqa: PLC0415
     from backend.models.invoice import (  # noqa: PLC0415
         Invoice,
-        InvoiceLabel,
         InvoiceLine,
         InvoiceStatus,
         InvoiceType,
+        derive_client_invoice_label,
     )
 
     parsed_sheet, normalized_rows, _, ignored_issues = _parse_invoice_sheet(ws)
@@ -1600,6 +1841,15 @@ async def _import_invoices_sheet(db: AsyncSession, ws: Any, result: ImportResult
             )
             continue
 
+        invoice_lines = _build_client_invoice_lines_from_import_row(invoice_row)
+        derived_label = derive_client_invoice_label(
+            {
+                line["line_type"]
+                for line in invoice_lines
+                if line["amount"] > 0
+            }
+        )
+
         invoice = Invoice(
             number=number_raw,
             type=InvoiceType.CLIENT,
@@ -1608,32 +1858,24 @@ async def _import_invoices_sheet(db: AsyncSession, ws: Any, result: ImportResult
             total_amount=total,
             paid_amount=Decimal("0"),
             status=InvoiceStatus.SENT,
-            label=InvoiceLabel(invoice_row.label),
-            has_explicit_breakdown=(
-                invoice_row.course_amount is not None and invoice_row.adhesion_amount is not None
-            ),
+            label=derived_label,
+            has_explicit_breakdown=len(invoice_lines) > 1,
         )
         db.add(invoice)
         await db.flush()
-        if invoice_row.course_amount is not None and invoice_row.adhesion_amount is not None:
-            db.add_all(
-                [
-                    InvoiceLine(
-                        invoice_id=invoice.id,
-                        description="Cours de soutien",
-                        quantity=Decimal("1"),
-                        unit_price=invoice_row.course_amount,
-                        amount=invoice_row.course_amount,
-                    ),
-                    InvoiceLine(
-                        invoice_id=invoice.id,
-                        description="Adhesion annuelle",
-                        quantity=Decimal("1"),
-                        unit_price=invoice_row.adhesion_amount,
-                        amount=invoice_row.adhesion_amount,
-                    ),
-                ]
-            )
+        db.add_all(
+            [
+                InvoiceLine(
+                    invoice_id=invoice.id,
+                    description=line["description"],
+                    line_type=line["line_type"],
+                    quantity=Decimal("1"),
+                    unit_price=line["amount"],
+                    amount=line["amount"],
+                )
+                for line in invoice_lines
+            ]
+        )
         created_invoices.append(invoice)
         logger.debug(
             "Row %d — invoice '%s' queued (contact_id=%d, amount=%s)",
@@ -2298,8 +2540,25 @@ async def _import_entries_sheet(db: AsyncSession, ws: Any, result: ImportResult)
     base_count = count_result.scalar_one_or_none() or 0
     entries_to_add: list[AccountingEntry] = []
     next_offset = 0
-    for entry_group in _build_entry_row_groups(normalized_rows):
-        if _matching_existing_client_invoice_reference(entry_group, existing_invoice_numbers):
+    entry_groups = _build_entry_row_groups(normalized_rows)
+    index = 0
+    while index < len(entry_groups):
+        entry_group, next_index = _merge_existing_client_invoice_entry_groups(
+            entry_groups,
+            index,
+            existing_invoice_numbers,
+        )
+        existing_client_invoice_reference = _matching_existing_client_invoice_reference(
+            entry_group,
+            existing_invoice_numbers,
+        )
+        if existing_client_invoice_reference is not None:
+            clarified_invoice = await _clarify_existing_client_invoice_from_entries(db, entry_group)
+            message = (
+                _CLIENT_INVOICE_CLARIFIED_MESSAGE
+                if clarified_invoice is not None
+                else ENTRY_EXISTING_MESSAGE
+            )
             for entry_row in entry_group:
                 result.add_ignored_row(
                     ws.title,
@@ -2307,10 +2566,20 @@ async def _import_entries_sheet(db: AsyncSession, ws: Any, result: ImportResult)
                     format_row_issue(
                         RowIgnoredIssue(
                             source_row_number=entry_row.source_row_number,
-                            message=ENTRY_EXISTING_MESSAGE,
+                            message=message,
                         )
                     ),
                 )
+            if clarified_invoice is not None:
+                result.record_created_object(
+                    sheet_name=ws.title,
+                    kind="entries",
+                    object_type="invoice",
+                    object_id=clarified_invoice.id,
+                    reference=clarified_invoice.number,
+                    details={"action": "clarified_from_accounting_entries"},
+                )
+            index = next_index
             continue
 
         if _matching_existing_client_payment_reference(
@@ -2328,6 +2597,7 @@ async def _import_entries_sheet(db: AsyncSession, ws: Any, result: ImportResult)
                         )
                     ),
                 )
+            index = next_index
             continue
 
         if _matching_existing_supplier_invoice_payment_reference(
@@ -2345,6 +2615,7 @@ async def _import_entries_sheet(db: AsyncSession, ws: Any, result: ImportResult)
                         )
                     ),
                 )
+            index = next_index
             continue
 
         if _matching_existing_salary_entry_group(
@@ -2362,6 +2633,7 @@ async def _import_entries_sheet(db: AsyncSession, ws: Any, result: ImportResult)
                         )
                     ),
                 )
+            index = next_index
             continue
 
         if _normalized_entry_group_signature(entry_group) in existing_generated_group_signatures:
@@ -2376,6 +2648,7 @@ async def _import_entries_sheet(db: AsyncSession, ws: Any, result: ImportResult)
                         )
                     ),
                 )
+            index = next_index
             continue
 
         group_key = f"import:{uuid4().hex}"
@@ -2415,6 +2688,8 @@ async def _import_entries_sheet(db: AsyncSession, ws: Any, result: ImportResult)
             entries_to_add.append(entry)
             existing_entry_signatures.add(signature)
             result.add_imported_row(ws.title, "entries")
+
+        index = next_index
 
     try:
         for entry in entries_to_add:
@@ -2650,18 +2925,35 @@ async def _add_comptabilite_existing_rows_preview(
         if parsed_sheet is None or parsed_sheet.missing_columns:
             continue
 
-        for entry_group in _build_entry_row_groups(normalized_rows):
-            if _matching_existing_client_invoice_reference(entry_group, existing_invoice_numbers):
+        entry_groups = _build_entry_row_groups(normalized_rows)
+        index = 0
+        while index < len(entry_groups):
+            entry_group, next_index = _merge_existing_client_invoice_entry_groups(
+                entry_groups,
+                index,
+                existing_invoice_numbers,
+            )
+            existing_client_invoice_reference = _matching_existing_client_invoice_reference(
+                entry_group,
+                existing_invoice_numbers,
+            )
+            if existing_client_invoice_reference is not None:
+                clarified_invoice = await _find_clarifiable_existing_client_invoice(db, entry_group)
                 for entry_row in entry_group:
                     _append_preview_ignored_issue(
                         preview,
                         sheet_preview,
                         RowIgnoredIssue(
                             source_row_number=entry_row.source_row_number,
-                            message=ENTRY_EXISTING_MESSAGE,
+                            message=(
+                                _CLIENT_INVOICE_CLARIFIED_MESSAGE
+                                if clarified_invoice is not None
+                                else ENTRY_EXISTING_MESSAGE
+                            ),
                         ),
                     )
                     preview.estimated_entries = max(0, preview.estimated_entries - 1)
+                index = next_index
                 continue
 
             if _matching_existing_client_payment_reference(
@@ -2678,6 +2970,7 @@ async def _add_comptabilite_existing_rows_preview(
                         ),
                     )
                     preview.estimated_entries = max(0, preview.estimated_entries - 1)
+                index = next_index
                 continue
 
             if _matching_existing_supplier_invoice_payment_reference(
@@ -2694,6 +2987,7 @@ async def _add_comptabilite_existing_rows_preview(
                         ),
                     )
                     preview.estimated_entries = max(0, preview.estimated_entries - 1)
+                index = next_index
                 continue
 
             if _matching_existing_salary_entry_group(
@@ -2710,6 +3004,7 @@ async def _add_comptabilite_existing_rows_preview(
                         ),
                     )
                     preview.estimated_entries = max(0, preview.estimated_entries - 1)
+                index = next_index
                 continue
 
             if (
@@ -2747,6 +3042,7 @@ async def _add_comptabilite_existing_rows_preview(
                     ),
                 )
                 preview.estimated_entries = max(0, preview.estimated_entries - 1)
+            index = next_index
 
     _recompute_preview_can_import(preview)
 

--- a/backend/services/excel_import.py
+++ b/backend/services/excel_import.py
@@ -1609,6 +1609,9 @@ async def _import_invoices_sheet(db: AsyncSession, ws: Any, result: ImportResult
             paid_amount=Decimal("0"),
             status=InvoiceStatus.SENT,
             label=InvoiceLabel(invoice_row.label),
+            has_explicit_breakdown=(
+                invoice_row.course_amount is not None and invoice_row.adhesion_amount is not None
+            ),
         )
         db.add(invoice)
         await db.flush()

--- a/backend/services/excel_import_parsers.py
+++ b/backend/services/excel_import_parsers.py
@@ -183,6 +183,14 @@ def parse_invoice_sheet(
     nom_idx = find_col_idx(col_map, "nom", "client", "adhérent", "adherent")
     numero_idx = find_invoice_number_idx(col_map, exclude_idx=date_idx)
     label_idx = find_col_idx(col_map, "motif", "libellé", "libelle", "type")
+    course_amount_idx = find_col_idx(col_map, "montant cours", "cours")
+    adhesion_amount_idx = find_col_idx(
+        col_map,
+        "montant adhésion",
+        "montant adhesion",
+        "adhésion",
+        "adhesion",
+    )
 
     missing_columns = invoice_missing_columns(
         date_idx=date_idx,
@@ -238,11 +246,38 @@ def parse_invoice_sheet(
         assert amount is not None
         assert invoice_date is not None
         raw_number = get_row_value(row, numero_idx)
+        normalized_label = normalize_invoice_label(get_row_value(row, label_idx))
         invoice_number: str | None = None
         if not isinstance(raw_number, (date, datetime)):
             candidate = parse_str(raw_number)
             if candidate and not _DATE_LIKE_TEXT_RE.match(candidate):
                 invoice_number = candidate
+
+        course_amount = parse_decimal(get_row_value(row, course_amount_idx))
+        adhesion_amount = parse_decimal(get_row_value(row, adhesion_amount_idx))
+        if normalized_label == "cs+a":
+            valid_course_amount = (
+                course_amount if course_amount is not None and course_amount > 0 else None
+            )
+            valid_adhesion_amount = (
+                adhesion_amount if adhesion_amount is not None and adhesion_amount > 0 else None
+            )
+            component_total = (valid_course_amount or Decimal("0")) + (
+                valid_adhesion_amount or Decimal("0")
+            )
+            if (
+                valid_course_amount is not None
+                and valid_adhesion_amount is not None
+                and component_total == amount
+            ):
+                course_amount = valid_course_amount
+                adhesion_amount = valid_adhesion_amount
+            else:
+                course_amount = None
+                adhesion_amount = None
+        else:
+            course_amount = None
+            adhesion_amount = None
 
         rows.append(
             NormalizedInvoiceRow(
@@ -251,7 +286,9 @@ def parse_invoice_sheet(
                 amount=amount,
                 contact_name=contact_name,
                 invoice_number=invoice_number,
-                label=normalize_invoice_label(get_row_value(row, label_idx)),
+                label=normalized_label,
+                course_amount=course_amount,
+                adhesion_amount=adhesion_amount,
             )
         )
 

--- a/backend/services/excel_import_parsers.py
+++ b/backend/services/excel_import_parsers.py
@@ -34,6 +34,7 @@ from backend.services.excel_import_policy import (
     ENTRY_MISSING_ACCOUNT_MESSAGE,
     ENTRY_SUSPICIOUS_DATE_MESSAGE,
     INVOICE_INVALID_AMOUNT_MESSAGE,
+    INVOICE_INVALID_COMPONENT_BREAKDOWN_MESSAGE,
     INVOICE_INVALID_DATE_MESSAGE,
     INVOICE_REQUIRED_CONTACT_MESSAGE,
     INVOICE_TOTAL_MESSAGE,
@@ -140,6 +141,10 @@ def _parse_salary_month(value: Any) -> str | None:
     if match is None:
         return None
     return f"{match.group(1)}-{match.group(2)}"
+
+
+def _has_explicit_component_value(value: Any) -> bool:
+    return parse_str(value) != ""
 
 
 def _salary_decimal_or_zero(value: Any) -> Decimal:
@@ -253,23 +258,38 @@ def parse_invoice_sheet(
             if candidate and not _DATE_LIKE_TEXT_RE.match(candidate):
                 invoice_number = candidate
 
-        course_amount = parse_decimal(get_row_value(row, course_amount_idx))
-        adhesion_amount = parse_decimal(get_row_value(row, adhesion_amount_idx))
+        raw_course_amount = get_row_value(row, course_amount_idx)
+        raw_adhesion_amount = get_row_value(row, adhesion_amount_idx)
+        course_amount = parse_decimal(raw_course_amount)
+        adhesion_amount = parse_decimal(raw_adhesion_amount)
         if normalized_label == "cs+a":
-            valid_course_amount = (
-                course_amount if course_amount is not None and course_amount > 0 else None
-            )
-            valid_adhesion_amount = (
-                adhesion_amount if adhesion_amount is not None and adhesion_amount > 0 else None
-            )
-            component_total = (valid_course_amount or Decimal("0")) + (
-                valid_adhesion_amount or Decimal("0")
-            )
-            if (
-                valid_course_amount is not None
-                and valid_adhesion_amount is not None
-                and component_total == amount
-            ):
+            has_explicit_breakdown = _has_explicit_component_value(
+                raw_course_amount
+            ) or _has_explicit_component_value(raw_adhesion_amount)
+            if has_explicit_breakdown:
+                valid_course_amount = (
+                    course_amount if course_amount is not None and course_amount >= 0 else None
+                )
+                valid_adhesion_amount = (
+                    adhesion_amount
+                    if adhesion_amount is not None and adhesion_amount >= 0
+                    else None
+                )
+                component_total = (valid_course_amount or Decimal("0")) + (
+                    valid_adhesion_amount or Decimal("0")
+                )
+                if (
+                    valid_course_amount is None
+                    or valid_adhesion_amount is None
+                    or component_total != amount
+                ):
+                    issues.append(
+                        make_validation_issue(
+                            source_row_number,
+                            [INVOICE_INVALID_COMPONENT_BREAKDOWN_MESSAGE],
+                        )
+                    )
+                    continue
                 course_amount = valid_course_amount
                 adhesion_amount = valid_adhesion_amount
             else:

--- a/backend/services/excel_import_policy.py
+++ b/backend/services/excel_import_policy.py
@@ -51,6 +51,9 @@ GESTION_UNKNOWN_STRUCTURE_MESSAGE = "Structure non reconnue, feuille ignoree par
 INVOICE_AMBIGUOUS_CONTACT_MESSAGE = "client ambigu : plusieurs contacts correspondent"
 INVOICE_INVALID_AMOUNT_MESSAGE = "montant manquant ou invalide"
 INVOICE_INVALID_DATE_MESSAGE = "date manquante ou invalide"
+INVOICE_INVALID_COMPONENT_BREAKDOWN_MESSAGE = (
+    "ventilation cours/adhesion incoherente avec le montant total"
+)
 INVOICE_REQUIRED_COLUMNS = ("date", "montant", "client")
 INVOICE_REQUIRED_CONTACT_MESSAGE = "client manquant"
 INVOICE_TOTAL_MESSAGE = "ligne de total ignoree"
@@ -127,6 +130,7 @@ _ISSUE_CATEGORY_BY_KIND_AND_MESSAGE = {
     "invoices": {
         INVOICE_AMBIGUOUS_CONTACT_MESSAGE: "invoice-ambiguous-contact",
         INVOICE_INVALID_AMOUNT_MESSAGE: "invoice-invalid-amount",
+        INVOICE_INVALID_COMPONENT_BREAKDOWN_MESSAGE: "invoice-invalid-component-breakdown",
         INVOICE_INVALID_DATE_MESSAGE: "invoice-invalid-date",
         INVOICE_REQUIRED_CONTACT_MESSAGE: "invoice-missing-contact",
     },

--- a/backend/services/excel_import_types.py
+++ b/backend/services/excel_import_types.py
@@ -42,6 +42,8 @@ class NormalizedInvoiceRow:
     contact_name: str
     invoice_number: str | None
     label: str
+    course_amount: Decimal | None = None
+    adhesion_amount: Decimal | None = None
 
 
 @dataclass(slots=True)

--- a/backend/services/invoice.py
+++ b/backend/services/invoice.py
@@ -7,7 +7,7 @@ from sqlalchemy import extract, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from backend.models.invoice import Invoice, InvoiceLine, InvoiceStatus, InvoiceType
+from backend.models.invoice import Invoice, InvoiceLabel, InvoiceLine, InvoiceStatus, InvoiceType
 from backend.schemas.invoice import InvoiceCreate, InvoiceLineCreate, InvoiceUpdate
 
 
@@ -64,6 +64,16 @@ def _compute_total(lines: list[InvoiceLineCreate]) -> Decimal:
     )
 
 
+def _has_user_entered_breakdown(
+    invoice_type: InvoiceType,
+    label: InvoiceLabel | None,
+    line_count: int,
+) -> bool:
+    return (
+        invoice_type == InvoiceType.CLIENT and label == InvoiceLabel.CS_ADHESION and line_count > 0
+    )
+
+
 async def _next_number(db: AsyncSession, invoice_type: InvoiceType, year: int) -> str:
     """Generate the next sequential invoice number for a given type and year.
 
@@ -106,6 +116,11 @@ async def create_invoice(db: AsyncSession, payload: InvoiceCreate) -> Invoice:
         reference=payload.reference,
         total_amount=total,
         paid_amount=Decimal("0"),
+        has_explicit_breakdown=_has_user_entered_breakdown(
+            payload.type,
+            payload.label,
+            len(payload.lines),
+        ),
         status=InvoiceStatus.DRAFT,
     )
     db.add(invoice)
@@ -186,7 +201,6 @@ async def update_invoice(db: AsyncSession, invoice: Invoice, payload: InvoiceUpd
         for existing_line in list(invoice.lines):
             await db.delete(existing_line)
         await db.flush()
-        invoice.has_explicit_breakdown = False
         new_lines = []
         for ln in payload.lines:
             line = InvoiceLine(
@@ -201,6 +215,13 @@ async def update_invoice(db: AsyncSession, invoice: Invoice, payload: InvoiceUpd
         invoice.total_amount = _compute_total(payload.lines)
     elif payload.total_amount is not None:
         invoice.total_amount = payload.total_amount
+
+    line_count = len(payload.lines) if payload.lines is not None else len(invoice.lines)
+    invoice.has_explicit_breakdown = _has_user_entered_breakdown(
+        invoice.type,
+        invoice.label,
+        line_count,
+    )
 
     invoice.updated_at = datetime.now(UTC)
     invoice_id = invoice.id  # save before expire clears attributes
@@ -245,6 +266,11 @@ async def duplicate_invoice(db: AsyncSession, source: Invoice) -> Invoice:
         reference=None,
         total_amount=source.total_amount,
         paid_amount=Decimal("0"),
+        has_explicit_breakdown=_has_user_entered_breakdown(
+            source.type,
+            source.label,
+            len(source.lines),
+        ),
         status=InvoiceStatus.DRAFT,
     )
     db.add(copy)

--- a/backend/services/invoice.py
+++ b/backend/services/invoice.py
@@ -111,7 +111,7 @@ def _has_user_entered_breakdown(
     invoice_type: InvoiceType,
     line_count: int,
 ) -> bool:
-    return invoice_type == InvoiceType.CLIENT and line_count > 0
+    return invoice_type == InvoiceType.CLIENT and line_count >= 2
 
 
 async def _next_number(db: AsyncSession, invoice_type: InvoiceType, year: int) -> str:

--- a/backend/services/invoice.py
+++ b/backend/services/invoice.py
@@ -186,6 +186,7 @@ async def update_invoice(db: AsyncSession, invoice: Invoice, payload: InvoiceUpd
         for existing_line in list(invoice.lines):
             await db.delete(existing_line)
         await db.flush()
+        invoice.has_explicit_breakdown = False
         new_lines = []
         for ln in payload.lines:
             line = InvoiceLine(

--- a/backend/services/invoice.py
+++ b/backend/services/invoice.py
@@ -1,5 +1,6 @@
 """Invoice service — CRUD, numbering, status changes, duplication."""
 
+from collections.abc import Sequence
 from datetime import UTC, date, datetime
 from decimal import Decimal
 
@@ -7,7 +8,16 @@ from sqlalchemy import extract, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from backend.models.invoice import Invoice, InvoiceLabel, InvoiceLine, InvoiceStatus, InvoiceType
+from backend.models.invoice import (
+    Invoice,
+    InvoiceLabel,
+    InvoiceLine,
+    InvoiceLineType,
+    InvoiceStatus,
+    InvoiceType,
+    derive_client_invoice_label,
+    infer_client_line_type,
+)
 from backend.schemas.invoice import InvoiceCreate, InvoiceLineCreate, InvoiceUpdate
 
 
@@ -64,14 +74,44 @@ def _compute_total(lines: list[InvoiceLineCreate]) -> Decimal:
     )
 
 
+def _resolve_client_line_type(
+    description: str,
+    line_type: InvoiceLineType | None,
+    fallback_label: InvoiceLabel | None,
+) -> InvoiceLineType:
+    return line_type or infer_client_line_type(description, fallback_label)
+
+
+def _derive_client_label(
+    lines: Sequence[InvoiceLineCreate | InvoiceLine],
+    fallback_label: InvoiceLabel | None,
+) -> InvoiceLabel:
+    line_types = {
+        _resolve_client_line_type(
+            line.description,
+            getattr(line, "line_type", None),
+            fallback_label,
+        )
+        for line in lines
+    }
+    return derive_client_invoice_label(line_types)
+
+
+def _resolve_invoice_label(
+    invoice_type: InvoiceType,
+    payload_label: InvoiceLabel | None,
+    lines: Sequence[InvoiceLineCreate | InvoiceLine],
+) -> InvoiceLabel | None:
+    if invoice_type != InvoiceType.CLIENT or not lines:
+        return payload_label
+    return _derive_client_label(lines, payload_label)
+
+
 def _has_user_entered_breakdown(
     invoice_type: InvoiceType,
-    label: InvoiceLabel | None,
     line_count: int,
 ) -> bool:
-    return (
-        invoice_type == InvoiceType.CLIENT and label == InvoiceLabel.CS_ADHESION and line_count > 0
-    )
+    return invoice_type == InvoiceType.CLIENT and line_count > 0
 
 
 async def _next_number(db: AsyncSession, invoice_type: InvoiceType, year: int) -> str:
@@ -105,20 +145,21 @@ async def create_invoice(db: AsyncSession, payload: InvoiceCreate) -> Invoice:
     else:
         total = Decimal("0")
 
+    resolved_label = _resolve_invoice_label(payload.type, payload.label, payload.lines)
+
     invoice = Invoice(
         number=number,
         type=payload.type,
         contact_id=payload.contact_id,
         date=payload.date,
         due_date=payload.due_date,
-        label=payload.label,
+        label=resolved_label,
         description=payload.description,
         reference=payload.reference,
         total_amount=total,
         paid_amount=Decimal("0"),
         has_explicit_breakdown=_has_user_entered_breakdown(
             payload.type,
-            payload.label,
             len(payload.lines),
         ),
         status=InvoiceStatus.DRAFT,
@@ -130,6 +171,11 @@ async def create_invoice(db: AsyncSession, payload: InvoiceCreate) -> Invoice:
         line = InvoiceLine(
             invoice_id=invoice.id,
             description=ln.description,
+            line_type=(
+                _resolve_client_line_type(ln.description, ln.line_type, resolved_label)
+                if payload.type == InvoiceType.CLIENT
+                else None
+            ),
             quantity=ln.quantity,
             unit_price=ln.unit_price,
             amount=_compute_line_amount(ln.quantity, ln.unit_price),
@@ -188,7 +234,6 @@ async def update_invoice(db: AsyncSession, invoice: Invoice, payload: InvoiceUpd
         "contact_id",
         "date",
         "due_date",
-        "label",
         "description",
         "reference",
     ):
@@ -196,16 +241,30 @@ async def update_invoice(db: AsyncSession, invoice: Invoice, payload: InvoiceUpd
         if value is not None:
             setattr(invoice, field, value)
 
+    if payload.label is not None and invoice.type != InvoiceType.CLIENT:
+        invoice.label = payload.label
+
+    effective_lines: Sequence[InvoiceLineCreate | InvoiceLine] = invoice.lines
     if payload.lines is not None:
         # Replace all existing lines
         for existing_line in list(invoice.lines):
             await db.delete(existing_line)
         await db.flush()
         new_lines = []
+        resolved_label = _resolve_invoice_label(
+            invoice.type,
+            payload.label if payload.label is not None else invoice.label,
+            payload.lines,
+        )
         for ln in payload.lines:
             line = InvoiceLine(
                 invoice_id=invoice.id,
                 description=ln.description,
+                line_type=(
+                    _resolve_client_line_type(ln.description, ln.line_type, resolved_label)
+                    if invoice.type == InvoiceType.CLIENT
+                    else None
+                ),
                 quantity=ln.quantity,
                 unit_price=ln.unit_price,
                 amount=_compute_line_amount(ln.quantity, ln.unit_price),
@@ -213,13 +272,19 @@ async def update_invoice(db: AsyncSession, invoice: Invoice, payload: InvoiceUpd
             db.add(line)
             new_lines.append(line)
         invoice.total_amount = _compute_total(payload.lines)
+        effective_lines = payload.lines
     elif payload.total_amount is not None:
         invoice.total_amount = payload.total_amount
+
+    invoice.label = _resolve_invoice_label(
+        invoice.type,
+        payload.label if payload.label is not None else invoice.label,
+        effective_lines,
+    )
 
     line_count = len(payload.lines) if payload.lines is not None else len(invoice.lines)
     invoice.has_explicit_breakdown = _has_user_entered_breakdown(
         invoice.type,
-        invoice.label,
         line_count,
     )
 
@@ -261,14 +326,13 @@ async def duplicate_invoice(db: AsyncSession, source: Invoice) -> Invoice:
         contact_id=source.contact_id,
         date=today,
         due_date=None,
-        label=source.label,
+        label=_resolve_invoice_label(source.type, source.label, source.lines),
         description=source.description,
         reference=None,
         total_amount=source.total_amount,
         paid_amount=Decimal("0"),
         has_explicit_breakdown=_has_user_entered_breakdown(
             source.type,
-            source.label,
             len(source.lines),
         ),
         status=InvoiceStatus.DRAFT,
@@ -280,6 +344,7 @@ async def duplicate_invoice(db: AsyncSession, source: Invoice) -> Invoice:
         line = InvoiceLine(
             invoice_id=copy.id,
             description=src_line.description,
+            line_type=src_line.line_type,
             quantity=src_line.quantity,
             unit_price=src_line.unit_price,
             amount=src_line.amount,

--- a/backend/templates/invoice.html
+++ b/backend/templates/invoice.html
@@ -33,7 +33,6 @@
   .totals td { padding: 6px 12px; font-size: 10pt; }
   .totals tr.grand-total td { font-weight: bold; font-size: 12pt; border-top: 2px solid #2563eb; }
   .totals td:last-child { text-align: right; }
-  .label-badge { display: inline-block; padding: 2px 8px; border-radius: 3px; font-size: 9pt; font-weight: bold; background: #dbeafe; color: #1e40af; }
   .footer { margin-top: 30px; padding-top: 14px; border-top: 1px solid #e2e8f0; font-size: 9pt; color: #64748b; text-align: center; line-height: 1.6; }
   .due-date { color: #dc2626; font-weight: bold; }
 </style>
@@ -74,9 +73,6 @@
 </div>
 
 <div class="meta">
-  {% if invoice.label %}
-  <div class="meta-item">Type : <span class="label-badge">{{ invoice.label }}</span></div>
-  {% endif %}
   {% if invoice.reference %}
   <div class="meta-item">Réf. : <span>{{ invoice.reference }}</span></div>
   {% endif %}

--- a/doc/backlog.md
+++ b/doc/backlog.md
@@ -426,7 +426,7 @@ Tout sujet concret qui doit survivre au-delà de la séance en cours doit être 
 	- quelle différence de traitement entre correction mineure, changement de montant et annulation métier ;
 	- faut-il prévoir plus tard des mécanismes dédiés (`avoir`, annulation, revalidation, journal d'audit`) au lieu d'une édition directe uniforme ;
 	- qu'a-t-on le droit de réécrire automatiquement lorsqu'un import `Comptabilité` vient clarifier une facture créée plus tôt depuis `Gestion`.
-- **Critère d'acceptation** : pour chaque grande famille d'objet métier, un utilisateur et un développeur peuvent répondre sans ambiguïté à la question "que se passe-t-il si je modifie cet objet maintenant ?".
+- **Critère d'acceptation** : pour chaque grande famille d'objets métier, un utilisateur et un développeur peuvent répondre sans ambiguïté à la question "que se passe-t-il si je modifie cet objet maintenant ?".
 - **Point d'attention** : la traçabilité et la cohérence comptable doivent primer sur la simplicité apparente d'une édition directe, y compris quand la modification vient d'un rapprochement automatique entre imports `Gestion` et `Comptabilité`.
 
 ## Prêt

--- a/doc/backlog.md
+++ b/doc/backlog.md
@@ -379,7 +379,7 @@ Tout sujet concret qui doit survivre au-delà de la séance en cours doit être 
 
 ### BL-029 — Saisie des factures clients pilotée par types de lignes
 
-- **Dates** : `created=2026-04-16`, `started=2026-04-16`, `completed=2026-04-16`
+- **Dates** : `created=2026-04-16`, `started=2026-04-16`
 - **Pourquoi** : le modèle actuel demande encore un label global de facture (`cs`, `a`, `cs+a`, `general`) alors que le besoin métier cible est plus fin : l'utilisateur pense d'abord en lignes de facture, chacune portant un type métier (`cours`, `adhésion`, `autres`), puis attend que Solde calcule le total et la ventilation comptable à partir de cette saisie ; les remises doivent rester visibles sur la facture mais être portées par des lignes négatives du même type métier, pas par une catégorie séparée. Le sous-sujet exploré auparavant comme `BL-028` est absorbé ici, car il n'est pas testable isolément sur `Gestion 2024` faute de détail source exploitable pour des factures mixtes.
 - **Résultat attendu** : une création de facture client où l'utilisateur saisit le client et les lignes, choisit un type par ligne, voit le total calculé automatiquement, et obtient à validation des écritures comptables dérivées de la composition réelle de la facture sans dépendre d'un label global saisi à la main.
 - **Règle métier cible actuellement privilégiée** :
@@ -404,6 +404,16 @@ Tout sujet concret qui doit survivre au-delà de la séance en cours doit être 
 	- quelle règle appliquer si une facture mélange `cours`, `adhésion` et `autres`, avec ou sans lignes négatives de remise.
 - **Critère d'acceptation** : un utilisateur peut créer une facture client complète sans se poser de question sur le label comptable global ; le total affiché correspond exactement aux lignes saisies et les écritures générées à validation reflètent cette décomposition ligne par ligne.
 - **Point d'attention** : l'import `Comptabilité` deviendrait alors non seulement un import d'écritures, mais aussi un mécanisme d'enrichissement métier des factures déjà créées ; il faudra l'encadrer par des règles de sûreté et de coexistence explicites.
+- **État d'avancement au 2026-04-16** : l'implémentation a été livrée sur la branche `feature/bl-029-factures-clients-par-lignes` et poussée dans la PR `#18` ; la recette utilisateur reste à faire.
+- **Implémenté dans ce lot** :
+	- ajout d'un type de ligne de facture client (`cours`, `adhésion`, `autres`) en base, API et logique métier ;
+	- calcul du total, du label dérivé et de la ventilation comptable directement à partir des lignes, avec support des remises via lignes négatives ;
+	- import `Gestion` revu pour créer systématiquement des lignes typées sans inventer de détail absent ;
+	- import `Comptabilité` revu pour clarifier de façon sûre une facture mixte existante quand les écritures permettent d'en déduire la ventilation ;
+	- formulaire frontend de facture client revu pour supprimer la saisie du label global et piloter la facture par types de lignes ;
+	- migration Alembic, tests backend/frontend et backlog mis à jour.
+- **Validation technique réalisée** : la suite `pytest tests/`, le `type-check` frontend, `eslint` ciblé et `prettier --check` sur les fichiers frontend touchés sont passés localement avant push.
+- **Prochaine étape** : recette métier utilisateur sur le scénario `Gestion 2024` puis `Comptabilité 2024`, avant clôture effective du ticket.
 
 ### BL-030 — Politique de modification des objets métier validés
 
@@ -427,10 +437,9 @@ Tout sujet concret qui doit survivre au-delà de la séance en cours doit être 
 
 - **BL-021** — `created=2026-04-13`, `started=2026-04-13` — Les lots 1 à 3 du manuel utilisateur sont livrés, mais le lot 4 reste à réaliser pour finaliser la stabilisation éditoriale et l'enrichissement visuel.
 - **BL-022** — `created=2026-04-13`, `started=2026-04-13` — Les lots 1 et 2 sont intégrés dans `develop` ; les lots suivants restent à traiter et le retest des droits réels a été traité séparément dans `BL-023`, désormais terminé.
+- **BL-029** — `created=2026-04-16`, `started=2026-04-16` — L'implémentation est poussée sur la PR `#18` avec lignes typées, import `Gestion`/`Comptabilité` adapté et UI revue ; la recette métier utilisateur reste à faire avant clôture.
 
 ## Fait
-
-- **BL-029** — `created=2026-04-16`, `started=2026-04-16`, `completed=2026-04-16` — Le ticket absorbe l'ancienne piste `BL-028` et livre maintenant la saisie client par lignes typées, la ventilation comptable dérivée de ces lignes et le cadrage d'import associé, y compris la clarification sûre depuis `Comptabilité` pour les factures mixtes importées depuis `Gestion`.
 
 - **BL-001** — `created=2026-04-12`, `completed=2026-04-12` — Le backlog sert désormais de support de suivi versionné avec priorités, statuts et mises à jour explicites.
 - **BL-002** — `created=2026-04-12`, `completed=2026-04-12` — La documentation utilisateur import/reset a été rédigée dans `doc/user/import-excel-et-reinitialisation.md`.

--- a/doc/backlog.md
+++ b/doc/backlog.md
@@ -23,6 +23,7 @@ Tout sujet concret qui doit survivre au-delà de la séance en cours doit être 
 5. Déplacer en **Fait** quand l'implémentation est livrée et considérée comme terminée côté backlog.
 6. Suivre les dates avec le format ISO (`YYYY-MM-DD`) : `created`, `started`, `completed`.
 7. Ne pas laisser de suite actionnable uniquement dans la conversation si elle doit être retrouvée plus tard.
+8. Dans chaque section qui liste des tickets, conserver l'ordre numérique croissant des identifiants `BL-xxx`.
 
 ### Signification des priorités
 
@@ -66,6 +67,8 @@ Tout sujet concret qui doit survivre au-delà de la séance en cours doit être 
 | BL-022 | 2026-04-13 | Évolution | Utilisateurs / Sécurité | P1 | Renforcer la gestion des utilisateurs avec des rôles métier plus clairs, la création et l'administration des comptes, l'autonomie sur le profil et un socle de sécurité de compte plus complet |
 | BL-024 | 2026-04-13 | Correction | Paiements / Banque | P1 | Clarifier le workflow cible de saisie des paiements et corriger l'automatisme qui remet en banque les paiements `espèces` et `virement` dès leur encodage |
 | BL-027 | 2026-04-15 | Évolution | Import Excel / Trésorerie | P1 | Gérer une ouverture du système explicite pour Banque et Caisse sur le premier exercice importé |
+| BL-029 | 2026-04-16 | Évolution | Factures clients / UX métier | P1 | Repenser la saisie et l'import des factures clients autour de lignes typées (`cours`, `adhésion`, `autres`), avec remises portées par des lignes négatives du même type métier, et faire de ces lignes la source de vérité pour le total et la ventilation comptable |
+| BL-030 | 2026-04-16 | Décision | Métier / Edition des données | P1 | Définir une politique explicite de modification des objets métier déjà créés ou validés (factures, paiements, achats, etc.) avec règles de recalcul, traçabilité et limites selon le statut |
 
 ## Détail des sujets
 
@@ -152,20 +155,6 @@ Tout sujet concret qui doit survivre au-delà de la séance en cours doit être 
 - **Critère d'acceptation** : on doit pouvoir répondre, sans rien persister, à quatre questions simples pour chacun des deux modes : qu'est-ce qui manque dans Solde, qu'est-ce qui est en trop, qu'est-ce qui diverge, et qu'est-ce qui est ignoré volontairement selon la politique métier.
 - **Hors périmètre initial** : pas de correction automatique des écarts, pas d'ouverture large de l'import `Comptabilite` en réel tant que `BL-005` n'est pas tranché, et pas d'outil générique de réconciliation déconnecté du cas de reprise réel.
 - **Enjeu** : sujet critique pour la confiance métier pendant toute la transition hors Excel.
-
-### BL-028 — Ventiler les factures clients mixtes `cs+a` comme dans la comptabilité Excel
-
-- **Dates** : `created=2026-04-16`, `started=2026-04-16`, `completed=2026-04-16`
-- **Pourquoi** : pendant `BL-026`, il apparaît que certaines factures clients historiques, comme `2024-0186`, sont ventilées dans Excel sur plusieurs comptes produits parce qu'elles mélangent des lignes de cours (`cs`) et d'adhésion (`a`). Aujourd'hui, Solde ne reproduit pas forcément cette ventilation fine, ce qui gêne le rapprochement comptable par compte et ne reflète pas totalement la réalité comptable attendue.
-- **Résultat attendu** : quand l'information source de `Gestion` permet d'identifier une facture mixte, Solde doit générer la même ventilation comptable par compte produit que celle attendue dans Excel, au lieu de s'appuyer uniquement sur un total global de facture.
-- **Périmètre initial** :
-	- identifier dans les données `Gestion` les signaux exploitables permettant de distinguer les composantes d'une facture mixte ;
-	- définir la règle comptable cible de ventilation par compte produit ;
-	- adapter la génération des écritures de factures clients pour refléter cette ventilation ;
-	- ajouter une couverture de tests ciblée sur au moins un cas réel de facture mixte.
-- **Critère d'acceptation** : sur un cas comme `2024-0186`, les écritures générées par Solde portent les mêmes montants sur les mêmes comptes produits que la comptabilité Excel de référence, sans casser les cas simples mono-produit.
-- **Point d'attention** : ce sujet est distinct de `BL-008` ; ici l'objectif est d'aligner le comportement comptable réel de Solde, pas seulement de mieux tolérer un écart dans l'outil de comparaison.
-- **Livré parce que** : l'import `Gestion` sait désormais exploiter des colonnes explicites `cours` / `adhésion` pour créer des lignes de facture sur les cas `cs+a`, et le moteur comptable ventile alors les produits sur `706110` et `756000` au lieu d'un seul produit global, avec couverture unitaire et d'intégration sur le cas type `2024-0186`.
 
 ### BL-009 — Enrichir le plan comptable par défaut à partir des imports réels
 
@@ -366,7 +355,7 @@ Tout sujet concret qui doit survivre au-delà de la séance en cours doit être 
 - **Dates** : `created=2026-04-15`, `started=2026-04-15`, `completed=2026-04-16`
 - **Pourquoi** : après la fiabilisation de la mécanique d'import, il faut maintenant confirmer sur le cas réel que les données visibles dans Solde correspondent bien aux fichiers Excel sources, aussi bien côté `Gestion` que côté `Comptabilité`, et cela sur les deux exercices historiques.
 - **Résultat attendu** : disposer d'une validation explicite, exercice par exercice, des chiffres importés dans Solde par rapport aux fichiers Excel `2024` et `2025`, avec une liste claire des écarts constatés ou la confirmation qu'il n'y en a pas.
-- **Résultat livré** : le cadrage de recette a été formalisé dans `doc/dev/bl-026-cadrage-validation-imports-excel.md` et un constat exploitable a été produit dans `doc/dev/bl-026-constat-validation-imports.md` pour l'exercice `2024`, avec distinction entre chiffres conformes, écarts justifiés de modélisation et sujets à corriger. Le ticket est clos comme ticket de constat et d'orientation ; la poursuite de la validation comptable stricte est désormais renvoyée vers `BL-008`, et l'alignement du comportement comptable attendu sur les factures clients mixtes vers `BL-028`.
+- **Résultat livré** : le cadrage de recette a été formalisé dans `doc/dev/bl-026-cadrage-validation-imports-excel.md` et un constat exploitable a été produit dans `doc/dev/bl-026-constat-validation-imports.md` pour l'exercice `2024`, avec distinction entre chiffres conformes, écarts justifiés de modélisation et sujets à corriger. Le ticket est clos comme ticket de constat et d'orientation ; la poursuite de la validation comptable stricte est désormais renvoyée vers `BL-008`, et l'alignement du comportement comptable attendu sur les factures clients mixtes vers `BL-029`.
 - **Périmètre minimal** :
 	- comparer les chiffres de `Gestion` visibles dans l'application avec ceux des fichiers Excel correspondants pour `2024` et `2025` ;
 	- comparer les chiffres de `Comptabilité` visibles dans l'application avec ceux des fichiers Excel correspondants pour `2024` et `2025` ;
@@ -388,6 +377,48 @@ Tout sujet concret qui doit survivre au-delà de la séance en cours doit être 
 - **Critère d'acceptation** : après import du plus ancien exercice, les écrans `Banque` et `Caisse` affichent un point de départ cohérent et identifié comme `ouverture du système`, les soldes des exercices suivants héritent correctement de ce point de départ sans doublon, et les chiffres `BL-026` peuvent être remesurés proprement pour la trésorerie.
 - **Point d'attention** : ce sujet doit être traité sur une branche distincte de `BL-026`, car il fera évoluer les chiffres de `Banque` et `Caisse` déjà relevés dans le constat de validation.
 
+### BL-029 — Saisie des factures clients pilotée par types de lignes
+
+- **Dates** : `created=2026-04-16`, `started=2026-04-16`
+- **Pourquoi** : le modèle actuel demande encore un label global de facture (`cs`, `a`, `cs+a`, `general`) alors que le besoin métier cible est plus fin : l'utilisateur pense d'abord en lignes de facture, chacune portant un type métier (`cours`, `adhésion`, `autres`), puis attend que Solde calcule le total et la ventilation comptable à partir de cette saisie ; les remises doivent rester visibles sur la facture mais être portées par des lignes négatives du même type métier, pas par une catégorie séparée. Le sous-sujet exploré auparavant comme `BL-028` est absorbé ici, car il n'est pas testable isolément sur `Gestion 2024` faute de détail source exploitable pour des factures mixtes.
+- **Résultat attendu** : une création de facture client où l'utilisateur saisit le client et les lignes, choisit un type par ligne, voit le total calculé automatiquement, et obtient à validation des écritures comptables dérivées de la composition réelle de la facture sans dépendre d'un label global saisi à la main.
+- **Règle métier cible actuellement privilégiée** :
+	- les seuls types de lignes métier exposés sont `cours`, `adhésion` et `autres` ;
+	- une remise est saisie comme une seconde ligne négative du même type métier que la ligne remisée ;
+	- le client voit toutes les lignes, y compris la remise, mais la ventilation comptable travaille sur le net agrégé par type métier ;
+	- une facture ne doit jamais aboutir à un total négatif.
+- **Conséquence de cadrage** :
+	- on ne garde plus de ticket autonome pour une ventilation `cs+a` dépendant d'un détail explicite dans `Gestion 2024` ;
+	- le travail utile déjà engagé sur la ventilation à partir des lignes de facture est poursuivi directement dans `BL-029` ;
+	- la logique future d'enrichissement a posteriori depuis `Comptabilité` reste traitée séparément dans `BL-030`.
+- **Comportement d'import cible** :
+	- import `Gestion` : si le libellé indique `cs`, créer une ligne `cours` ; s'il indique `a`, créer une ligne `adhésion` ; sinon créer une ligne `autres` ;
+	- import `Gestion` : ne pas inventer de remise ni de ventilation détaillée absente de la source ;
+	- import `Comptabilité` : quand une facture déjà présente porte une ligne `autres`, autoriser un enrichissement ou une clarification automatique de cette ligne si les comptes produits utilisés dans les écritures permettent une déduction sûre ;
+	- en cas de rapprochement ambigu entre `Gestion` et `Comptabilité`, ne rien réécrire silencieusement.
+- **Questions à trancher** :
+	- faut-il supprimer complètement le label global utilisateur au profit d'un calcul depuis les lignes ;
+	- comment modéliser les lignes `autres` côté comptable ;
+	- jusqu'où autoriser l'import `Comptabilité` à requalifier automatiquement une ligne `autres` ;
+	- quelle traçabilité garder entre ligne créée depuis `Gestion`, ligne enrichie via `Comptabilité` et ligne corrigée manuellement ;
+	- quelle règle appliquer si une facture mélange `cours`, `adhésion` et `autres`, avec ou sans lignes négatives de remise.
+- **Critère d'acceptation** : un utilisateur peut créer une facture client complète sans se poser de question sur le label comptable global ; le total affiché correspond exactement aux lignes saisies et les écritures générées à validation reflètent cette décomposition ligne par ligne.
+- **Point d'attention** : l'import `Comptabilité` deviendrait alors non seulement un import d'écritures, mais aussi un mécanisme d'enrichissement métier des factures déjà créées ; il faudra l'encadrer par des règles de sûreté et de coexistence explicites.
+
+### BL-030 — Politique de modification des objets métier validés
+
+- **Dates** : `created=2026-04-16`
+- **Pourquoi** : plusieurs objets métier ont déjà un cycle de vie implicite (`draft`, `sent`, `paid`, écritures auto-générées, imports historiques), mais la règle cible de modification reste floue dès qu'un objet a déjà produit des effets comptables ou des dépendances fonctionnelles.
+- **Résultat attendu** : une politique explicite qui dit, selon le type d'objet et son statut, ce qui est modifiable directement, ce qui doit régénérer des effets dérivés, ce qui doit être historisé, et ce qui doit être interdit ou remplacé par une opération métier distincte.
+- **Questions à trancher** :
+	- peut-on modifier librement une facture `draft`, `sent` ou `paid` ;
+	- faut-il régénérer, annuler puis recréer, ou historiser les écritures comptables dérivées après modification ;
+	- quelle différence de traitement entre correction mineure, changement de montant et annulation métier ;
+	- faut-il prévoir plus tard des mécanismes dédiés (`avoir`, annulation, revalidation, journal d'audit`) au lieu d'une édition directe uniforme ;
+	- qu'a-t-on le droit de réécrire automatiquement lorsqu'un import `Comptabilité` vient clarifier une facture créée plus tôt depuis `Gestion`.
+- **Critère d'acceptation** : pour chaque grande famille d'objet métier, un utilisateur et un développeur peuvent répondre sans ambiguïté à la question "que se passe-t-il si je modifie cet objet maintenant ?".
+- **Point d'attention** : la traçabilité et la cohérence comptable doivent primer sur la simplicité apparente d'une édition directe, y compris quand la modification vient d'un rapprochement automatique entre imports `Gestion` et `Comptabilité`.
+
 ## Prêt
 
 - Aucun sujet pour le moment.
@@ -396,6 +427,7 @@ Tout sujet concret qui doit survivre au-delà de la séance en cours doit être 
 
 - **BL-021** — `created=2026-04-13`, `started=2026-04-13` — Les lots 1 à 3 du manuel utilisateur sont livrés, mais le lot 4 reste à réaliser pour finaliser la stabilisation éditoriale et l'enrichissement visuel.
 - **BL-022** — `created=2026-04-13`, `started=2026-04-13` — Les lots 1 et 2 sont intégrés dans `develop` ; les lots suivants restent à traiter et le retest des droits réels a été traité séparément dans `BL-023`, désormais terminé.
+- **BL-029** — `created=2026-04-16`, `started=2026-04-16` — Le ticket absorbe l'ancienne piste `BL-028` et porte désormais le travail testable sur la création de factures clients pilotée par les lignes, la ventilation comptable dérivée de ces lignes et le cadrage d'import associé.
 
 ## Fait
 
@@ -405,14 +437,13 @@ Tout sujet concret qui doit survivre au-delà de la séance en cours doit être 
 - **BL-007** — `created=2026-04-12`, `completed=2026-04-13` — La convention est arrêtée pour le mode de travail actuel : `doc/backlog.md` reste la source de vérité, sans synchronisation systématique avec des issues GitHub à ce stade.
 - **BL-009** — `created=2026-04-12`, `completed=2026-04-12` — Le plan comptable par défaut a été enrichi à partir des comptes réellement rencontrés dans les imports historiques.
 - **BL-010** — `created=2026-04-12`, `completed=2026-04-12` — Une stratégie sûre de clôture administrative des exercices historiques importés a été définie et livrée.
-- **BL-025** — `created=2026-04-13`, `started=2026-04-13`, `completed=2026-04-13` — Le grand livre est maintenant borné à l'exercice choisi, sans option multi-exercices, avec un solde d'ouverture cohérent quand la période démarre en cours d'exercice.
 - **BL-011** — `created=2026-04-12`, `completed=2026-04-12` — L'exercice courant global et son sélecteur partagé ont été livrés sur les écrans comptables concernés.
+- **BL-012** — `created=2026-04-12`, `completed=2026-04-12` — La liste des paiements affiche la référence métier et permet l'édition directe.
+- **BL-013** — `created=2026-04-12`, `completed=2026-04-12` — Le journal de caisse propose désormais référence, détail et édition directe.
+- **BL-014** — `created=2026-04-12`, `completed=2026-04-12` — Le journal comptable est enrichi pour la lecture métier, le détail et la navigation vers les factures.
 - **BL-016** — `created=2026-04-13`, `started=2026-04-14`, `completed=2026-04-14` — Les microcopies et états visibles les plus incohérents ont été harmonisés sur `Banque`, `Caisse` et `Salaires` via des clés i18n dédiées.
 - **BL-017** — `created=2026-04-13`, `started=2026-04-14`, `completed=2026-04-14` — L'affichage des mois et périodes métier est maintenant uniformisé au format français sur `Salaires` et le `Dashboard` sans changer les formats d'échange ISO.
 - **BL-018** — `created=2026-04-13`, `started=2026-04-14`, `completed=2026-04-14` — Les écrans de liste principaux partagent maintenant un socle commun de tri, filtres et compteurs d'état, avec filtres de date FR/ISO et exclusion explicite des tableaux fixes `bilan` / `résultat`.
 - **BL-023** — `created=2026-04-13`, `started=2026-04-14`, `completed=2026-04-14` — Les rôles métier `Gestionnaire` / `Comptable` / `Administrateur` sont maintenant alignés entre docs, navigation, guards frontend et permissions backend, avec séparation visible `Gestion` / `Comptabilité` et couverture de test ciblée.
-- **BL-026** — `created=2026-04-15`, `started=2026-04-15`, `completed=2026-04-16` — Le ticket a livré un cadrage de recette et un constat exploitable sur la reprise `2024`, puis a été clos une fois les écarts résiduels requalifiés en différences de modélisation assumées ou en suites dédiées (`BL-008`, `BL-028`).
-- **BL-028** — `created=2026-04-16`, `started=2026-04-16`, `completed=2026-04-16` — Les factures clients mixtes `cs+a` sont désormais ventilées sur plusieurs comptes produits quand la feuille `Factures` fournit explicitement les composantes `cours` et `adhésion`, avec lignes de facture importées et génération comptable alignée sur la cible Excel.
-- **BL-012** — `created=2026-04-12`, `completed=2026-04-12` — La liste des paiements affiche la référence métier et permet l'édition directe.
-- **BL-013** — `created=2026-04-12`, `completed=2026-04-12` — Le journal de caisse propose désormais référence, détail et édition directe.
-- **BL-014** — `created=2026-04-12`, `completed=2026-04-12` — Le journal comptable est enrichi pour la lecture métier, le détail et la navigation vers les factures.
+- **BL-025** — `created=2026-04-13`, `started=2026-04-13`, `completed=2026-04-13` — Le grand livre est maintenant borné à l'exercice choisi, sans option multi-exercices, avec un solde d'ouverture cohérent quand la période démarre en cours d'exercice.
+- **BL-026** — `created=2026-04-15`, `started=2026-04-15`, `completed=2026-04-16` — Le ticket a livré un cadrage de recette et un constat exploitable sur la reprise `2024`, puis a été clos une fois les écarts résiduels requalifiés en différences de modélisation assumées ou en suites dédiées (`BL-008`, `BL-029`).

--- a/doc/backlog.md
+++ b/doc/backlog.md
@@ -66,7 +66,6 @@ Tout sujet concret qui doit survivre au-delà de la séance en cours doit être 
 | BL-022 | 2026-04-13 | Évolution | Utilisateurs / Sécurité | P1 | Renforcer la gestion des utilisateurs avec des rôles métier plus clairs, la création et l'administration des comptes, l'autonomie sur le profil et un socle de sécurité de compte plus complet |
 | BL-024 | 2026-04-13 | Correction | Paiements / Banque | P1 | Clarifier le workflow cible de saisie des paiements et corriger l'automatisme qui remet en banque les paiements `espèces` et `virement` dès leur encodage |
 | BL-027 | 2026-04-15 | Évolution | Import Excel / Trésorerie | P1 | Gérer une ouverture du système explicite pour Banque et Caisse sur le premier exercice importé |
-| BL-028 | 2026-04-16 | Correction | Comptabilité / Factures clients | P1 | Ventiler les factures clients mixtes de type `cs+a` sur les mêmes comptes produits que dans Excel quand l'information source le permet |
 
 ## Détail des sujets
 
@@ -156,7 +155,7 @@ Tout sujet concret qui doit survivre au-delà de la séance en cours doit être 
 
 ### BL-028 — Ventiler les factures clients mixtes `cs+a` comme dans la comptabilité Excel
 
-- **Dates** : `created=2026-04-16`
+- **Dates** : `created=2026-04-16`, `started=2026-04-16`, `completed=2026-04-16`
 - **Pourquoi** : pendant `BL-026`, il apparaît que certaines factures clients historiques, comme `2024-0186`, sont ventilées dans Excel sur plusieurs comptes produits parce qu'elles mélangent des lignes de cours (`cs`) et d'adhésion (`a`). Aujourd'hui, Solde ne reproduit pas forcément cette ventilation fine, ce qui gêne le rapprochement comptable par compte et ne reflète pas totalement la réalité comptable attendue.
 - **Résultat attendu** : quand l'information source de `Gestion` permet d'identifier une facture mixte, Solde doit générer la même ventilation comptable par compte produit que celle attendue dans Excel, au lieu de s'appuyer uniquement sur un total global de facture.
 - **Périmètre initial** :
@@ -166,6 +165,7 @@ Tout sujet concret qui doit survivre au-delà de la séance en cours doit être 
 	- ajouter une couverture de tests ciblée sur au moins un cas réel de facture mixte.
 - **Critère d'acceptation** : sur un cas comme `2024-0186`, les écritures générées par Solde portent les mêmes montants sur les mêmes comptes produits que la comptabilité Excel de référence, sans casser les cas simples mono-produit.
 - **Point d'attention** : ce sujet est distinct de `BL-008` ; ici l'objectif est d'aligner le comportement comptable réel de Solde, pas seulement de mieux tolérer un écart dans l'outil de comparaison.
+- **Livré parce que** : l'import `Gestion` sait désormais exploiter des colonnes explicites `cours` / `adhésion` pour créer des lignes de facture sur les cas `cs+a`, et le moteur comptable ventile alors les produits sur `706110` et `756000` au lieu d'un seul produit global, avec couverture unitaire et d'intégration sur le cas type `2024-0186`.
 
 ### BL-009 — Enrichir le plan comptable par défaut à partir des imports réels
 
@@ -412,6 +412,7 @@ Tout sujet concret qui doit survivre au-delà de la séance en cours doit être 
 - **BL-018** — `created=2026-04-13`, `started=2026-04-14`, `completed=2026-04-14` — Les écrans de liste principaux partagent maintenant un socle commun de tri, filtres et compteurs d'état, avec filtres de date FR/ISO et exclusion explicite des tableaux fixes `bilan` / `résultat`.
 - **BL-023** — `created=2026-04-13`, `started=2026-04-14`, `completed=2026-04-14` — Les rôles métier `Gestionnaire` / `Comptable` / `Administrateur` sont maintenant alignés entre docs, navigation, guards frontend et permissions backend, avec séparation visible `Gestion` / `Comptabilité` et couverture de test ciblée.
 - **BL-026** — `created=2026-04-15`, `started=2026-04-15`, `completed=2026-04-16` — Le ticket a livré un cadrage de recette et un constat exploitable sur la reprise `2024`, puis a été clos une fois les écarts résiduels requalifiés en différences de modélisation assumées ou en suites dédiées (`BL-008`, `BL-028`).
+- **BL-028** — `created=2026-04-16`, `started=2026-04-16`, `completed=2026-04-16` — Les factures clients mixtes `cs+a` sont désormais ventilées sur plusieurs comptes produits quand la feuille `Factures` fournit explicitement les composantes `cours` et `adhésion`, avec lignes de facture importées et génération comptable alignée sur la cible Excel.
 - **BL-012** — `created=2026-04-12`, `completed=2026-04-12` — La liste des paiements affiche la référence métier et permet l'édition directe.
 - **BL-013** — `created=2026-04-12`, `completed=2026-04-12` — Le journal de caisse propose désormais référence, détail et édition directe.
 - **BL-014** — `created=2026-04-12`, `completed=2026-04-12` — Le journal comptable est enrichi pour la lecture métier, le détail et la navigation vers les factures.

--- a/doc/backlog.md
+++ b/doc/backlog.md
@@ -379,7 +379,7 @@ Tout sujet concret qui doit survivre au-delà de la séance en cours doit être 
 
 ### BL-029 — Saisie des factures clients pilotée par types de lignes
 
-- **Dates** : `created=2026-04-16`, `started=2026-04-16`
+- **Dates** : `created=2026-04-16`, `started=2026-04-16`, `completed=2026-04-16`
 - **Pourquoi** : le modèle actuel demande encore un label global de facture (`cs`, `a`, `cs+a`, `general`) alors que le besoin métier cible est plus fin : l'utilisateur pense d'abord en lignes de facture, chacune portant un type métier (`cours`, `adhésion`, `autres`), puis attend que Solde calcule le total et la ventilation comptable à partir de cette saisie ; les remises doivent rester visibles sur la facture mais être portées par des lignes négatives du même type métier, pas par une catégorie séparée. Le sous-sujet exploré auparavant comme `BL-028` est absorbé ici, car il n'est pas testable isolément sur `Gestion 2024` faute de détail source exploitable pour des factures mixtes.
 - **Résultat attendu** : une création de facture client où l'utilisateur saisit le client et les lignes, choisit un type par ligne, voit le total calculé automatiquement, et obtient à validation des écritures comptables dérivées de la composition réelle de la facture sans dépendre d'un label global saisi à la main.
 - **Règle métier cible actuellement privilégiée** :
@@ -427,9 +427,10 @@ Tout sujet concret qui doit survivre au-delà de la séance en cours doit être 
 
 - **BL-021** — `created=2026-04-13`, `started=2026-04-13` — Les lots 1 à 3 du manuel utilisateur sont livrés, mais le lot 4 reste à réaliser pour finaliser la stabilisation éditoriale et l'enrichissement visuel.
 - **BL-022** — `created=2026-04-13`, `started=2026-04-13` — Les lots 1 et 2 sont intégrés dans `develop` ; les lots suivants restent à traiter et le retest des droits réels a été traité séparément dans `BL-023`, désormais terminé.
-- **BL-029** — `created=2026-04-16`, `started=2026-04-16` — Le ticket absorbe l'ancienne piste `BL-028` et porte désormais le travail testable sur la création de factures clients pilotée par les lignes, la ventilation comptable dérivée de ces lignes et le cadrage d'import associé.
 
 ## Fait
+
+- **BL-029** — `created=2026-04-16`, `started=2026-04-16`, `completed=2026-04-16` — Le ticket absorbe l'ancienne piste `BL-028` et livre maintenant la saisie client par lignes typées, la ventilation comptable dérivée de ces lignes et le cadrage d'import associé, y compris la clarification sûre depuis `Comptabilité` pour les factures mixtes importées depuis `Gestion`.
 
 - **BL-001** — `created=2026-04-12`, `completed=2026-04-12` — Le backlog sert désormais de support de suivi versionné avec priorités, statuts et mises à jour explicites.
 - **BL-002** — `created=2026-04-12`, `completed=2026-04-12` — La documentation utilisateur import/reset a été rédigée dans `doc/user/import-excel-et-reinitialisation.md`.

--- a/doc/dev/bl-026-constat-validation-imports.md
+++ b/doc/dev/bl-026-constat-validation-imports.md
@@ -71,7 +71,7 @@ Méthode de référence : `doc/dev/bl-026-cadrage-validation-imports-excel.md`.
 
 - Bornes de l'exercice dans Solde : `...`
 - Fichier(s) Excel de référence : `...`
-- Décision de clôture `BL-026` : `l'exercice 2025 n'est pas poursuivi dans ce ticket ; la suite de la validation stricte est reportée après cadrage de BL-008 et traitement des correctifs identifiés comme BL-028`
+- Décision de clôture `BL-026` : `l'exercice 2025 n'est pas poursuivi dans ce ticket ; la suite de la validation stricte est reportée après cadrage de BL-008 et traitement des correctifs identifiés comme BL-029`
 
 | Domaine | Chiffres Excel | Chiffres Solde | Statut | Commentaire |
 |---|---|---|---|---|
@@ -96,6 +96,6 @@ Méthode de référence : `doc/dev/bl-026-cadrage-validation-imports-excel.md`.
 
 - Niveau de confiance sur la reprise `Gestion` : `élevé sur l'exercice 2024 pour les chiffres métier visibles : factures fournisseurs, paiements, banque et caisse sont conformes ou justifiés ; la validation 2025 reste à faire et certains points de convention métier demeurent ouverts côté factures clients et salaires`
 - Niveau de confiance sur la reprise `Comptabilité` : `moyen à bon sur l'exercice 2024 : les états principaux sont cohérents et les écarts résiduels identifiés relèvent en partie de différences de modélisation entre Excel et Solde ; la validation 2025 n'est pas poursuivie dans BL-026 et la règle de comparaison comptable cible doit encore être figée`
-- Écarts bloquants : `aucun écart bloquant démontré à ce stade sur la reprise 2024 ; en revanche, il n'existe pas encore de convention de rapprochement assez explicite pour conclure à une convergence comptable brute Excel = Solde sur le journal final, ce qui motive la bascule vers BL-008 et BL-028`
+- Écarts bloquants : `aucun écart bloquant démontré à ce stade sur la reprise 2024 ; en revanche, il n'existe pas encore de convention de rapprochement assez explicite pour conclure à une convergence comptable brute Excel = Solde sur le journal final, ce qui motive la bascule vers BL-008 et BL-029`
 - Écarts non bloquants : `montant en retard client dépendant de la convention UI (`due_date` / `overdue`) ; trésorerie 2024 nécessitant l'intégration de l'ouverture du système hors fichier ; comparaison comptable 2024 sensible à des différences de granularité (facture fournisseur + règlement dans Solde vs paiement direct dans Excel, ventilation produit côté clients, regroupements salariaux)`
-- Sujets à transformer en correctifs distincts : `BL-028 pour la ventilation comptable des factures clients mixtes de type cs+a ; BL-008 pour un mode de validation itérative distinguant convergence globale et validation du moteur Gestion ; éventuellement un sujet dédié si la convention d'affichage du passif au Bilan doit être revue ; la validation future de 2025 devra être reprise dans ce nouveau cadre plutôt que prolongée telle quelle dans BL-026`
+- Sujets à transformer en correctifs distincts : `BL-029 pour la saisie et la ventilation des factures clients pilotées par les lignes, y compris le cas des factures mixtes ; BL-008 pour un mode de validation itérative distinguant convergence globale et validation du moteur Gestion ; éventuellement un sujet dédié si la convention d'affichage du passif au Bilan doit être revue ; la validation future de 2025 devra être reprise dans ce nouveau cadre plutôt que prolongée telle quelle dans BL-026`

--- a/frontend/src/api/accounting.ts
+++ b/frontend/src/api/accounting.ts
@@ -568,14 +568,18 @@ export interface TestImportShortcut {
 export async function importGestionFileApi(file: File): Promise<ImportResult> {
   const form = new FormData()
   form.append('file', file)
-  const response = await apiClient.post<ImportResult>('/api/import/excel/gestion', form)
+  const response = await apiClient.post<ImportResult>('/api/import/excel/gestion', form, {
+    timeout: 120000,
+  })
   return response.data
 }
 
 export async function importComptabiliteFileApi(file: File): Promise<ImportResult> {
   const form = new FormData()
   form.append('file', file)
-  const response = await apiClient.post<ImportResult>('/api/import/excel/comptabilite', form)
+  const response = await apiClient.post<ImportResult>('/api/import/excel/comptabilite', form, {
+    timeout: 120000,
+  })
   return response.data
 }
 
@@ -760,7 +764,9 @@ export interface PreviewResult {
 export async function previewGestionFileApi(file: File): Promise<PreviewResult> {
   const form = new FormData()
   form.append('file', file)
-  const response = await apiClient.post<PreviewResult>('/api/import/excel/gestion/preview', form)
+  const response = await apiClient.post<PreviewResult>('/api/import/excel/gestion/preview', form, {
+    timeout: 60000,
+  })
   return response.data
 }
 
@@ -770,6 +776,9 @@ export async function previewComptabiliteFileApi(file: File): Promise<PreviewRes
   const response = await apiClient.post<PreviewResult>(
     '/api/import/excel/comptabilite/preview',
     form,
+    {
+      timeout: 60000,
+    },
   )
   return response.data
 }

--- a/frontend/src/api/invoices.ts
+++ b/frontend/src/api/invoices.ts
@@ -2,12 +2,14 @@ import apiClient from './client'
 
 export type InvoiceType = 'client' | 'fournisseur'
 export type InvoiceLabel = 'cs' | 'a' | 'cs+a' | 'general'
+export type InvoiceLineType = 'cours' | 'adhesion' | 'autres'
 export type InvoiceStatus = 'draft' | 'sent' | 'paid' | 'partial' | 'overdue' | 'disputed'
 
 export interface InvoiceLine {
   id: number
   invoice_id: number
   description: string
+  line_type: InvoiceLineType | null
   quantity: string
   unit_price: string
   amount: string
@@ -15,6 +17,7 @@ export interface InvoiceLine {
 
 export interface InvoiceLineCreate {
   description: string
+  line_type?: InvoiceLineType | null
   quantity?: string
   unit_price?: string
 }

--- a/frontend/src/components/ClientInvoiceForm.vue
+++ b/frontend/src/components/ClientInvoiceForm.vue
@@ -38,23 +38,9 @@
           </div>
         </div>
 
-        <div class="app-form-grid">
-          <div class="app-field">
-            <label class="app-field__label">{{ t('invoices.label') }}</label>
-            <Select
-              v-model="form.label"
-              :options="labelOptions"
-              option-label="label"
-              option-value="value"
-              :placeholder="t('invoices.label_placeholder')"
-              show-clear
-              class="w-full"
-            />
-          </div>
-          <div class="app-field">
-            <label class="app-field__label">{{ t('invoices.description') }}</label>
-            <InputText v-model="form.description" class="w-full" />
-          </div>
+        <div class="app-field">
+          <label class="app-field__label">{{ t('invoices.description') }}</label>
+          <InputText v-model="form.description" class="w-full" />
         </div>
       </div>
     </section>
@@ -76,6 +62,15 @@
         />
       </div>
       <div v-for="(line, idx) in form.lines" :key="idx" class="invoice-form__line-row">
+        <Select
+          v-model="line.line_type"
+          :options="lineTypeOptions"
+          option-label="label"
+          option-value="value"
+          :placeholder="t('invoices.client.line_type')"
+          class="invoice-form__type"
+          @update:model-value="onLineTypeChange(line)"
+        />
         <InputText
           v-model="line.description"
           :placeholder="t('invoices.line_description')"
@@ -91,7 +86,6 @@
         <InputNumber
           v-model="line.unit_price"
           :placeholder="t('invoices.line_price')"
-          :min="0"
           :max-fraction-digits="2"
           class="invoice-form__price"
           suffix=" €"
@@ -107,6 +101,9 @@
         />
       </div>
       <div class="invoice-form__grand-total">{{ t('invoices.total') }}: {{ computedTotal }} €</div>
+      <p v-if="hasNegativeTotal" class="invoice-form__error">
+        {{ t('invoices.client.negative_total_error') }}
+      </p>
     </section>
 
     <div class="app-form-actions">
@@ -117,7 +114,7 @@
         outlined
         @click="emit('cancel')"
       />
-      <Button :label="t('common.save')" type="submit" :loading="saving" />
+      <Button :label="t('common.save')" type="submit" :loading="saving" :disabled="saveDisabled" />
     </div>
   </form>
 </template>
@@ -133,7 +130,12 @@ import { computed, onMounted, reactive, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import type { Contact } from '../api/contacts'
-import { createInvoiceApi, updateInvoiceApi, type Invoice } from '../api/invoices'
+import {
+  createInvoiceApi,
+  updateInvoiceApi,
+  type Invoice,
+  type InvoiceLineType,
+} from '../api/invoices'
 
 const props = defineProps<{
   invoice: Invoice | null
@@ -150,6 +152,7 @@ const saving = ref(false)
 const isEditing = computed(() => props.invoice !== null)
 
 interface LineForm {
+  line_type: InvoiceLineType | null
   description: string
   quantity: number
   unit_price: number
@@ -159,7 +162,6 @@ interface FormState {
   contact_id: number | null
   date: Date | null
   due_date: Date | null
-  label: string | null
   description: string
   lines: LineForm[]
 }
@@ -168,17 +170,21 @@ const form = reactive<FormState>({
   contact_id: null,
   date: null,
   due_date: null,
-  label: null,
   description: '',
   lines: [],
 })
 
-const labelOptions = [
-  { label: t('invoices.labels.cs'), value: 'cs' },
-  { label: t('invoices.labels.a'), value: 'a' },
-  { label: 'invoices.labels.cs_a', value: 'cs+a' },
-  { label: t('invoices.labels.general'), value: 'general' },
+const lineTypeOptions = [
+  { label: t('invoices.client.line_types.cours'), value: 'cours' },
+  { label: t('invoices.client.line_types.adhesion'), value: 'adhesion' },
+  { label: t('invoices.client.line_types.autres'), value: 'autres' },
 ]
+
+const defaultLineDescriptions: Record<InvoiceLineType, string> = {
+  cours: 'Cours de soutien',
+  adhesion: 'Adhesion annuelle',
+  autres: 'Autres prestations',
+}
 
 function lineAmount(line: LineForm): string {
   return ((line.quantity || 0) * (line.unit_price || 0)).toFixed(2)
@@ -188,8 +194,48 @@ const computedTotal = computed(() =>
   form.lines.reduce((sum, l) => sum + (l.quantity || 0) * (l.unit_price || 0), 0).toFixed(2),
 )
 
+const hasNegativeTotal = computed(
+  () => form.lines.reduce((sum, l) => sum + (l.quantity || 0) * (l.unit_price || 0), 0) < 0,
+)
+
+const saveDisabled = computed(
+  () =>
+    saving.value ||
+    !form.contact_id ||
+    !form.date ||
+    form.lines.length === 0 ||
+    hasNegativeTotal.value ||
+    form.lines.some((line) => !line.description.trim() || !line.line_type),
+)
+
+function inferLineType(description: string, label: Invoice['label']): InvoiceLineType {
+  const normalizedDescription = description.toLocaleLowerCase('fr-FR')
+  if (normalizedDescription.includes('adhesion')) return 'adhesion'
+  if (normalizedDescription.includes('cours') || normalizedDescription.includes('soutien')) {
+    return 'cours'
+  }
+  if (label === 'cs') return 'cours'
+  if (label === 'a') return 'adhesion'
+  return 'autres'
+}
+
+function onLineTypeChange(line: LineForm) {
+  if (!line.line_type) return
+  if (
+    !line.description.trim() ||
+    Object.values(defaultLineDescriptions).includes(line.description)
+  ) {
+    line.description = defaultLineDescriptions[line.line_type]
+  }
+}
+
 function addLine() {
-  form.lines.push({ description: '', quantity: 1, unit_price: 0 })
+  form.lines.push({
+    line_type: 'cours',
+    description: 'Cours de soutien',
+    quantity: 1,
+    unit_price: 0,
+  })
 }
 
 function removeLine(idx: number) {
@@ -200,7 +246,6 @@ function resetForm() {
   form.contact_id = null
   form.date = null
   form.due_date = null
-  form.label = null
   form.description = ''
   form.lines = []
 }
@@ -209,9 +254,9 @@ function setFromInvoice(inv: Invoice) {
   form.contact_id = inv.contact_id
   form.date = new Date(inv.date)
   form.due_date = inv.due_date ? new Date(inv.due_date) : null
-  form.label = inv.label
   form.description = inv.description ?? ''
   form.lines = inv.lines.map((l) => ({
+    line_type: l.line_type ?? inferLineType(l.description, inv.label),
     description: l.description,
     quantity: parseFloat(l.quantity),
     unit_price: parseFloat(l.unit_price),
@@ -222,7 +267,10 @@ watch(
   () => props.invoice,
   (inv) => {
     if (inv) setFromInvoice(inv)
-    else resetForm()
+    else {
+      resetForm()
+      addLine()
+    }
   },
   { immediate: true },
 )
@@ -240,10 +288,10 @@ async function submit() {
       contact_id: form.contact_id,
       date: formatDate(form.date),
       due_date: form.due_date ? formatDate(form.due_date) : null,
-      label: (form.label as Invoice['label']) ?? null,
       description: form.description || null,
       lines: form.lines.map((l) => ({
         description: l.description,
+        line_type: l.line_type,
         quantity: String(l.quantity),
         unit_price: String(l.unit_price),
       })),
@@ -293,11 +341,12 @@ onMounted(() => {
 
 .invoice-form__line-row {
   display: grid;
-  grid-template-columns: minmax(0, 1.8fr) 110px 140px 110px auto;
+  grid-template-columns: 160px minmax(0, 1.6fr) 110px 140px 110px auto;
   gap: var(--app-space-3);
   align-items: center;
 }
 
+.invoice-form__type,
 .invoice-form__description,
 .invoice-form__quantity,
 .invoice-form__price {
@@ -316,6 +365,11 @@ onMounted(() => {
   font-size: 1rem;
   font-weight: 800;
   font-variant-numeric: tabular-nums;
+}
+
+.invoice-form__error {
+  color: var(--p-red-600);
+  font-size: 0.92rem;
 }
 
 @media (max-width: 900px) {

--- a/frontend/src/components/ClientInvoiceForm.vue
+++ b/frontend/src/components/ClientInvoiceForm.vue
@@ -17,8 +17,8 @@
           <label class="app-field__label">{{ t('invoices.contact') }}</label>
           <Select
             v-model="form.contact_id"
-            :options="contacts"
-            option-label="nom"
+            :options="contactOptions"
+            option-label="displayName"
             option-value="id"
             :placeholder="t('invoices.contact_placeholder')"
             filter
@@ -97,6 +97,7 @@
           severity="danger"
           text
           type="button"
+          class="invoice-form__remove"
           @click="removeLine(idx)"
         />
       </div>
@@ -136,6 +137,7 @@ import {
   type Invoice,
   type InvoiceLineType,
 } from '../api/invoices'
+import { formatContactDisplayName } from '../utils/contact'
 
 const props = defineProps<{
   invoice: Invoice | null
@@ -179,6 +181,13 @@ const lineTypeOptions = [
   { label: t('invoices.client.line_types.adhesion'), value: 'adhesion' },
   { label: t('invoices.client.line_types.autres'), value: 'autres' },
 ]
+
+const contactOptions = computed(() =>
+  props.contacts.map((contact) => ({
+    ...contact,
+    displayName: formatContactDisplayName(contact),
+  })),
+)
 
 const defaultLineDescriptions: Record<InvoiceLineType, string> = {
   cours: 'Cours de soutien',
@@ -341,9 +350,16 @@ onMounted(() => {
 
 .invoice-form__line-row {
   display: grid;
-  grid-template-columns: 160px minmax(0, 1.6fr) 110px 140px 110px auto;
+  grid-template-columns:
+    minmax(8.5rem, 1.05fr) minmax(0, 1.8fr) minmax(5.5rem, 0.7fr) minmax(7rem, 0.9fr)
+    minmax(6.5rem, 0.75fr) auto;
+  grid-template-areas: 'type description quantity price total remove';
   gap: var(--app-space-3);
   align-items: center;
+}
+
+.invoice-form__line-row > * {
+  min-width: 0;
 }
 
 .invoice-form__type,
@@ -353,11 +369,41 @@ onMounted(() => {
   width: 100%;
 }
 
+.invoice-form__type {
+  grid-area: type;
+}
+
+.invoice-form__description {
+  grid-area: description;
+}
+
+.invoice-form__quantity {
+  grid-area: quantity;
+}
+
+.invoice-form__price {
+  grid-area: price;
+}
+
+.invoice-form__line-row :deep(.p-select),
+.invoice-form__line-row :deep(.p-inputtext),
+.invoice-form__line-row :deep(.p-inputnumber),
+.invoice-form__line-row :deep(.p-inputnumber-input) {
+  width: 100%;
+  min-width: 0;
+}
+
 .invoice-form__total {
+  grid-area: total;
   text-align: right;
   font-size: 0.95rem;
   font-weight: 700;
   font-variant-numeric: tabular-nums;
+}
+
+.invoice-form__remove {
+  grid-area: remove;
+  justify-self: end;
 }
 
 .invoice-form__grand-total {
@@ -372,14 +418,39 @@ onMounted(() => {
   font-size: 0.92rem;
 }
 
-@media (max-width: 900px) {
+@media (max-width: 1080px) {
+  .invoice-form__line-row {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    grid-template-areas:
+      'type description description remove'
+      'quantity price total remove';
+    align-items: start;
+  }
+
+  .invoice-form__remove {
+    align-self: center;
+  }
+}
+
+@media (max-width: 700px) {
   .invoice-form__line-row {
     grid-template-columns: 1fr;
+    grid-template-areas:
+      'type'
+      'description'
+      'quantity'
+      'price'
+      'total'
+      'remove';
   }
 
   .invoice-form__total,
   .invoice-form__grand-total {
     text-align: left;
+  }
+
+  .invoice-form__remove {
+    justify-self: start;
   }
 }
 </style>

--- a/frontend/src/components/SupplierInvoiceForm.vue
+++ b/frontend/src/components/SupplierInvoiceForm.vue
@@ -19,8 +19,8 @@
           <label class="app-field__label">{{ t('invoices.contact') }}</label>
           <Select
             v-model="form.contact_id"
-            :options="contacts"
-            option-label="nom"
+            :options="contactOptions"
+            option-label="displayName"
             option-value="id"
             :placeholder="t('invoices.contact_placeholder')"
             filter
@@ -100,6 +100,7 @@ import { useI18n } from 'vue-i18n'
 
 import type { Contact } from '../api/contacts'
 import { createInvoiceApi, updateInvoiceApi, type Invoice } from '../api/invoices'
+import { formatContactDisplayName } from '../utils/contact'
 
 const props = defineProps<{
   invoice: Invoice | null
@@ -132,6 +133,13 @@ const form = reactive<FormState>({
   total_amount: null,
   description: '',
 })
+
+const contactOptions = computed(() =>
+  props.contacts.map((contact) => ({
+    ...contact,
+    displayName: formatContactDisplayName(contact),
+  })),
+)
 
 function resetForm() {
   form.contact_id = null

--- a/frontend/src/i18n/fr.ts
+++ b/frontend/src/i18n/fr.ts
@@ -855,6 +855,8 @@ export default {
     result_persistent_hint:
       '{count} élément(s) créé(s), {ignored} ligne(s) ignorée(s) et {blocked} ligne(s) bloquantes. Le détail complet reste affiché ci-dessous.',
     file_required: 'Veuillez sélectionner un fichier.',
+    request_timeout:
+      'L’import prend plus de temps que prévu. Le traitement a peut-être continué côté serveur ; vérifiez le résultat puis relancez si nécessaire.',
     result_sheets_title: 'Détail par feuille',
     sheet_ignored_rows: '{count} ligne(s) ignorée(s)',
     sheet_blocked_rows: '{count} ligne(s) bloquante(s)',

--- a/frontend/src/i18n/fr.ts
+++ b/frontend/src/i18n/fr.ts
@@ -240,10 +240,17 @@ export default {
         'Ajustez la facture sans perdre la lisibilité des lignes et des montants déjà préparés.',
       identity_title: 'Cadre de facturation',
       identity_subtitle:
-        'Choisissez le contact, les dates et le type de facture avant de détailler les lignes.',
+        'Choisissez le contact et les dates, puis laissez la composition de la facture se déduire des lignes.',
       lines_title: 'Détail des lignes',
       lines_subtitle:
-        'Chaque ligne doit rester lisible pour faciliter la relecture, l’envoi et le suivi du paiement.',
+        'Chaque ligne porte un type métier ; une remise reste visible via une ligne négative du même type.',
+      line_type: 'Type de ligne',
+      line_types: {
+        cours: 'Cours',
+        adhesion: 'Adhésion',
+        autres: 'Autres',
+      },
+      negative_total_error: 'Le total de la facture client ne peut pas être négatif.',
       history_intro:
         'Retrouvez rapidement le niveau d’encaissement et l’historique des règlements associés à cette facture.',
     },

--- a/frontend/src/utils/contact.ts
+++ b/frontend/src/utils/contact.ts
@@ -1,0 +1,12 @@
+export interface ContactNameLike {
+  nom: string | null | undefined
+  prenom?: string | null | undefined
+}
+
+export function formatContactDisplayName(contact: ContactNameLike): string {
+  const firstName = typeof contact.prenom === 'string' ? contact.prenom.trim() : ''
+  const lastName =
+    typeof contact.nom === 'string' ? contact.nom.trim().toLocaleUpperCase('fr-FR') : ''
+
+  return [firstName, lastName].filter((value) => value.length > 0).join(' ')
+}

--- a/frontend/src/views/ClientInvoicesView.vue
+++ b/frontend/src/views/ClientInvoicesView.vue
@@ -449,6 +449,7 @@ import {
   findSelectedFilterLabel,
 } from '../composables/activeFilterLabels'
 import { useFiscalYearStore } from '../stores/fiscalYear'
+import { formatContactDisplayName } from '../utils/contact'
 import { formatDisplayDate } from '@/utils/format'
 
 const { t } = useI18n()
@@ -579,7 +580,7 @@ function formatAmount(val: string | number) {
 function contactName(id: number): string {
   const c = contacts.value.find((c) => c.id === id)
   if (!c) return String(id)
-  return c.prenom ? `${c.prenom} ${c.nom}` : c.nom
+  return formatContactDisplayName(c)
 }
 
 function statusSeverity(s: InvoiceStatus): string {

--- a/frontend/src/views/ImportExcelView.vue
+++ b/frontend/src/views/ImportExcelView.vue
@@ -527,6 +527,28 @@ function onFileChange(event: Event) {
   resetImportFlow()
 }
 
+function getImportErrorSummary(error: unknown): string {
+  const responseData = (error as { response?: { data?: unknown } }).response?.data
+  const detail =
+    responseData && typeof responseData === 'object'
+      ? (responseData as { detail?: unknown }).detail
+      : undefined
+  if (typeof detail === 'string' && detail.trim()) {
+    return detail
+  }
+
+  if ((error as { code?: string }).code === 'ECONNABORTED') {
+    return t('import.request_timeout')
+  }
+
+  const message = (error as { message?: unknown }).message
+  if (typeof message === 'string' && message.trim()) {
+    return message
+  }
+
+  return t('common.error.unknown')
+}
+
 async function loadTestShortcuts() {
   try {
     testShortcuts.value = (await listTestImportShortcutsApi()).sort(
@@ -553,8 +575,8 @@ async function doPreview() {
     } else {
       preview.value = await previewComptabiliteFileApi(selectedFile.value)
     }
-  } catch {
-    toast.add({ severity: 'error', summary: t('common.error.unknown'), life: 4000 })
+  } catch (error: unknown) {
+    toast.add({ severity: 'error', summary: getImportErrorSummary(error), life: 5000 })
   } finally {
     previewing.value = false
   }
@@ -591,8 +613,8 @@ async function doImport() {
       summary: hasIssues ? t('import.completed_with_issues') : t('import.success'),
       life: 3500,
     })
-  } catch {
-    toast.add({ severity: 'error', summary: t('common.error.unknown'), life: 4000 })
+  } catch (error: unknown) {
+    toast.add({ severity: 'error', summary: getImportErrorSummary(error), life: 5000 })
   } finally {
     importing.value = false
   }

--- a/frontend/src/views/SupplierInvoicesView.vue
+++ b/frontend/src/views/SupplierInvoicesView.vue
@@ -338,6 +338,7 @@ import {
   findSelectedFilterLabel,
 } from '../composables/activeFilterLabels'
 import { useFiscalYearStore } from '../stores/fiscalYear'
+import { formatContactDisplayName } from '../utils/contact'
 import { formatDisplayDate } from '@/utils/format'
 
 const { t } = useI18n()
@@ -433,7 +434,7 @@ function formatAmount(val: string | number) {
 function contactName(id: number): string {
   const c = contacts.value.find((c) => c.id === id)
   if (!c) return String(id)
-  return c.prenom ? `${c.prenom} ${c.nom}` : c.nom
+  return formatContactDisplayName(c)
 }
 
 function statusSeverity(s: InvoiceStatus): string {

--- a/tests/integration/test_import_api.py
+++ b/tests/integration/test_import_api.py
@@ -359,6 +359,89 @@ async def test_preview_and_import_gestion_accept_payment_matched_by_contact(
 
 @pytest.mark.asyncio
 @pytest.mark.skipif(not OPENPYXL_AVAILABLE, reason="openpyxl not installed")
+async def test_import_gestion_splits_cs_a_invoice_when_component_columns_exist(
+    client: AsyncClient,
+    auth_headers: dict,
+    db_session,
+) -> None:
+    from sqlalchemy.orm import selectinload
+
+    from backend.models.accounting_entry import AccountingEntry, EntrySourceType
+    from backend.models.invoice import Invoice
+    from backend.services.accounting_engine import seed_default_rules
+
+    await seed_default_rules(db_session)
+
+    content = _make_multi_sheet_xlsx(
+        {
+            "Factures": (
+                [
+                    "Date facture",
+                    "Réf facture",
+                    "Client",
+                    "Montant",
+                    "Montant cours",
+                    "Montant adhésion",
+                    "Type",
+                ],
+                [["2024-08-26", "2024-0186", "Alexandre ELEZI", 160, 130, 30, "cs+a"]],
+            ),
+        }
+    )
+
+    import_response = await client.post(
+        "/api/import/excel/gestion",
+        files={"file": ("Gestion 2024.xlsx", content, _XLSX_MIME)},
+        headers=auth_headers,
+    )
+
+    assert import_response.status_code == 200
+    import_data = import_response.json()
+    assert import_data["invoices_created"] == 1
+    assert import_data["entries_created"] == 3
+
+    invoice = (
+        (
+            await db_session.execute(
+                select(Invoice)
+                .where(Invoice.number == "2024-0186")
+                .options(selectinload(Invoice.lines))
+            )
+        )
+        .scalars()
+        .one()
+    )
+    assert [(line.description, line.amount) for line in invoice.lines] == [
+        ("Cours de soutien", Decimal("130.00")),
+        ("Adhesion annuelle", Decimal("30.00")),
+    ]
+
+    entries = (
+        (
+            await db_session.execute(
+                select(AccountingEntry)
+                .where(AccountingEntry.source_type == EntrySourceType.INVOICE)
+                .where(AccountingEntry.source_id == invoice.id)
+                .order_by(AccountingEntry.entry_number.asc())
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(entries) == 3
+    assert any(
+        entry.account_number == "411100" and entry.debit == Decimal("160.00") for entry in entries
+    )
+    assert any(
+        entry.account_number == "706110" and entry.credit == Decimal("130.00") for entry in entries
+    )
+    assert any(
+        entry.account_number == "756000" and entry.credit == Decimal("30.00") for entry in entries
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not OPENPYXL_AVAILABLE, reason="openpyxl not installed")
 async def test_preview_and_import_gestion_create_supplier_invoice_and_payment_from_bank_row(
     client: AsyncClient,
     auth_headers: dict,

--- a/tests/integration/test_import_api.py
+++ b/tests/integration/test_import_api.py
@@ -508,8 +508,7 @@ async def test_import_gestion_maps_mixed_client_invoice_to_other_line_when_no_sp
     )
     assert len(entries) == 2
     assert any(
-        entry.account_number == "758000" and entry.credit == Decimal("100.00")
-        for entry in entries
+        entry.account_number == "758000" and entry.credit == Decimal("100.00") for entry in entries
     )
 
 
@@ -3150,6 +3149,69 @@ async def test_preview_comptabilite_ignores_journal_saisie(
     assert sheets["Journal"]["status"] == "recognized"
     assert sheets["Journal (saisie)"]["status"] == "ignored"
     assert any("Journal (saisie)" in warning for warning in data["warnings"])
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not OPENPYXL_AVAILABLE, reason="openpyxl not installed")
+async def test_preview_comptabilite_ignores_existing_generated_group(
+    client: AsyncClient,
+    auth_headers: dict,
+    db_session,
+) -> None:
+    from backend.models.accounting_entry import AccountingEntry, EntrySourceType
+
+    db_session.add_all(
+        [
+            AccountingEntry(
+                entry_number="000001",
+                date=date(2025, 8, 1),
+                account_number="658000",
+                label="Frais divers",
+                debit=Decimal("10.00"),
+                credit=Decimal("0.00"),
+                source_type=EntrySourceType.GESTION,
+                source_id=1,
+                group_key="gestion:1",
+            ),
+            AccountingEntry(
+                entry_number="000002",
+                date=date(2025, 8, 1),
+                account_number="512000",
+                label="Frais divers",
+                debit=Decimal("0.00"),
+                credit=Decimal("10.00"),
+                source_type=EntrySourceType.GESTION,
+                source_id=1,
+                group_key="gestion:1",
+            ),
+        ]
+    )
+    await db_session.commit()
+
+    content = _make_multi_sheet_xlsx(
+        {
+            "Journal": (
+                ["Date", "N° compte", "Libellé de l'écriture", "Débit", "Crédit", "ChangeNum"],
+                [
+                    ["2025-08-01", "658000", "Frais divers", 10, None, 1],
+                    ["2025-08-01", "512000", "Frais divers", None, 10, 1],
+                ],
+            ),
+        }
+    )
+
+    response = await client.post(
+        "/api/import/excel/comptabilite/preview",
+        files={"file": ("Comptabilite 2025.xlsx", content, _XLSX_MIME)},
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["estimated_entries"] == 0
+    assert data["can_import"] is True
+    journal_sheet = next(sheet for sheet in data["sheets"] if sheet["name"] == "Journal")
+    assert journal_sheet["ignored_rows"] == 2
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_import_api.py
+++ b/tests/integration/test_import_api.py
@@ -367,7 +367,7 @@ async def test_import_gestion_splits_cs_a_invoice_when_component_columns_exist(
     from sqlalchemy.orm import selectinload
 
     from backend.models.accounting_entry import AccountingEntry, EntrySourceType
-    from backend.models.invoice import Invoice
+    from backend.models.invoice import Invoice, InvoiceLabel, InvoiceLineType
     from backend.services.accounting_engine import seed_default_rules
 
     await seed_default_rules(db_session)
@@ -411,11 +411,12 @@ async def test_import_gestion_splits_cs_a_invoice_when_component_columns_exist(
         .scalars()
         .one()
     )
-    assert [(line.description, line.amount) for line in invoice.lines] == [
-        ("Cours de soutien", Decimal("130.00")),
-        ("Adhesion annuelle", Decimal("30.00")),
+    assert [(line.description, line.line_type, line.amount) for line in invoice.lines] == [
+        ("Cours de soutien", InvoiceLineType.COURSE, Decimal("130.00")),
+        ("Adhesion annuelle", InvoiceLineType.ADHESION, Decimal("30.00")),
     ]
     assert invoice.has_explicit_breakdown is True
+    assert invoice.label == InvoiceLabel.CS_ADHESION
 
     entries = (
         (
@@ -438,6 +439,77 @@ async def test_import_gestion_splits_cs_a_invoice_when_component_columns_exist(
     )
     assert any(
         entry.account_number == "756000" and entry.credit == Decimal("30.00") for entry in entries
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not OPENPYXL_AVAILABLE, reason="openpyxl not installed")
+async def test_import_gestion_maps_mixed_client_invoice_to_other_line_when_no_split_exists(
+    client: AsyncClient,
+    auth_headers: dict,
+    db_session,
+) -> None:
+    from sqlalchemy.orm import selectinload
+
+    from backend.models.accounting_entry import AccountingEntry, EntrySourceType
+    from backend.models.invoice import Invoice, InvoiceLabel, InvoiceLineType
+    from backend.services.accounting_engine import seed_default_rules
+
+    await seed_default_rules(db_session)
+
+    content = _make_multi_sheet_xlsx(
+        {
+            "Factures": (
+                ["Date facture", "Réf facture", "Client", "Montant", "Type"],
+                [["2024-08-30", "2024-0192", "Aleksander ELEZI", 100, "cs+a"]],
+            ),
+        }
+    )
+
+    import_response = await client.post(
+        "/api/import/excel/gestion",
+        files={"file": ("Gestion 2024.xlsx", content, _XLSX_MIME)},
+        headers=auth_headers,
+    )
+
+    assert import_response.status_code == 200
+    import_data = import_response.json()
+    assert import_data["invoices_created"] == 1
+    assert import_data["entries_created"] == 2
+
+    invoice = (
+        (
+            await db_session.execute(
+                select(Invoice)
+                .where(Invoice.number == "2024-0192")
+                .options(selectinload(Invoice.lines))
+            )
+        )
+        .scalars()
+        .one()
+    )
+    assert invoice.label == InvoiceLabel.GENERAL
+    assert invoice.has_explicit_breakdown is False
+    assert [(line.line_type, line.amount) for line in invoice.lines] == [
+        (InvoiceLineType.OTHER, Decimal("100.00"))
+    ]
+
+    entries = (
+        (
+            await db_session.execute(
+                select(AccountingEntry)
+                .where(AccountingEntry.source_type == EntrySourceType.INVOICE)
+                .where(AccountingEntry.source_id == invoice.id)
+                .order_by(AccountingEntry.entry_number.asc())
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(entries) == 2
+    assert any(
+        entry.account_number == "758000" and entry.credit == Decimal("100.00")
+        for entry in entries
     )
 
 
@@ -3507,18 +3579,28 @@ async def test_import_comptabilite_ignores_generated_group_even_when_label_diffe
 
 @pytest.mark.asyncio
 @pytest.mark.skipif(not OPENPYXL_AVAILABLE, reason="openpyxl not installed")
-async def test_import_comptabilite_ignores_client_invoice_groups_when_split(
+async def test_import_comptabilite_clarifies_existing_client_invoice_other_line_when_split_is_safe(
     client: AsyncClient,
     auth_headers: dict,
     db_session,
 ) -> None:
-    """Client invoice journal rows should be ignored.
+    """Client invoice journal rows can clarify an existing imported mixed invoice."""
+    from sqlalchemy.orm import selectinload
 
-    This remains true when an existing invoice is split differently.
-    """
     from backend.models.accounting_entry import AccountingEntry, EntrySourceType
     from backend.models.contact import Contact, ContactType
-    from backend.models.invoice import Invoice, InvoiceLabel, InvoiceStatus, InvoiceType
+    from backend.models.invoice import (
+        Invoice,
+        InvoiceLabel,
+        InvoiceLine,
+        InvoiceLineType,
+        InvoiceStatus,
+        InvoiceType,
+    )
+    from backend.services.accounting_engine import seed_default_rules
+
+    await seed_default_rules(db_session)
+    await db_session.commit()
 
     contact = Contact(nom="ELEZI", prenom="Aleksander", type=ContactType.CLIENT)
     db_session.add(contact)
@@ -3532,10 +3614,22 @@ async def test_import_comptabilite_ignores_client_invoice_groups_when_split(
         total_amount=Decimal("100.00"),
         paid_amount=Decimal("100.00"),
         status=InvoiceStatus.PAID,
-        label=InvoiceLabel.CS,
+        label=InvoiceLabel.GENERAL,
+        has_explicit_breakdown=False,
     )
     db_session.add(invoice)
     await db_session.flush()
+
+    db_session.add(
+        InvoiceLine(
+            invoice_id=invoice.id,
+            description="Autres prestations",
+            line_type=InvoiceLineType.OTHER,
+            quantity=Decimal("1.00"),
+            unit_price=Decimal("100.00"),
+            amount=Decimal("100.00"),
+        )
+    )
 
     db_session.add_all(
         [
@@ -3606,6 +3700,44 @@ async def test_import_comptabilite_ignores_client_invoice_groups_when_split(
         select(AccountingEntry).where(AccountingEntry.source_type == EntrySourceType.MANUAL)
     )
     assert result.scalars().all() == []
+
+    refreshed_invoice = (
+        (
+            await db_session.execute(
+                select(Invoice).where(Invoice.id == invoice.id).options(selectinload(Invoice.lines))
+            )
+        )
+        .scalars()
+        .one()
+    )
+    assert refreshed_invoice.label == InvoiceLabel.CS_ADHESION
+    assert refreshed_invoice.has_explicit_breakdown is True
+    assert {(line.line_type, line.amount) for line in refreshed_invoice.lines} == {
+        (InvoiceLineType.COURSE, Decimal("50.00")),
+        (InvoiceLineType.ADHESION, Decimal("50.00")),
+    }
+
+    invoice_entries = (
+        (
+            await db_session.execute(
+                select(AccountingEntry)
+                .where(AccountingEntry.source_type == EntrySourceType.INVOICE)
+                .where(AccountingEntry.source_id == invoice.id)
+                .order_by(AccountingEntry.entry_number.asc())
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(invoice_entries) == 3
+    assert any(
+        entry.account_number == "706110" and entry.credit == Decimal("50.00")
+        for entry in invoice_entries
+    )
+    assert any(
+        entry.account_number == "756000" and entry.credit == Decimal("50.00")
+        for entry in invoice_entries
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_import_api.py
+++ b/tests/integration/test_import_api.py
@@ -415,6 +415,7 @@ async def test_import_gestion_splits_cs_a_invoice_when_component_columns_exist(
         ("Cours de soutien", Decimal("130.00")),
         ("Adhesion annuelle", Decimal("30.00")),
     ]
+    assert invoice.has_explicit_breakdown is True
 
     entries = (
         (
@@ -437,6 +438,47 @@ async def test_import_gestion_splits_cs_a_invoice_when_component_columns_exist(
     )
     assert any(
         entry.account_number == "756000" and entry.credit == Decimal("30.00") for entry in entries
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not OPENPYXL_AVAILABLE, reason="openpyxl not installed")
+async def test_preview_gestion_blocks_inconsistent_cs_a_component_columns(
+    client: AsyncClient,
+    auth_headers: dict,
+) -> None:
+    content = _make_multi_sheet_xlsx(
+        {
+            "Factures": (
+                [
+                    "Date facture",
+                    "Réf facture",
+                    "Client",
+                    "Montant",
+                    "Montant cours",
+                    "Montant adhésion",
+                    "Type",
+                ],
+                [["2024-08-26", "2024-0186", "Alexandre ELEZI", 160, 120, 30, "cs+a"]],
+            ),
+        }
+    )
+
+    preview_response = await client.post(
+        "/api/import/excel/gestion/preview",
+        files={"file": ("Gestion 2024.xlsx", content, _XLSX_MIME)},
+        headers=auth_headers,
+    )
+
+    assert preview_response.status_code == 200
+    preview_data = preview_response.json()
+    sheets = {sheet["name"]: sheet for sheet in preview_data["sheets"]}
+    assert preview_data["can_import"] is False
+    assert preview_data["estimated_invoices"] == 0
+    assert sheets["Factures"]["rows"] == 0
+    assert any(
+        "ventilation cours/adhesion incoherente" in error.lower()
+        for error in sheets["Factures"]["errors"]
     )
 
 

--- a/tests/integration/test_invoices_api.py
+++ b/tests/integration/test_invoices_api.py
@@ -1,8 +1,13 @@
 """Integration tests for the invoices API."""
 
 from datetime import date
+from decimal import Decimal
 
 from httpx import AsyncClient
+from sqlalchemy import select
+
+from backend.models.accounting_entry import AccountingEntry, EntrySourceType
+from backend.services.accounting_engine import seed_default_rules
 
 
 async def _create_contact(client: AsyncClient, headers: dict, nom: str = "Dupont") -> int:
@@ -21,6 +26,7 @@ async def _create_invoice(
     contact_id: int,
     *,
     invoice_type: str = "client",
+    label: str | None = None,
     lines: list | None = None,
     total_amount: float | None = None,
     invoice_date: date = date(2025, 9, 1),
@@ -31,6 +37,8 @@ async def _create_invoice(
         "date": str(invoice_date),
         "lines": lines or [],
     }
+    if label is not None:
+        payload["label"] = label
     if total_amount is not None:
         payload["total_amount"] = str(total_amount)
     r = await client.post("/api/invoices/", json=payload, headers=headers)
@@ -185,6 +193,56 @@ class TestStatusChange:
             headers=auth_headers,
         )
         assert r.status_code == 409
+
+    async def test_sent_client_cs_a_invoice_splits_entries_from_user_lines(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        db_session,
+    ):
+        await seed_default_rules(db_session)
+        cid = await _create_contact(client, auth_headers)
+        created = await _create_invoice(
+            client,
+            auth_headers,
+            cid,
+            label="cs+a",
+            lines=[
+                {"description": "Cours de soutien", "quantity": "1", "unit_price": "130.00"},
+                {"description": "Adhesion annuelle", "quantity": "1", "unit_price": "30.00"},
+            ],
+        )
+
+        r = await client.patch(
+            f"/api/invoices/{created['id']}/status",
+            json={"status": "sent"},
+            headers=auth_headers,
+        )
+
+        assert r.status_code == 200
+        entries = list(
+            (
+                await db_session.execute(
+                    select(AccountingEntry)
+                    .where(AccountingEntry.source_type == EntrySourceType.INVOICE)
+                    .where(AccountingEntry.source_id == created["id"])
+                    .order_by(AccountingEntry.entry_number.asc())
+                )
+            ).scalars()
+        )
+        assert len(entries) == 3
+        assert any(
+            entry.account_number == "411100" and entry.debit == Decimal("160.00")
+            for entry in entries
+        )
+        assert any(
+            entry.account_number == "706110" and entry.credit == Decimal("130.00")
+            for entry in entries
+        )
+        assert any(
+            entry.account_number == "756000" and entry.credit == Decimal("30.00")
+            for entry in entries
+        )
 
 
 class TestDuplicate:

--- a/tests/integration/test_invoices_api.py
+++ b/tests/integration/test_invoices_api.py
@@ -109,14 +109,25 @@ class TestCreateInvoice:
     async def test_create_client_invoice_with_lines(self, client: AsyncClient, auth_headers: dict):
         cid = await _create_contact(client, auth_headers)
         lines = [
-            {"description": "Cours maths", "quantity": "2", "unit_price": "30.00"},
-            {"description": "Adhésion", "quantity": "1", "unit_price": "20.00"},
+            {
+                "description": "Cours maths",
+                "line_type": "cours",
+                "quantity": "2",
+                "unit_price": "30.00",
+            },
+            {
+                "description": "Adhésion",
+                "line_type": "adhesion",
+                "quantity": "1",
+                "unit_price": "20.00",
+            },
         ]
         invoice = await _create_invoice(client, auth_headers, cid, lines=lines)
         assert invoice["number"] == "2025-C-0001"
         assert float(invoice["total_amount"]) == 80.0
         assert invoice["status"] == "draft"
         assert len(invoice["lines"]) == 2
+        assert invoice["label"] == "cs+a"
 
     async def test_create_supplier_invoice(self, client: AsyncClient, auth_headers: dict):
         cid = await _create_contact(client, auth_headers)
@@ -206,10 +217,19 @@ class TestStatusChange:
             client,
             auth_headers,
             cid,
-            label="cs+a",
             lines=[
-                {"description": "Cours de soutien", "quantity": "1", "unit_price": "130.00"},
-                {"description": "Adhesion annuelle", "quantity": "1", "unit_price": "30.00"},
+                {
+                    "description": "Cours de soutien",
+                    "line_type": "cours",
+                    "quantity": "1",
+                    "unit_price": "130.00",
+                },
+                {
+                    "description": "Adhesion annuelle",
+                    "line_type": "adhesion",
+                    "quantity": "1",
+                    "unit_price": "30.00",
+                },
             ],
         )
 

--- a/tests/unit/test_accounting_engine.py
+++ b/tests/unit/test_accounting_engine.py
@@ -314,9 +314,7 @@ class TestGenerateEntriesForInvoice:
         }
 
     @pytest.mark.asyncio
-    async def test_client_other_lines_use_general_rule(
-        self, db_session: AsyncSession
-    ) -> None:
+    async def test_client_other_lines_use_general_rule(self, db_session: AsyncSession) -> None:
         await _seed_one_rule(db_session, TriggerType.INVOICE_CLIENT_GENERAL, "411100", "758000")
         inv = await _make_invoice(
             db_session,

--- a/tests/unit/test_accounting_engine.py
+++ b/tests/unit/test_accounting_engine.py
@@ -325,7 +325,7 @@ class TestGenerateEntriesForInvoice:
         )
 
     @pytest.mark.asyncio
-    async def test_client_cs_a_manual_lines_do_not_trigger_split(
+    async def test_client_cs_a_lines_without_explicit_breakdown_fall_back_to_default_rule(
         self, db_session: AsyncSession
     ) -> None:
         await _seed_one_rule(db_session, TriggerType.INVOICE_CLIENT_CS_A, "411100", "706110")

--- a/tests/unit/test_accounting_engine.py
+++ b/tests/unit/test_accounting_engine.py
@@ -81,6 +81,7 @@ async def _make_invoice(
     label: InvoiceLabel | None = InvoiceLabel.CS,
     total: Decimal = Decimal("100.00"),
     lines: list[tuple[str, Decimal]] | None = None,
+    has_explicit_breakdown: bool = False,
 ) -> Invoice:
     invoice_total = sum((amount for _, amount in lines), Decimal("0")) if lines else total
     inv = Invoice(
@@ -92,6 +93,7 @@ async def _make_invoice(
         paid_amount=Decimal("0"),
         status=InvoiceStatus.SENT,
         label=label,
+        has_explicit_breakdown=has_explicit_breakdown,
     )
     db.add(inv)
     await db.flush()
@@ -287,6 +289,7 @@ class TestGenerateEntriesForInvoice:
                 ("Cours de soutien", Decimal("130.00")),
                 ("Adhesion annuelle", Decimal("30.00")),
             ],
+            has_explicit_breakdown=True,
         )
 
         entries = await generate_entries_for_invoice(db_session, inv)
@@ -318,6 +321,89 @@ class TestGenerateEntriesForInvoice:
         assert len(entries) == 2
         assert any(
             entry.account_number == "706110" and entry.credit == Decimal("100.00")
+            for entry in entries
+        )
+
+    @pytest.mark.asyncio
+    async def test_client_cs_a_manual_lines_do_not_trigger_split(
+        self, db_session: AsyncSession
+    ) -> None:
+        await _seed_one_rule(db_session, TriggerType.INVOICE_CLIENT_CS_A, "411100", "706110")
+        await _seed_one_rule(db_session, TriggerType.INVOICE_CLIENT_CS, "411100", "706110")
+        await _seed_one_rule(db_session, TriggerType.INVOICE_CLIENT_A, "411100", "756000")
+        inv = await _make_invoice(
+            db_session,
+            label=InvoiceLabel.CS_ADHESION,
+            lines=[
+                ("Cours de soutien", Decimal("130.00")),
+                ("Adhesion annuelle", Decimal("30.00")),
+            ],
+        )
+
+        entries = await generate_entries_for_invoice(db_session, inv)
+
+        assert len(entries) == 2
+        assert any(
+            entry.account_number == "706110" and entry.credit == Decimal("160.00")
+            for entry in entries
+        )
+        assert all(entry.account_number != "756000" or entry.credit <= 0 for entry in entries)
+
+    @pytest.mark.asyncio
+    async def test_client_cs_a_explicit_breakdown_skips_zero_credit_entry(
+        self, db_session: AsyncSession
+    ) -> None:
+        await _seed_one_rule(db_session, TriggerType.INVOICE_CLIENT_CS_A, "411100", "706110")
+        await _seed_one_rule(db_session, TriggerType.INVOICE_CLIENT_CS, "411100", "706110")
+        await _seed_one_rule(db_session, TriggerType.INVOICE_CLIENT_A, "411100", "756000")
+        inv = await _make_invoice(
+            db_session,
+            label=InvoiceLabel.CS_ADHESION,
+            lines=[
+                ("Cours de soutien", Decimal("160.00")),
+                ("Adhesion annuelle", Decimal("0.00")),
+            ],
+            has_explicit_breakdown=True,
+        )
+
+        entries = await generate_entries_for_invoice(db_session, inv)
+
+        assert len(entries) == 2
+        assert any(
+            entry.account_number == "411100" and entry.debit == Decimal("160.00")
+            for entry in entries
+        )
+        assert any(
+            entry.account_number == "706110" and entry.credit == Decimal("160.00")
+            for entry in entries
+        )
+        assert all(entry.account_number != "756000" for entry in entries)
+
+    @pytest.mark.asyncio
+    async def test_client_cs_a_explicit_breakdown_with_zero_component_does_not_require_unused_rule(
+        self, db_session: AsyncSession
+    ) -> None:
+        await _seed_one_rule(db_session, TriggerType.INVOICE_CLIENT_CS_A, "411100", "706110")
+        await _seed_one_rule(db_session, TriggerType.INVOICE_CLIENT_CS, "411100", "706110")
+        inv = await _make_invoice(
+            db_session,
+            label=InvoiceLabel.CS_ADHESION,
+            lines=[
+                ("Cours de soutien", Decimal("160.00")),
+                ("Adhesion annuelle", Decimal("0.00")),
+            ],
+            has_explicit_breakdown=True,
+        )
+
+        entries = await generate_entries_for_invoice(db_session, inv)
+
+        assert len(entries) == 2
+        assert any(
+            entry.account_number == "411100" and entry.debit == Decimal("160.00")
+            for entry in entries
+        )
+        assert any(
+            entry.account_number == "706110" and entry.credit == Decimal("160.00")
             for entry in entries
         )
 

--- a/tests/unit/test_accounting_engine.py
+++ b/tests/unit/test_accounting_engine.py
@@ -6,7 +6,9 @@ from datetime import date
 from decimal import Decimal
 
 import pytest
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from backend.models.accounting_entry import EntrySourceType
 from backend.models.accounting_rule import (
@@ -19,7 +21,7 @@ from backend.models.accounting_rule import (
 from backend.models.bank import Deposit, DepositType
 from backend.models.contact import Contact, ContactType
 from backend.models.fiscal_year import FiscalYear, FiscalYearStatus
-from backend.models.invoice import Invoice, InvoiceLabel, InvoiceStatus, InvoiceType
+from backend.models.invoice import Invoice, InvoiceLabel, InvoiceLine, InvoiceStatus, InvoiceType
 from backend.models.payment import Payment, PaymentMethod
 from backend.models.salary import Salary
 from backend.services.accounting_engine import (
@@ -78,21 +80,36 @@ async def _make_invoice(
     inv_type: InvoiceType = InvoiceType.CLIENT,
     label: InvoiceLabel | None = InvoiceLabel.CS,
     total: Decimal = Decimal("100.00"),
+    lines: list[tuple[str, Decimal]] | None = None,
 ) -> Invoice:
+    invoice_total = sum((amount for _, amount in lines), Decimal("0")) if lines else total
     inv = Invoice(
         number="2024-C-0001",
         type=inv_type,
         contact_id=1,
         date=date(2024, 1, 15),
-        total_amount=total,
+        total_amount=invoice_total,
         paid_amount=Decimal("0"),
         status=InvoiceStatus.SENT,
         label=label,
     )
     db.add(inv)
+    await db.flush()
+    for description, amount in lines or []:
+        db.add(
+            InvoiceLine(
+                invoice_id=inv.id,
+                description=description,
+                quantity=Decimal("1"),
+                unit_price=amount,
+                amount=amount,
+            )
+        )
     await db.commit()
-    await db.refresh(inv)
-    return inv
+    result = await db.execute(
+        select(Invoice).where(Invoice.id == inv.id).options(selectinload(Invoice.lines))
+    )
+    return result.scalar_one()
 
 
 async def _make_payment(
@@ -257,6 +274,52 @@ class TestGenerateEntriesForInvoice:
         inv = await _make_invoice(db_session, label=InvoiceLabel.CS_ADHESION)
         entries = await generate_entries_for_invoice(db_session, inv)
         assert len(entries) == 2
+
+    @pytest.mark.asyncio
+    async def test_client_cs_a_lines_split_credit_accounts(self, db_session: AsyncSession) -> None:
+        await _seed_one_rule(db_session, TriggerType.INVOICE_CLIENT_CS_A, "411100", "706110")
+        await _seed_one_rule(db_session, TriggerType.INVOICE_CLIENT_CS, "411100", "706110")
+        await _seed_one_rule(db_session, TriggerType.INVOICE_CLIENT_A, "411100", "756000")
+        inv = await _make_invoice(
+            db_session,
+            label=InvoiceLabel.CS_ADHESION,
+            lines=[
+                ("Cours de soutien", Decimal("130.00")),
+                ("Adhesion annuelle", Decimal("30.00")),
+            ],
+        )
+
+        entries = await generate_entries_for_invoice(db_session, inv)
+
+        assert len(entries) == 3
+        debit = next(entry for entry in entries if entry.debit > 0)
+        assert debit.account_number == "411100"
+        assert debit.debit == Decimal("160.00")
+        assert {entry.account_number: entry.credit for entry in entries if entry.credit > 0} == {
+            "706110": Decimal("130.00"),
+            "756000": Decimal("30.00"),
+        }
+
+    @pytest.mark.asyncio
+    async def test_client_cs_a_unclassified_lines_fall_back_to_default_rule(
+        self, db_session: AsyncSession
+    ) -> None:
+        await _seed_one_rule(db_session, TriggerType.INVOICE_CLIENT_CS_A, "411100", "706110")
+        await _seed_one_rule(db_session, TriggerType.INVOICE_CLIENT_CS, "411100", "706110")
+        await _seed_one_rule(db_session, TriggerType.INVOICE_CLIENT_A, "411100", "756000")
+        inv = await _make_invoice(
+            db_session,
+            label=InvoiceLabel.CS_ADHESION,
+            lines=[("Pack rentree", Decimal("100.00"))],
+        )
+
+        entries = await generate_entries_for_invoice(db_session, inv)
+
+        assert len(entries) == 2
+        assert any(
+            entry.account_number == "706110" and entry.credit == Decimal("100.00")
+            for entry in entries
+        )
 
     @pytest.mark.asyncio
     async def test_client_general_label(self, db_session: AsyncSession) -> None:

--- a/tests/unit/test_accounting_engine.py
+++ b/tests/unit/test_accounting_engine.py
@@ -21,7 +21,14 @@ from backend.models.accounting_rule import (
 from backend.models.bank import Deposit, DepositType
 from backend.models.contact import Contact, ContactType
 from backend.models.fiscal_year import FiscalYear, FiscalYearStatus
-from backend.models.invoice import Invoice, InvoiceLabel, InvoiceLine, InvoiceStatus, InvoiceType
+from backend.models.invoice import (
+    Invoice,
+    InvoiceLabel,
+    InvoiceLine,
+    InvoiceLineType,
+    InvoiceStatus,
+    InvoiceType,
+)
 from backend.models.payment import Payment, PaymentMethod
 from backend.models.salary import Salary
 from backend.services.accounting_engine import (
@@ -80,10 +87,10 @@ async def _make_invoice(
     inv_type: InvoiceType = InvoiceType.CLIENT,
     label: InvoiceLabel | None = InvoiceLabel.CS,
     total: Decimal = Decimal("100.00"),
-    lines: list[tuple[str, Decimal]] | None = None,
+    lines: list[tuple[str, Decimal] | tuple[str, Decimal, InvoiceLineType | None]] | None = None,
     has_explicit_breakdown: bool = False,
 ) -> Invoice:
-    invoice_total = sum((amount for _, amount in lines), Decimal("0")) if lines else total
+    invoice_total = sum((line[1] for line in lines), Decimal("0")) if lines else total
     inv = Invoice(
         number="2024-C-0001",
         type=inv_type,
@@ -97,11 +104,14 @@ async def _make_invoice(
     )
     db.add(inv)
     await db.flush()
-    for description, amount in lines or []:
+    for line in lines or []:
+        description, amount = line[0], line[1]
+        line_type = line[2] if len(line) > 2 else None
         db.add(
             InvoiceLine(
                 invoice_id=inv.id,
                 description=description,
+                line_type=line_type,
                 quantity=Decimal("1"),
                 unit_price=amount,
                 amount=amount,
@@ -286,8 +296,8 @@ class TestGenerateEntriesForInvoice:
             db_session,
             label=InvoiceLabel.CS_ADHESION,
             lines=[
-                ("Cours de soutien", Decimal("130.00")),
-                ("Adhesion annuelle", Decimal("30.00")),
+                ("Cours de soutien", Decimal("130.00"), InvoiceLineType.COURSE),
+                ("Adhesion annuelle", Decimal("30.00"), InvoiceLineType.ADHESION),
             ],
             has_explicit_breakdown=True,
         )
@@ -304,28 +314,26 @@ class TestGenerateEntriesForInvoice:
         }
 
     @pytest.mark.asyncio
-    async def test_client_cs_a_unclassified_lines_fall_back_to_default_rule(
+    async def test_client_other_lines_use_general_rule(
         self, db_session: AsyncSession
     ) -> None:
-        await _seed_one_rule(db_session, TriggerType.INVOICE_CLIENT_CS_A, "411100", "706110")
-        await _seed_one_rule(db_session, TriggerType.INVOICE_CLIENT_CS, "411100", "706110")
-        await _seed_one_rule(db_session, TriggerType.INVOICE_CLIENT_A, "411100", "756000")
+        await _seed_one_rule(db_session, TriggerType.INVOICE_CLIENT_GENERAL, "411100", "758000")
         inv = await _make_invoice(
             db_session,
-            label=InvoiceLabel.CS_ADHESION,
-            lines=[("Pack rentree", Decimal("100.00"))],
+            label=InvoiceLabel.GENERAL,
+            lines=[("Pack rentree", Decimal("100.00"), InvoiceLineType.OTHER)],
         )
 
         entries = await generate_entries_for_invoice(db_session, inv)
 
         assert len(entries) == 2
         assert any(
-            entry.account_number == "706110" and entry.credit == Decimal("100.00")
+            entry.account_number == "758000" and entry.credit == Decimal("100.00")
             for entry in entries
         )
 
     @pytest.mark.asyncio
-    async def test_client_cs_a_lines_without_explicit_breakdown_fall_back_to_default_rule(
+    async def test_client_typed_lines_split_without_extra_flag(
         self, db_session: AsyncSession
     ) -> None:
         await _seed_one_rule(db_session, TriggerType.INVOICE_CLIENT_CS_A, "411100", "706110")
@@ -335,22 +343,21 @@ class TestGenerateEntriesForInvoice:
             db_session,
             label=InvoiceLabel.CS_ADHESION,
             lines=[
-                ("Cours de soutien", Decimal("130.00")),
-                ("Adhesion annuelle", Decimal("30.00")),
+                ("Cours de soutien", Decimal("130.00"), InvoiceLineType.COURSE),
+                ("Adhesion annuelle", Decimal("30.00"), InvoiceLineType.ADHESION),
             ],
         )
 
         entries = await generate_entries_for_invoice(db_session, inv)
 
-        assert len(entries) == 2
-        assert any(
-            entry.account_number == "706110" and entry.credit == Decimal("160.00")
-            for entry in entries
-        )
-        assert all(entry.account_number != "756000" or entry.credit <= 0 for entry in entries)
+        assert len(entries) == 3
+        assert {entry.account_number: entry.credit for entry in entries if entry.credit > 0} == {
+            "706110": Decimal("130.00"),
+            "756000": Decimal("30.00"),
+        }
 
     @pytest.mark.asyncio
-    async def test_client_cs_a_explicit_breakdown_skips_zero_credit_entry(
+    async def test_client_typed_lines_skip_zero_credit_entry(
         self, db_session: AsyncSession
     ) -> None:
         await _seed_one_rule(db_session, TriggerType.INVOICE_CLIENT_CS_A, "411100", "706110")
@@ -360,10 +367,9 @@ class TestGenerateEntriesForInvoice:
             db_session,
             label=InvoiceLabel.CS_ADHESION,
             lines=[
-                ("Cours de soutien", Decimal("160.00")),
-                ("Adhesion annuelle", Decimal("0.00")),
+                ("Cours de soutien", Decimal("160.00"), InvoiceLineType.COURSE),
+                ("Adhesion annuelle", Decimal("0.00"), InvoiceLineType.ADHESION),
             ],
-            has_explicit_breakdown=True,
         )
 
         entries = await generate_entries_for_invoice(db_session, inv)
@@ -380,30 +386,29 @@ class TestGenerateEntriesForInvoice:
         assert all(entry.account_number != "756000" for entry in entries)
 
     @pytest.mark.asyncio
-    async def test_client_cs_a_explicit_breakdown_with_zero_component_does_not_require_unused_rule(
+    async def test_client_negative_line_is_aggregated_by_type(
         self, db_session: AsyncSession
     ) -> None:
         await _seed_one_rule(db_session, TriggerType.INVOICE_CLIENT_CS_A, "411100", "706110")
         await _seed_one_rule(db_session, TriggerType.INVOICE_CLIENT_CS, "411100", "706110")
         inv = await _make_invoice(
             db_session,
-            label=InvoiceLabel.CS_ADHESION,
+            label=InvoiceLabel.CS,
             lines=[
-                ("Cours de soutien", Decimal("160.00")),
-                ("Adhesion annuelle", Decimal("0.00")),
+                ("Cours de soutien", Decimal("160.00"), InvoiceLineType.COURSE),
+                ("Remise cours", Decimal("-10.00"), InvoiceLineType.COURSE),
             ],
-            has_explicit_breakdown=True,
         )
 
         entries = await generate_entries_for_invoice(db_session, inv)
 
         assert len(entries) == 2
         assert any(
-            entry.account_number == "411100" and entry.debit == Decimal("160.00")
+            entry.account_number == "411100" and entry.debit == Decimal("150.00")
             for entry in entries
         )
         assert any(
-            entry.account_number == "706110" and entry.credit == Decimal("160.00")
+            entry.account_number == "706110" and entry.credit == Decimal("150.00")
             for entry in entries
         )
 

--- a/tests/unit/test_excel_import_parsers.py
+++ b/tests/unit/test_excel_import_parsers.py
@@ -82,6 +82,34 @@ def test_parse_invoice_sheet_blocks_missing_or_invalid_invoice_date() -> None:
     ]
 
 
+def test_parse_invoice_sheet_extracts_optional_cs_a_components() -> None:
+    sheet = _make_sheet(
+        "Factures",
+        [
+            [
+                "Date facture",
+                "Réf facture",
+                "Client",
+                "Montant",
+                "Montant cours",
+                "Montant adhésion",
+                "Type",
+            ],
+            ["2025-08-01", "2025-0142", "Christine LOPES", 160, 130, 30, "CS+A"],
+        ],
+    )
+
+    parsed_sheet, rows, issues, ignored_issues = parse_invoice_sheet(sheet)
+
+    assert parsed_sheet is not None
+    assert issues == []
+    assert ignored_issues == []
+    assert len(rows) == 1
+    assert rows[0].label == "cs+a"
+    assert rows[0].course_amount == Decimal("130")
+    assert rows[0].adhesion_amount == Decimal("30")
+
+
 def test_parse_payment_sheet_normalizes_payment_fields() -> None:
     sheet = _make_sheet(
         "Paiements",

--- a/tests/unit/test_excel_import_parsers.py
+++ b/tests/unit/test_excel_import_parsers.py
@@ -20,10 +20,12 @@ from backend.services.excel_import_policy import (
     BANK_BALANCE_DESCRIPTION_MESSAGE,
     CASH_INITIAL_BALANCE_MESSAGE,
     CASH_PENDING_DEPOSIT_MESSAGE,
+    INVOICE_INVALID_COMPONENT_BREAKDOWN_MESSAGE,
     INVOICE_INVALID_DATE_MESSAGE,
     INVOICE_TOTAL_MESSAGE,
     ZERO_JOURNAL_ENTRY_MESSAGE,
 )
+from backend.services.excel_import_types import RowValidationIssue
 
 
 def _make_sheet(title: str, rows: list[list[object | None]]) -> Worksheet:
@@ -108,6 +110,63 @@ def test_parse_invoice_sheet_extracts_optional_cs_a_components() -> None:
     assert rows[0].label == "cs+a"
     assert rows[0].course_amount == Decimal("130")
     assert rows[0].adhesion_amount == Decimal("30")
+
+
+def test_parse_invoice_sheet_accepts_zero_value_cs_a_component() -> None:
+    sheet = _make_sheet(
+        "Factures",
+        [
+            [
+                "Date facture",
+                "Réf facture",
+                "Client",
+                "Montant",
+                "Montant cours",
+                "Montant adhésion",
+                "Type",
+            ],
+            ["2025-08-01", "2025-0142", "Christine LOPES", 160, 160, 0, "CS+A"],
+        ],
+    )
+
+    parsed_sheet, rows, issues, ignored_issues = parse_invoice_sheet(sheet)
+
+    assert parsed_sheet is not None
+    assert issues == []
+    assert ignored_issues == []
+    assert len(rows) == 1
+    assert rows[0].course_amount == Decimal("160")
+    assert rows[0].adhesion_amount == Decimal("0")
+
+
+def test_parse_invoice_sheet_blocks_inconsistent_explicit_cs_a_components() -> None:
+    sheet = _make_sheet(
+        "Factures",
+        [
+            [
+                "Date facture",
+                "Réf facture",
+                "Client",
+                "Montant",
+                "Montant cours",
+                "Montant adhésion",
+                "Type",
+            ],
+            ["2025-08-01", "2025-0142", "Christine LOPES", 160, 120, 30, "CS+A"],
+        ],
+    )
+
+    parsed_sheet, rows, issues, ignored_issues = parse_invoice_sheet(sheet)
+
+    assert parsed_sheet is not None
+    assert rows == []
+    assert ignored_issues == []
+    assert issues == [
+        RowValidationIssue(
+            source_row_number=2,
+            message=INVOICE_INVALID_COMPONENT_BREAKDOWN_MESSAGE,
+        )
+    ]
 
 
 def test_parse_payment_sheet_normalizes_payment_fields() -> None:

--- a/tests/unit/test_invoice_service.py
+++ b/tests/unit/test_invoice_service.py
@@ -7,7 +7,7 @@ import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.models.contact import Contact, ContactType
-from backend.models.invoice import InvoiceLabel, InvoiceStatus, InvoiceType
+from backend.models.invoice import InvoiceLabel, InvoiceLineType, InvoiceStatus, InvoiceType
 from backend.schemas.invoice import InvoiceCreate, InvoiceLineCreate, InvoiceUpdate
 from backend.services.invoice import (
     InvoiceDeleteError,
@@ -109,6 +109,11 @@ class TestCreateInvoice:
         assert invoice.total_amount == Decimal("80.00")
         assert len(invoice.lines) == 2
         assert invoice.status == InvoiceStatus.DRAFT
+        assert invoice.label == InvoiceLabel.CS_ADHESION
+        assert [line.line_type for line in invoice.lines] == [
+            InvoiceLineType.COURSE,
+            InvoiceLineType.ADHESION,
+        ]
 
     async def test_creates_supplier_invoice_with_total_amount(self, db_session: AsyncSession):
         contact = await _make_contact(db_session)
@@ -147,8 +152,9 @@ class TestCreateInvoice:
         )
         invoice = await create_invoice(db_session, payload)
         assert invoice.lines[0].amount == Decimal("75.00")
+        assert invoice.lines[0].line_type == InvoiceLineType.COURSE
 
-    async def test_client_cs_a_with_lines_marks_explicit_breakdown(self, db_session: AsyncSession):
+    async def test_client_lines_mark_explicit_breakdown(self, db_session: AsyncSession):
         contact = await _make_contact(db_session)
         payload = InvoiceCreate(
             type=InvoiceType.CLIENT,
@@ -279,8 +285,13 @@ class TestUpdateInvoice:
         )
         assert updated.total_amount == Decimal("65.00")
         assert len(updated.lines) == 2
+        assert updated.label == InvoiceLabel.CS_ADHESION
+        assert [line.line_type for line in updated.lines] == [
+            InvoiceLineType.COURSE,
+            InvoiceLineType.ADHESION,
+        ]
 
-    async def test_update_cs_a_lines_marks_explicit_breakdown(self, db_session: AsyncSession):
+    async def test_update_client_lines_marks_explicit_breakdown(self, db_session: AsyncSession):
         invoice = await _make_invoice(db_session)
 
         updated = await update_invoice(
@@ -356,6 +367,7 @@ class TestDuplicate:
         copy = await duplicate_invoice(db_session, invoice)
         assert len(copy.lines) == 1
         assert copy.lines[0].description == "Cours"
+        assert copy.lines[0].line_type == InvoiceLineType.COURSE
 
     async def test_copy_paid_amount_is_zero(self, db_session: AsyncSession):
         invoice = await _make_invoice(db_session)

--- a/tests/unit/test_invoice_service.py
+++ b/tests/unit/test_invoice_service.py
@@ -7,7 +7,7 @@ import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.models.contact import Contact, ContactType
-from backend.models.invoice import InvoiceStatus, InvoiceType
+from backend.models.invoice import InvoiceLabel, InvoiceStatus, InvoiceType
 from backend.schemas.invoice import InvoiceCreate, InvoiceLineCreate, InvoiceUpdate
 from backend.services.invoice import (
     InvoiceDeleteError,
@@ -37,12 +37,14 @@ async def _make_invoice(
     lines: list[InvoiceLineCreate] | None = None,
     total_amount: Decimal | None = None,
     invoice_date: date | None = None,
+    label: InvoiceLabel | None = None,
 ) -> object:
     contact = await _make_contact(db)
     payload = InvoiceCreate(
         type=invoice_type,
         contact_id=contact.id,
         date=invoice_date or date(2025, 6, 1),
+        label=label,
         lines=lines or [],
         total_amount=total_amount,
     )
@@ -145,6 +147,31 @@ class TestCreateInvoice:
         )
         invoice = await create_invoice(db_session, payload)
         assert invoice.lines[0].amount == Decimal("75.00")
+
+    async def test_client_cs_a_with_lines_marks_explicit_breakdown(self, db_session: AsyncSession):
+        contact = await _make_contact(db_session)
+        payload = InvoiceCreate(
+            type=InvoiceType.CLIENT,
+            contact_id=contact.id,
+            date=date(2025, 9, 1),
+            label=InvoiceLabel.CS_ADHESION,
+            lines=[
+                InvoiceLineCreate(
+                    description="Cours de soutien",
+                    quantity=Decimal("1"),
+                    unit_price=Decimal("130.00"),
+                ),
+                InvoiceLineCreate(
+                    description="Adhesion annuelle",
+                    quantity=Decimal("1"),
+                    unit_price=Decimal("30.00"),
+                ),
+            ],
+        )
+
+        invoice = await create_invoice(db_session, payload)
+
+        assert invoice.has_explicit_breakdown is True
 
 
 class TestGetInvoice:
@@ -253,6 +280,31 @@ class TestUpdateInvoice:
         assert updated.total_amount == Decimal("65.00")
         assert len(updated.lines) == 2
 
+    async def test_update_cs_a_lines_marks_explicit_breakdown(self, db_session: AsyncSession):
+        invoice = await _make_invoice(db_session)
+
+        updated = await update_invoice(
+            db_session,
+            invoice,
+            InvoiceUpdate(
+                label=InvoiceLabel.CS_ADHESION,
+                lines=[
+                    InvoiceLineCreate(
+                        description="Cours de soutien",
+                        quantity=Decimal("1"),
+                        unit_price=Decimal("130.00"),
+                    ),
+                    InvoiceLineCreate(
+                        description="Adhesion annuelle",
+                        quantity=Decimal("1"),
+                        unit_price=Decimal("30.00"),
+                    ),
+                ],
+            ),
+        )
+
+        assert updated.has_explicit_breakdown is True
+
 
 class TestStatusChange:
     async def test_draft_to_sent(self, db_session: AsyncSession):
@@ -309,6 +361,30 @@ class TestDuplicate:
         invoice = await _make_invoice(db_session)
         copy = await duplicate_invoice(db_session, invoice)  # type: ignore[arg-type]
         assert copy.paid_amount == Decimal("0")
+
+    async def test_duplicate_preserves_explicit_breakdown_for_cs_a_lines(
+        self, db_session: AsyncSession
+    ):
+        invoice = await _make_invoice(
+            db_session,
+            label=InvoiceLabel.CS_ADHESION,
+            lines=[
+                InvoiceLineCreate(
+                    description="Cours de soutien",
+                    quantity=Decimal("1"),
+                    unit_price=Decimal("130.00"),
+                ),
+                InvoiceLineCreate(
+                    description="Adhesion annuelle",
+                    quantity=Decimal("1"),
+                    unit_price=Decimal("30.00"),
+                ),
+            ],
+        )
+
+        copy = await duplicate_invoice(db_session, invoice)  # type: ignore[arg-type]
+
+        assert copy.has_explicit_breakdown is True
 
 
 class TestDeleteInvoice:

--- a/tests/unit/test_invoice_service.py
+++ b/tests/unit/test_invoice_service.py
@@ -179,6 +179,28 @@ class TestCreateInvoice:
 
         assert invoice.has_explicit_breakdown is True
 
+    async def test_single_client_line_does_not_mark_explicit_breakdown(
+        self, db_session: AsyncSession
+    ):
+        contact = await _make_contact(db_session)
+        payload = InvoiceCreate(
+            type=InvoiceType.CLIENT,
+            contact_id=contact.id,
+            date=date(2025, 9, 1),
+            label=InvoiceLabel.CS_ADHESION,
+            lines=[
+                InvoiceLineCreate(
+                    description="Cours de soutien",
+                    quantity=Decimal("1"),
+                    unit_price=Decimal("130.00"),
+                )
+            ],
+        )
+
+        invoice = await create_invoice(db_session, payload)
+
+        assert invoice.has_explicit_breakdown is False
+
 
 class TestGetInvoice:
     async def test_returns_invoice_with_lines(self, db_session: AsyncSession):
@@ -316,6 +338,42 @@ class TestUpdateInvoice:
 
         assert updated.has_explicit_breakdown is True
 
+    async def test_update_single_client_line_clears_explicit_breakdown(
+        self, db_session: AsyncSession
+    ):
+        invoice = await _make_invoice(
+            db_session,
+            label=InvoiceLabel.CS_ADHESION,
+            lines=[
+                InvoiceLineCreate(
+                    description="Cours de soutien",
+                    quantity=Decimal("1"),
+                    unit_price=Decimal("130.00"),
+                ),
+                InvoiceLineCreate(
+                    description="Adhesion annuelle",
+                    quantity=Decimal("1"),
+                    unit_price=Decimal("30.00"),
+                ),
+            ],
+        )
+
+        updated = await update_invoice(
+            db_session,
+            invoice,
+            InvoiceUpdate(
+                lines=[
+                    InvoiceLineCreate(
+                        description="Cours de soutien",
+                        quantity=Decimal("1"),
+                        unit_price=Decimal("160.00"),
+                    )
+                ]
+            ),
+        )
+
+        assert updated.has_explicit_breakdown is False
+
 
 class TestStatusChange:
     async def test_draft_to_sent(self, db_session: AsyncSession):
@@ -397,6 +455,25 @@ class TestDuplicate:
         copy = await duplicate_invoice(db_session, invoice)  # type: ignore[arg-type]
 
         assert copy.has_explicit_breakdown is True
+
+    async def test_duplicate_single_client_line_does_not_mark_explicit_breakdown(
+        self, db_session: AsyncSession
+    ):
+        invoice = await _make_invoice(
+            db_session,
+            label=InvoiceLabel.CS_ADHESION,
+            lines=[
+                InvoiceLineCreate(
+                    description="Cours de soutien",
+                    quantity=Decimal("1"),
+                    unit_price=Decimal("130.00"),
+                )
+            ],
+        )
+
+        copy = await duplicate_invoice(db_session, invoice)  # type: ignore[arg-type]
+
+        assert copy.has_explicit_breakdown is False
 
 
 class TestDeleteInvoice:


### PR DESCRIPTION
This PR reframes the work under BL-029 and makes client invoice revenue splitting derive from entered invoice lines instead of relying on a standalone BL-028 path.

- mark client `cs+a` invoices with entered lines as explicit breakdown during create, update, and duplicate flows
- cover the split behavior through invoice service, accounting engine, and invoice API tests
- update the backlog and BL-026 validation notes to absorb BL-028 into BL-029

## Summary by Sourcery

Derive the accounting split of mixed client invoices (`cs+a`) from invoice lines and Excel component columns, and persist an explicit breakdown flag on invoices to drive this behavior across creation, update, duplication, import, and entry generation.

New Features:
- Support splitting mixed client invoices into course and adhesion components based on user-entered lines when generating accounting entries.
- Allow Excel Gestion imports to carry optional course and adhesion component amounts for `cs+a` invoices and create matching invoice lines.
- Expose an explicit breakdown flag on invoices to track when a line-level composition should control revenue splitting.

Bug Fixes:
- Prevent inconsistent `cs+a` component amounts from being imported by validating that course and adhesion totals match the invoice amount before creating rows.

Enhancements:
- Refine the accounting engine to optionally apply only selected rule entries and to reuse a mixed-invoice debit rule with component-specific credit rules.
- Extend invoice service workflows so create, update, and duplicate operations correctly set or preserve the explicit breakdown flag for relevant client invoices.
- Improve Excel import parsing and policy to normalize `cs+a` labels, capture component amounts, and surface clear validation issues for invalid breakdowns.
- Extend API and service-level tests to cover `cs+a` invoice splitting from both manual invoices and Excel imports, including zero-value components and fallback behavior.
- Update backlog and validation documentation to fold the previous `cs+a` ventilation topic into a broader ticket on line-typed client invoices and clarify related decisions.

Documentation:
- Document the new backlog items and decisions around client invoice line typing, mixed-invoice ventilation, and modification policies, replacing the previous standalone `cs+a` ventilation ticket.

Tests:
- Add unit, integration, and import parser tests that exercise explicit `cs+a` breakdown handling, including successful splits, fallbacks to default rules, and blocked inconsistent imports.

Chores:
- Add an Alembic migration to introduce the `has_explicit_breakdown` column on invoices.