### PR TITLE
feat(import): refine accounting coexistence diagnostics

### DIFF
--- a/backend/services/excel_import.py
+++ b/backend/services/excel_import.py
@@ -81,7 +81,9 @@ from backend.services.excel_import_payment_matching import (
 )
 from backend.services.excel_import_policy import (
     COMPTABILITE_UNKNOWN_STRUCTURE_MESSAGE,
+    ENTRY_COVERED_BY_SOLDE_MESSAGE,
     ENTRY_EXISTING_MESSAGE,
+    ENTRY_NEAR_EXISTING_MANUAL_MESSAGE,
     EXISTING_GESTION_ROW_MESSAGE,
     EXISTING_SALARY_MESSAGE,
     GESTION_UNKNOWN_STRUCTURE_MESSAGE,
@@ -114,6 +116,9 @@ from backend.services.excel_import_preview_helpers import (
 )
 from backend.services.excel_import_preview_helpers import (
     append_preview_open_error as _append_preview_open_error,
+)
+from backend.services.excel_import_preview_helpers import (
+    append_preview_warning_issue as _append_preview_warning_issue,
 )
 from backend.services.excel_import_preview_helpers import (
     append_reasoned_ignored_sheet_preview as _append_reasoned_ignored_sheet_preview,
@@ -172,6 +177,7 @@ from backend.services.excel_import_state import (
 )
 from backend.services.excel_import_state import (
     load_existing_generated_accounting_group_signatures,
+    load_existing_manual_accounting_line_signatures,
 )
 from backend.services.excel_import_state import (
     load_existing_invoice_numbers as _load_existing_invoice_numbers,
@@ -193,6 +199,7 @@ from backend.services.excel_import_types import (
     ParsedSheet,
     RowIgnoredIssue,
     RowValidationIssue,
+    RowWarningIssue,
 )
 
 logger = logging.getLogger(__name__)
@@ -4381,6 +4388,7 @@ async def _import_entries_sheet(db: AsyncSession, ws: Any, result: ImportResult)
         await _load_existing_supplier_payment_reference_signatures(db)
     )
     existing_salary_group_signatures = await _load_existing_salary_group_signatures(db)
+    existing_manual_line_signatures = await load_existing_manual_accounting_line_signatures(db)
     existing_generated_group_signatures = (
         await _load_existing_generated_accounting_group_signatures(db)
     )
@@ -4417,7 +4425,7 @@ async def _import_entries_sheet(db: AsyncSession, ws: Any, result: ImportResult)
             message = (
                 _CLIENT_INVOICE_CLARIFIED_MESSAGE
                 if clarified_invoice is not None
-                else ENTRY_EXISTING_MESSAGE
+                else ENTRY_COVERED_BY_SOLDE_MESSAGE
             )
             for entry_row in entry_group:
                 result.add_ignored_row(
@@ -4453,7 +4461,7 @@ async def _import_entries_sheet(db: AsyncSession, ws: Any, result: ImportResult)
                     format_row_issue(
                         RowIgnoredIssue(
                             source_row_number=entry_row.source_row_number,
-                            message=ENTRY_EXISTING_MESSAGE,
+                            message=ENTRY_COVERED_BY_SOLDE_MESSAGE,
                         )
                     ),
                 )
@@ -4471,7 +4479,7 @@ async def _import_entries_sheet(db: AsyncSession, ws: Any, result: ImportResult)
                     format_row_issue(
                         RowIgnoredIssue(
                             source_row_number=entry_row.source_row_number,
-                            message=ENTRY_EXISTING_MESSAGE,
+                            message=ENTRY_COVERED_BY_SOLDE_MESSAGE,
                         )
                     ),
                 )
@@ -4489,7 +4497,7 @@ async def _import_entries_sheet(db: AsyncSession, ws: Any, result: ImportResult)
                     format_row_issue(
                         RowIgnoredIssue(
                             source_row_number=entry_row.source_row_number,
-                            message=ENTRY_EXISTING_MESSAGE,
+                            message=ENTRY_COVERED_BY_SOLDE_MESSAGE,
                         )
                     ),
                 )
@@ -4504,7 +4512,7 @@ async def _import_entries_sheet(db: AsyncSession, ws: Any, result: ImportResult)
                     format_row_issue(
                         RowIgnoredIssue(
                             source_row_number=entry_row.source_row_number,
-                            message=ENTRY_EXISTING_MESSAGE,
+                            message=ENTRY_COVERED_BY_SOLDE_MESSAGE,
                         )
                     ),
                 )
@@ -4532,6 +4540,24 @@ async def _import_entries_sheet(db: AsyncSession, ws: Any, result: ImportResult)
                     ),
                 )
                 continue
+
+            line_signature = _accounting_entry_line_signature(
+                entry_date=entry_row.entry_date,
+                account_number=entry_row.account_number,
+                debit=entry_row.debit,
+                credit=entry_row.credit,
+            )
+            if line_signature in existing_manual_line_signatures:
+                result.add_warning(
+                    ws.title,
+                    "entries",
+                    format_row_issue(
+                        RowWarningIssue(
+                            source_row_number=entry_row.source_row_number,
+                            message=ENTRY_NEAR_EXISTING_MANUAL_MESSAGE,
+                        )
+                    ),
+                )
 
             next_offset += 1
             entry = AccountingEntry(
@@ -4888,6 +4914,7 @@ async def _add_comptabilite_existing_rows_preview(
     )
     existing_client_invoices_by_number = await _load_existing_client_invoices_by_number(db)
     existing_salary_group_signatures = await _load_existing_salary_group_signatures(db)
+    existing_manual_line_signatures = await load_existing_manual_accounting_line_signatures(db)
     existing_generated_group_signatures = (
         await _load_existing_generated_accounting_group_signatures(db)
     )
@@ -4937,7 +4964,7 @@ async def _add_comptabilite_existing_rows_preview(
                             message=(
                                 _CLIENT_INVOICE_CLARIFIED_MESSAGE
                                 if clarified_invoice is not None
-                                else ENTRY_EXISTING_MESSAGE
+                                else ENTRY_COVERED_BY_SOLDE_MESSAGE
                             ),
                         ),
                     )
@@ -4956,7 +4983,7 @@ async def _add_comptabilite_existing_rows_preview(
                         sheet_preview,
                         RowIgnoredIssue(
                             source_row_number=entry_row.source_row_number,
-                            message=ENTRY_EXISTING_MESSAGE,
+                            message=ENTRY_COVERED_BY_SOLDE_MESSAGE,
                         ),
                     )
                     sheet_preview["rows"] = max(0, sheet_preview["rows"] - 1)
@@ -4974,7 +5001,7 @@ async def _add_comptabilite_existing_rows_preview(
                         sheet_preview,
                         RowIgnoredIssue(
                             source_row_number=entry_row.source_row_number,
-                            message=ENTRY_EXISTING_MESSAGE,
+                            message=ENTRY_COVERED_BY_SOLDE_MESSAGE,
                         ),
                     )
                     sheet_preview["rows"] = max(0, sheet_preview["rows"] - 1)
@@ -4992,7 +5019,7 @@ async def _add_comptabilite_existing_rows_preview(
                         sheet_preview,
                         RowIgnoredIssue(
                             source_row_number=entry_row.source_row_number,
-                            message=ENTRY_EXISTING_MESSAGE,
+                            message=ENTRY_COVERED_BY_SOLDE_MESSAGE,
                         ),
                     )
                     sheet_preview["rows"] = max(0, sheet_preview["rows"] - 1)
@@ -5010,7 +5037,7 @@ async def _add_comptabilite_existing_rows_preview(
                         sheet_preview,
                         RowIgnoredIssue(
                             source_row_number=entry_row.source_row_number,
-                            message=ENTRY_EXISTING_MESSAGE,
+                            message=ENTRY_COVERED_BY_SOLDE_MESSAGE,
                         ),
                     )
                     sheet_preview["rows"] = max(0, sheet_preview["rows"] - 1)
@@ -5027,6 +5054,21 @@ async def _add_comptabilite_existing_rows_preview(
                     credit=entry_row.credit,
                 )
                 if signature not in existing_entry_signatures:
+                    line_signature = _accounting_entry_line_signature(
+                        entry_date=entry_row.entry_date,
+                        account_number=entry_row.account_number,
+                        debit=entry_row.debit,
+                        credit=entry_row.credit,
+                    )
+                    if line_signature in existing_manual_line_signatures:
+                        _append_preview_warning_issue(
+                            preview,
+                            sheet_preview,
+                            RowWarningIssue(
+                                source_row_number=entry_row.source_row_number,
+                                message=ENTRY_NEAR_EXISTING_MANUAL_MESSAGE,
+                            ),
+                        )
                     continue
                 _append_preview_ignored_issue(
                     preview,

--- a/backend/services/excel_import_policy.py
+++ b/backend/services/excel_import_policy.py
@@ -11,6 +11,7 @@ from backend.services.excel_import_types import (
     NormalizedInvoiceRow,
     RowIgnoredIssue,
     RowValidationIssue,
+    RowWarningIssue,
 )
 
 BANK_BALANCE_DESCRIPTION_MESSAGE = "ligne descriptive de solde ignoree"
@@ -27,7 +28,7 @@ CASH_INVALID_MOVEMENT_MESSAGE = "mouvement ou montant manquant/invalide"
 CASH_REQUIRED_DATE_OR_AMOUNT_COLUMNS = ("date", "entrée/sortie ou montant")
 CONTACT_REQUIRED_NAME_MESSAGE = "nom"
 COMPTABILITE_ENTRY_HELPER_SHEET_MESSAGE = "Feuille d'aide a la saisie ignoree par la preview"
-COMPTABILITE_COEXISTENCE_BLOCKED_MESSAGE_PREFIX = (
+COMPTABILITE_COEXISTENCE_WARNING_MESSAGE_PREFIX = (
     "Import comptabilite : des ecritures auto-generees issues de la gestion existent deja en base"
 )
 COMPTABILITE_REPORT_SHEET_MESSAGE = "Feuille de reporting ignoree par la preview"
@@ -40,6 +41,10 @@ ENTRY_INVALID_CREDIT_MESSAGE = "montant credit invalide"
 ENTRY_INVALID_DATE_MESSAGE = "date invalide"
 ENTRY_INVALID_DEBIT_MESSAGE = "montant debit invalide"
 ENTRY_EXISTING_MESSAGE = "ecriture deja existante, ligne ignoree"
+ENTRY_COVERED_BY_SOLDE_MESSAGE = "ecriture deja couverte par Solde, ligne ignoree"
+ENTRY_NEAR_EXISTING_MANUAL_MESSAGE = (
+    "ecriture proche d'une ecriture manuelle existante, revue conseillee"
+)
 EXISTING_GESTION_ROW_MESSAGE = "ligne deja existante dans Solde, ligne ignoree"
 ENTRY_MISSING_ACCOUNT_MESSAGE = "compte manquant"
 ENTRY_SUSPICIOUS_DATE_MESSAGE = "date incoherente avec les lignes voisines"
@@ -90,7 +95,9 @@ _UNAMBIGUOUS_ISSUE_CATEGORY_BY_MESSAGE = {
     COMPTABILITE_UNKNOWN_STRUCTURE_MESSAGE: "comptabilite-unknown-structure",
     DUPLICATE_CONTACT_MESSAGE: "duplicate-contact",
     DUPLICATE_INVOICE_MESSAGE: "duplicate-invoice",
+    ENTRY_COVERED_BY_SOLDE_MESSAGE: "entry-covered-by-solde",
     ENTRY_EXISTING_MESSAGE: "entry-existing",
+    ENTRY_NEAR_EXISTING_MANUAL_MESSAGE: "entry-near-manual",
     EXISTING_GESTION_ROW_MESSAGE: "existing-row-in-solde",
     EXISTING_CONTACT_MESSAGE: "existing-contact",
     EXISTING_INVOICE_MESSAGE: "existing-invoice",
@@ -353,7 +360,7 @@ def format_source_row_issue(source_row_number: int, message: str) -> str:
     return f"Ligne {source_row_number} : {message}"
 
 
-def format_row_issue(issue: RowValidationIssue | RowIgnoredIssue) -> str:
+def format_row_issue(issue: RowValidationIssue | RowIgnoredIssue | RowWarningIssue) -> str:
     """Build the stable display string for a typed row issue."""
     return format_source_row_issue(issue.source_row_number, issue.message)
 
@@ -408,7 +415,7 @@ def issue_category_for_message(
     """Return a stable category for a known issue message when available."""
     if message.startswith(ALREADY_IMPORTED_MESSAGE_PREFIX):
         return "already-imported"
-    if message.startswith(COMPTABILITE_COEXISTENCE_BLOCKED_MESSAGE_PREFIX):
+    if message.startswith(COMPTABILITE_COEXISTENCE_WARNING_MESSAGE_PREFIX):
         return "comptabilite-coexistence"
     if message.startswith(IMPORT_ERROR_MESSAGE_PREFIX):
         return "import-error"

--- a/backend/services/excel_import_preview_helpers.py
+++ b/backend/services/excel_import_preview_helpers.py
@@ -198,6 +198,16 @@ def append_preview_ignored_issue(
     preview.warnings.append(f"{sheet_preview['name']} — {message}")
 
 
+def append_preview_warning_issue(
+    preview: PreviewResult,
+    sheet_preview: dict[str, Any],
+    issue: Any,
+) -> None:
+    message = format_row_issue(issue)
+    sheet_preview["warnings"].append(message)
+    preview.warnings.append(f"{sheet_preview['name']} — {message}")
+
+
 def append_preview_blocked_issue(
     preview: PreviewResult,
     sheet_preview: dict[str, Any],

--- a/backend/services/excel_import_state.py
+++ b/backend/services/excel_import_state.py
@@ -153,6 +153,30 @@ async def load_existing_accounting_entry_signatures(db: AsyncSession) -> set[str
     }
 
 
+async def load_existing_manual_accounting_line_signatures(db: AsyncSession) -> set[str]:
+    from sqlalchemy import select  # noqa: PLC0415
+
+    from backend.models.accounting_entry import AccountingEntry, EntrySourceType  # noqa: PLC0415
+
+    result = await db.execute(
+        select(
+            AccountingEntry.date,
+            AccountingEntry.account_number,
+            AccountingEntry.debit,
+            AccountingEntry.credit,
+        ).where(AccountingEntry.source_type == EntrySourceType.MANUAL)
+    )
+    return {
+        accounting_entry_line_signature(
+            entry_date=entry_date,
+            account_number=account_number,
+            debit=debit,
+            credit=credit,
+        )
+        for entry_date, account_number, debit, credit in result.all()
+    }
+
+
 async def load_existing_generated_accounting_group_signatures(
     db: AsyncSession,
 ) -> set[tuple[str, ...]]:

--- a/backend/services/excel_import_types.py
+++ b/backend/services/excel_import_types.py
@@ -33,6 +33,14 @@ class RowIgnoredIssue:
 
 
 @dataclass(slots=True)
+class RowWarningIssue:
+    """Non-blocking warning attached to a source row."""
+
+    source_row_number: int
+    message: str
+
+
+@dataclass(slots=True)
 class NormalizedInvoiceRow:
     """Validated invoice row ready for preview or persistence."""
 

--- a/doc/backlog.md
+++ b/doc/backlog.md
@@ -52,7 +52,7 @@ Tout sujet concret qui doit survivre au-delà de la séance en cours doit être 
 
 1. **BL-024** — clarifier le workflow de saisie des paiements et corriger les remises en banque automatiques.
 2. **BL-022** — terminer les lots restants sur la gestion des utilisateurs, profils et sécurité de compte.
-3. **BL-027** — gérer une ouverture du système explicite pour Banque et Caisse.
+3. **BL-029** — repenser la saisie et l'import des factures clients autour de lignes typées.
 
 ## Récapitulatif des sujets ouverts
 
@@ -64,9 +64,9 @@ Tout sujet concret qui doit survivre au-delà de la séance en cours doit être 
 | BL-015 | 2026-04-13 | Amélioration | Import Excel / Outillage | P2 | Ajouter un reset sélectif orienté reprise pour rejouer proprement un import par filière ou période sans repartir systématiquement d'un effacement global |
 | BL-019 | 2026-04-13 | Documentation | Projet / Exploitation | P1 | Refaire le README et la documentation technique d'installation, mise à jour, pile techno, configuration et exploitation Docker |
 | BL-020 | 2026-04-13 | Documentation | Développement | P3 | Documenter clairement comment participer au projet : prérequis, environnement local, commandes utiles, qualité attendue et workflow PR |
+| BL-021 | 2026-04-13 | Documentation | Utilisateur / Parcours | P1 | Rédiger un manuel utilisateur illustré et pas à pas aligné sur les écrans réellement disponibles |
 | BL-022 | 2026-04-13 | Évolution | Utilisateurs / Sécurité | P1 | Renforcer la gestion des utilisateurs avec des rôles métier plus clairs, la création et l'administration des comptes, l'autonomie sur le profil et un socle de sécurité de compte plus complet |
 | BL-024 | 2026-04-13 | Correction | Paiements / Banque | P1 | Clarifier le workflow cible de saisie des paiements et corriger l'automatisme qui remet en banque les paiements `espèces` et `virement` dès leur encodage |
-| BL-027 | 2026-04-15 | Évolution | Import Excel / Trésorerie | P1 | Gérer une ouverture du système explicite pour Banque et Caisse sur le premier exercice importé |
 | BL-029 | 2026-04-16 | Évolution | Factures clients / UX métier | P1 | Repenser la saisie et l'import des factures clients autour de lignes typées (`cours`, `adhésion`, `autres`), avec remises portées par des lignes négatives du même type métier, et faire de ces lignes la source de vérité pour le total et la ventilation comptable |
 | BL-030 | 2026-04-16 | Décision | Métier / Edition des données | P1 | Définir une politique explicite de modification des objets métier déjà créés ou validés (factures, paiements, achats, etc.) avec règles de recalcul, traçabilité et limites selon le statut |
 
@@ -102,9 +102,11 @@ Tout sujet concret qui doit survivre au-delà de la séance en cours doit être 
 
 ### BL-005 — Politique de coexistence import / écritures existantes
 
-- **Dates** : `created=2026-04-12`
+- **Dates** : `created=2026-04-12`, `started=2026-04-19`
 - **Pourquoi** : l'import historique a désormais des garde-fous solides, mais la politique cible n'est pas encore entièrement tranchée quand des écritures manuelles, des écritures auto-générées ou des doublons métier proches coexistent déjà en base.
 - **Résultat attendu** : une politique explicite, documentée et testée qui dit pour chaque cas de coexistence ce qui doit être bloqué, toléré, ignoré comme doublon ou remonté pour revue manuelle avant d'ouvrir davantage l'import `Comptabilite` en réel.
+- **État actuel** : le contrat opérationnel courant des imports historiques est déjà consigné dans `doc/dev/import-excel-contract.md` avec les catégories `accepté / ignoré / bloquant / ambigu`, mais la matrice cible de coexistence fine entre imports, écritures auto-générées et écritures manuelles reste encore à formaliser explicitement.
+- **Avancement au 2026-04-19** : la politique de coexistence actuellement implémentée a été formalisée dans `doc/dev/bl-005-politique-coexistence-imports.md` à partir du comportement réel du code et des tests : avertissement non bloquant en présence d'écritures auto-générées, déduplication stricte des doublons exacts, coexistence autorisée avec des écritures `MANUAL`, signal non bloquant pour les écritures proches d'une `MANUAL`, blocage maintenu pour les rapprochements métier ambigus, et diagnostics désormais distincts entre `entry-existing` (doublon exact), `entry-covered-by-solde` (déjà couvert par Solde) et `entry-near-manual` (proximité avec une écriture manuelle).
 - **Cas à trancher explicitement** :
 	- import `Comptabilite` alors que des écritures auto-générées issues de la gestion existent déjà ;
 	- import `Comptabilite` alors que des écritures `MANUAL` existent déjà sur la même période ;
@@ -278,6 +280,7 @@ Tout sujet concret qui doit survivre au-delà de la séance en cours doit être 
 - **Dates** : `created=2026-04-13`
 - **Pourquoi** : la documentation projet existe mais reste encore trop dispersée ou trop implicite pour quelqu'un qui doit installer, mettre à jour ou exploiter Solde sans relire tout le dépôt.
 - **Résultat attendu** : un README plus clair et une documentation technique structurée couvrant au minimum l'installation, la mise à jour, la pile technologique, la configuration, Docker, les volumes de données, les sauvegardes et les points d'exploitation courants.
+- **État actuel** : le `README.md` couvre déjà le démarrage Docker/local, les variables d'environnement, la structure du dépôt et les liens de documentation ; il manque encore la documentation d'exploitation structurée attendue sur la mise à jour, les volumes de données, les sauvegardes et les opérations courantes.
 - **Priorisation proposée** : lot rapide et structurant ; c'est le meilleur point d'entrée documentation à livrer vite car il clarifie aussi le cadre pour les docs plus détaillées.
 - **Séquence recommandée** : commencer par clarifier le README, puis extraire les détails longs vers une doc technique dédiée plutôt que tout entasser en page d'accueil.
 - **Point d'attention** : distinguer ce qui relève du guide d'exploitation réel de ce qui relève des détails purement développeur, pour éviter un README surchargé.
@@ -287,6 +290,7 @@ Tout sujet concret qui doit survivre au-delà de la séance en cours doit être 
 - **Dates** : `created=2026-04-13`
 - **Pourquoi** : contribuer efficacement au projet suppose aujourd'hui de reconstituer les prérequis et les conventions depuis plusieurs fichiers, ce qui freine la reprise de contexte et la qualité des contributions.
 - **Résultat attendu** : une documentation développeur claire expliquant les prérequis, la mise en route locale, les commandes de build/test/lint, la qualité attendue, l'organisation du dépôt, le workflow de contribution et les attentes avant PR.
+- **État actuel** : le `README.md` fournit déjà une mise en route locale minimale et les commandes de base, et `doc/dev/gestion-utilisateurs-et-permissions.md` documente un sous-ensemble fonctionnel utile ; il manque encore une documentation développeur centrale sur le workflow de contribution, les commandes qualité réellement utilisées et les attentes avant PR.
 - **Priorisation proposée** : lot utile mais moins urgent ; à traiter après le cadrage README/doc technique et sans concurrencer le manuel utilisateur.
 - **Séquence recommandée** : s'appuyer sur les commandes et conventions déjà stabilisées dans le dépôt, puis documenter le workflow réel de contribution sans créer de nouvelle couche procédurale artificielle.
 - **Point d'attention** : cette documentation doit rester fidèle aux commandes réellement utilisées dans le dépôt, pas à un idéal théorique.
@@ -410,16 +414,17 @@ Tout sujet concret qui doit survivre au-delà de la séance en cours doit être 
 
 ### BL-027 — Gérer une ouverture du système explicite pour Banque et Caisse
 
-- **Dates** : `created=2026-04-15`
+- **Dates** : `created=2026-04-15`, `started=2026-04-15`, `completed=2026-04-16`
 - **Pourquoi** : pendant la validation `BL-026`, il apparaît que le premier exercice importé a besoin d'un point de départ explicite côté gestion pour `Banque` et `Caisse`, distinct de l'ouverture comptable de l'exercice. Aujourd'hui, les lignes Excel de `solde initial` sont traitées comme des lignes ignorées, ce qui ne permet pas de représenter proprement l'état hérité du système avant le premier exercice suivi.
 - **Résultat attendu** : définir puis implémenter une notion d'`ouverture du système` pour `Banque` et `Caisse`, injectée une seule fois sur le plus ancien exercice importé, contribuant aux soldes cumulés, et identifiée visiblement comme donnée spéciale dans l'interface (badge, type ou rendu distinct).
+- **Résultat livré** : une ouverture du système dédiée peut être configurée côté paramètres pour la `Banque` et la `Caisse`, avec une date par défaut calée sur le plus ancien exercice ; ces écritures sont stockées avec une source explicite `system_opening`, intégrées aux soldes, affichées distinctement dans les vues de trésorerie, et exclues des comparaisons d'import pour éviter les doublons ; le constat `BL-026` confirme ensuite le comportement attendu sur les chiffres visibles.
 - **Périmètre initial** :
 	- gérer explicitement un solde d'ouverture `Banque` sur le premier exercice importé ;
 	- gérer explicitement un solde d'ouverture `Caisse` sur le premier exercice importé ;
 	- rendre ces lignes distinguables des mouvements normaux dans les écrans de trésorerie ;
 	- éviter toute réinjection automatique du même concept sur les exercices suivants.
 - **Critère d'acceptation** : après import du plus ancien exercice, les écrans `Banque` et `Caisse` affichent un point de départ cohérent et identifié comme `ouverture du système`, les soldes des exercices suivants héritent correctement de ce point de départ sans doublon, et les chiffres `BL-026` peuvent être remesurés proprement pour la trésorerie.
-- **Point d'attention** : ce sujet doit être traité sur une branche distincte de `BL-026`, car il fera évoluer les chiffres de `Banque` et `Caisse` déjà relevés dans le constat de validation.
+- **Livré parce que** : le commit `1faa72a` du `2026-04-15` introduit l'ouverture du système et sa gestion d'import, puis le constat `BL-026` du `2026-04-16` documente explicitement son application sur `Banque` et `Caisse`.
 
 ### BL-029 — Saisie des factures clients pilotée par types de lignes
 
@@ -448,7 +453,7 @@ Tout sujet concret qui doit survivre au-delà de la séance en cours doit être 
 	- quelle règle appliquer si une facture mélange `cours`, `adhésion` et `autres`, avec ou sans lignes négatives de remise.
 - **Critère d'acceptation** : un utilisateur peut créer une facture client complète sans se poser de question sur le label comptable global ; le total affiché correspond exactement aux lignes saisies et les écritures générées à validation reflètent cette décomposition ligne par ligne.
 - **Point d'attention** : l'import `Comptabilité` deviendrait alors non seulement un import d'écritures, mais aussi un mécanisme d'enrichissement métier des factures déjà créées ; il faudra l'encadrer par des règles de sûreté et de coexistence explicites.
-- **État d'avancement au 2026-04-16** : l'implémentation a été livrée sur la branche `feature/bl-029-factures-clients-par-lignes` et poussée dans la PR `#18` ; la recette utilisateur reste à faire.
+- **État d'avancement au 2026-04-18** : l'implémentation a été fusionnée dans `develop` via le merge de la PR `#18` ; la recette utilisateur reste à faire avant clôture.
 - **Implémenté dans ce lot** :
 	- ajout d'un type de ligne de facture client (`cours`, `adhésion`, `autres`) en base, API et logique métier ;
 	- calcul du total, du label dérivé et de la ventilation comptable directement à partir des lignes, avec support des remises via lignes négatives ;
@@ -479,9 +484,10 @@ Tout sujet concret qui doit survivre au-delà de la séance en cours doit être 
 
 ## En cours
 
+- **BL-005** — `created=2026-04-12`, `started=2026-04-19` — La politique de coexistence réellement implémentée est maintenant explicitée dans `doc/dev/bl-005-politique-coexistence-imports.md`, avec diagnostics distincts entre doublon exact, ligne déjà couverte par Solde et proximité avec une écriture `MANUAL` ; il reste à décider si certains autres doublons proches doivent à l'avenir être signalés plus finement.
 - **BL-021** — `created=2026-04-13`, `started=2026-04-13` — Les lots 1 à 3 du manuel utilisateur sont livrés, mais le lot 4 reste à réaliser pour finaliser la stabilisation éditoriale et l'enrichissement visuel.
 - **BL-022** — `created=2026-04-13`, `started=2026-04-13` — Les lots 1 et 2 sont intégrés dans `develop` ; les lots suivants restent à traiter et le retest des droits réels a été traité séparément dans `BL-023`, désormais terminé.
-- **BL-029** — `created=2026-04-16`, `started=2026-04-16` — L'implémentation est poussée sur la PR `#18` avec lignes typées, import `Gestion`/`Comptabilité` adapté et UI revue ; la recette métier utilisateur reste à faire avant clôture.
+- **BL-029** — `created=2026-04-16`, `started=2026-04-16` — L'implémentation est désormais fusionnée dans `develop` via la PR `#18`, avec lignes typées, import `Gestion`/`Comptabilité` adapté et UI revue ; la recette métier utilisateur reste à faire avant clôture.
 
 ## Fait
 

--- a/doc/dev/bl-005-politique-coexistence-imports.md
+++ b/doc/dev/bl-005-politique-coexistence-imports.md
@@ -1,0 +1,121 @@
+# BL-005 — Politique de coexistence entre imports et écritures existantes
+
+## Objectif
+
+Rendre explicite la règle de coexistence actuelle entre :
+
+- les imports `Gestion` ;
+- les imports `Comptabilite` ;
+- les objets métier déjà présents dans Solde ;
+- les écritures comptables déjà générées automatiquement ;
+- les écritures comptables saisies manuellement.
+
+Ce document formalise la politique actuellement retenue dans le code pour éviter les décisions implicites ou contradictoires pendant les reprises historiques et la convergence Excel/Solde.
+
+## Principes directeurs
+
+1. La sûreté métier prime sur l'automatisation.
+2. Un import ne doit jamais réécrire silencieusement un objet ou une écriture existante sans règle explicite et sûre.
+3. En comptabilité, seul le doublon exact est dédupliqué automatiquement.
+4. Une ambiguïté de rapprochement métier doit être bloquée ou laissée à revue manuelle, jamais résolue arbitrairement.
+5. La coexistence avec des écritures `MANUAL` est autorisée tant qu'il n'existe pas de doublon exact.
+
+## Politique retenue
+
+### Vue synthétique
+
+| Cas | Preview | Import réel | Décision retenue |
+|---|---|---|---|
+| Fichier déjà importé à hash identique | bloqué | bloqué | refuser le réimport exact |
+| Doublon exact d'objet `Gestion` déjà présent | ignoré | ignoré | ne pas recréer le même objet métier |
+| Doublon exact de ligne comptable déjà présente | ignoré | ignoré | ne pas recréer la même ligne comptable |
+| Groupe comptable déjà couvert par des écritures auto-générées Solde | avertissement global + lignes ignorées | lignes ignorées | conserver Solde comme source déjà suffisante pour ce groupe |
+| Écritures `MANUAL` déjà présentes sur la période sans doublon exact | autorisé | autorisé | importer les nouvelles lignes en plus |
+| Rapprochement métier ambigu | bloqué | bloqué | exiger une résolution humaine |
+| Clarification sûre d'une facture client existante depuis `Comptabilite` | ignoré comme nouvelle écriture + clarification métier | clarification appliquée | enrichir l'objet existant sans dupliquer les écritures |
+| Doublon proche non exact | signal implicite seulement via delta ou comportement normal | importé comme nouvelle écriture | ne pas fusionner automatiquement un cas ambigu |
+
+## Règles détaillées par famille de cas
+
+### 1. Idempotence par fichier
+
+- Un fichier déjà importé avec succès, identifié par le même hash, est refusé.
+- Cette règle vaut pour `Gestion` comme pour `Comptabilite`.
+- Le diagnostic visible est `already-imported`.
+
+### 2. Imports `Gestion`
+
+#### Contacts, factures, salaires déjà présents
+
+- Si l'objet existe déjà selon la signature métier actuellement retenue, la ligne est ignorée.
+- L'import ne tente pas de fusionner, compléter ou écraser l'objet existant.
+
+#### Paiements, banque, caisse déjà présents
+
+- Si la signature de comparaison métier existe déjà dans Solde, la ligne est ignorée.
+- Le but est d'éviter le doublon fonctionnel, pas seulement le doublon technique de ligne.
+
+#### Cas ambigus côté `Gestion`
+
+- Si un contact client est ambigu, la facture est bloquée.
+- Si un paiement ne peut pas être rapproché de façon sûre, il est bloqué.
+- Si plusieurs candidats existent pour un même rapprochement, il est bloqué.
+
+### 3. Imports `Comptabilite`
+
+#### Doublon exact de ligne comptable
+
+- Une ligne `Journal` déjà présente avec la même signature `(date, compte, libellé normalisé, débit, crédit)` est ignorée.
+- Cette déduplication est volontairement stricte.
+
+#### Groupe déjà couvert par Solde
+
+- Si un groupe d'écritures correspond déjà à un groupe auto-généré par Solde (`invoice`, `payment`, `deposit`, `salary`, `gestion`, `cloture`), il est ignoré ligne par ligne.
+- La preview ajoute un avertissement global de coexistence pour signaler qu'une partie du journal Excel recouvre des écritures déjà produites dans Solde.
+- Cet avertissement n'est pas bloquant.
+
+#### Écritures `MANUAL` déjà existantes
+
+- La simple présence d'écritures `MANUAL` n'empêche pas l'import `Comptabilite`.
+- Si une nouvelle ligne comptable ne correspond pas à un doublon exact, elle est importée comme nouvelle écriture `MANUAL`.
+- La règle retenue est de ne pas surbloquer un import historique à cause d'une comptabilité manuelle existante, tout en conservant la déduplication stricte.
+- Quand une ligne importée partage la même date, le même compte et les mêmes montants qu'une écriture `MANUAL` sans être un doublon exact sur le libellé, Solde émet un avertissement non bloquant de proximité pour inviter à revue manuelle.
+
+#### Clarification d'une facture client existante
+
+- Si des écritures `Comptabilite` correspondent à une facture client déjà présente dans Solde, Solde ne crée pas de nouvelle écriture comptable manuelle pour la dupliquer.
+- Si la facture existante peut être clarifiée de façon sûre à partir des écritures, cette clarification est appliquée.
+- Sinon, les lignes sont ignorées comme déjà couvertes par l'existant.
+
+### 4. Doublons proches et écarts ambigus
+
+- Un doublon proche mais non exact n'est pas automatiquement fusionné.
+- Exemple typique : même date, même compte et même montant, mais libellé différent sans preuve suffisante qu'il s'agit de la même écriture.
+- Dans ce cas, la règle retenue reste conservatrice : on préfère conserver deux écritures plutôt que supprimer ou fusionner à tort.
+
+## Traduction opérationnelle actuelle dans les diagnostics
+
+Les catégories stables actuellement visibles ou dérivables sont notamment :
+
+- `already-imported` pour le réimport exact d'un fichier ;
+- `entry-existing` pour une écriture comptable déjà présente ;
+- `entry-covered-by-solde` pour une ligne comptable déjà couverte par un groupe métier ou une opération existante dans Solde ;
+- `entry-near-manual` pour une ligne comptable proche d'une écriture `MANUAL` existante mais non strictement identique ;
+- `existing-row-in-solde` pour une ligne de gestion déjà représentée dans Solde ;
+- `comptabilite-coexistence` pour l'avertissement global de coexistence avec des écritures auto-générées ;
+- les catégories d'ambiguïté ou d'échec de rapprochement (`invoice-ambiguous-contact`, `payment-unmatched`, etc.) pour les cas à bloquer.
+
+## Ce que BL-005 acte maintenant
+
+BL-005 acte la politique suivante comme cible produit actuelle :
+
+- coexistence autorisée avec l'existant quand le cas est sûr et non destructif ;
+- déduplication automatique uniquement sur les doublons exacts ou les groupes explicitement reconnus comme déjà couverts par Solde ;
+- aucun blocage de principe sur la seule présence d'écritures `MANUAL` ;
+- signal non bloquant quand une ligne importée est proche d'une écriture `MANUAL` existante sans être strictement identique ;
+- aucun écrasement silencieux d'une donnée existante ;
+- blocage dès qu'un rapprochement métier devient ambigu.
+
+## Suites éventuelles hors de ce cadrage initial
+
+- décider si certains autres doublons proches doivent un jour être signalés explicitement pour revue manuelle au-delà du cas `MANUAL` déjà couvert.

--- a/tests/integration/test_import_api.py
+++ b/tests/integration/test_import_api.py
@@ -5217,16 +5217,14 @@ async def test_import_comptabilite_blocks_reimport_of_same_file(
 
 @pytest.mark.asyncio
 @pytest.mark.skipif(not OPENPYXL_AVAILABLE, reason="openpyxl not installed")
-async def test_preview_and_import_comptabilite_ignores_exact_duplicates_and_keeps_new_rows(
+async def test_preview_and_import_comptabilite_ignores_rows_already_covered_by_solde(
     client: AsyncClient,
     auth_headers: dict,
     db_session,
 ) -> None:
-    """Comptabilité import should ignore exact duplicates and keep new rows."""
+    """Comptabilité import should ignore rows already covered by Solde and keep new rows."""
     from datetime import date
     from decimal import Decimal
-
-    from sqlalchemy import select
 
     from backend.models.accounting_entry import AccountingEntry, EntrySourceType
     from backend.models.fiscal_year import FiscalYear, FiscalYearStatus
@@ -5278,7 +5276,12 @@ async def test_preview_and_import_comptabilite_ignores_exact_duplicates_and_keep
     assert preview_data["estimated_entries"] == 1
     assert preview_data["sheets"][0]["ignored_rows"] == 1
     assert any(
-        "deja existante" in warning.lower() for warning in preview_data["sheets"][0]["warnings"]
+        "deja couverte par solde" in warning.lower()
+        for warning in preview_data["sheets"][0]["warnings"]
+    )
+    assert any(
+        detail["category"] == "entry-covered-by-solde"
+        for detail in preview_data["sheets"][0]["warning_details"]
     )
 
     import_response = await client.post(
@@ -5293,6 +5296,79 @@ async def test_preview_and_import_comptabilite_ignores_exact_duplicates_and_keep
     assert import_data["ignored_rows"] == 1
     assert import_data["errors"] == []
 
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not OPENPYXL_AVAILABLE, reason="openpyxl not installed")
+async def test_preview_and_import_comptabilite_ignores_exact_manual_duplicates_with_exact_category(
+    client: AsyncClient,
+    auth_headers: dict,
+    db_session,
+) -> None:
+    """Exact duplicates against existing manual entries stay categorized as entry-existing."""
+    from datetime import date
+    from decimal import Decimal
+
+    from sqlalchemy import select
+
+    from backend.models.accounting_entry import AccountingEntry, EntrySourceType
+
+    db_session.add(
+        AccountingEntry(
+            entry_number="000001",
+            date=date(2025, 8, 1),
+            account_number="411100",
+            label="Ecriture manuelle existante",
+            debit=Decimal("55"),
+            credit=Decimal("0"),
+            source_type=EntrySourceType.MANUAL,
+            source_id=None,
+        )
+    )
+    await db_session.commit()
+
+    content = _make_multi_sheet_xlsx(
+        {
+            "Journal": (
+                ["Date", "N° compte", "Libellé de l'écriture", "Débit", "Crédit"],
+                [["2025-08-01", "411100", "Ecriture manuelle existante", 55, None]],
+            ),
+        }
+    )
+
+    preview_response = await client.post(
+        "/api/import/excel/comptabilite/preview",
+        files={"file": ("Comptabilite exact-duplicate.xlsx", content, _XLSX_MIME)},
+        headers=auth_headers,
+    )
+
+    assert preview_response.status_code == 200
+    preview_data = preview_response.json()
+    assert preview_data["estimated_entries"] == 0
+    assert preview_data["sheets"][0]["ignored_rows"] == 1
+    assert any(
+        "deja existante" in warning.lower() for warning in preview_data["sheets"][0]["warnings"]
+    )
+    assert any(
+        detail["category"] == "entry-existing"
+        for detail in preview_data["sheets"][0]["warning_details"]
+    )
+    assert all(
+        detail["category"] != "entry-near-manual"
+        for detail in preview_data["sheets"][0]["warning_details"]
+    )
+
+    import_response = await client.post(
+        "/api/import/excel/comptabilite",
+        files={"file": ("Comptabilite exact-duplicate.xlsx", content, _XLSX_MIME)},
+        headers=auth_headers,
+    )
+
+    assert import_response.status_code == 200
+    import_data = import_response.json()
+    assert import_data["entries_created"] == 0
+    assert import_data["ignored_rows"] == 1
+    assert import_data["errors"] == []
+
     manual_entries = (
         (
             await db_session.execute(
@@ -5303,9 +5379,95 @@ async def test_preview_and_import_comptabilite_ignores_exact_duplicates_and_keep
         .all()
     )
     assert len(manual_entries) == 1
-    assert manual_entries[0].account_number == "706200"
-    assert manual_entries[0].label == "Nouvelle ecriture"
-    assert manual_entries[0].fiscal_year_id == fiscal_year.id
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not OPENPYXL_AVAILABLE, reason="openpyxl not installed")
+async def test_preview_and_import_comptabilite_warns_for_near_manual_entries_without_blocking(
+    client: AsyncClient,
+    auth_headers: dict,
+    db_session,
+) -> None:
+    """Near matches with manual entries should warn but still import."""
+    from datetime import date
+    from decimal import Decimal
+
+    from sqlalchemy import select
+
+    from backend.models.accounting_entry import AccountingEntry, EntrySourceType
+
+    db_session.add(
+        AccountingEntry(
+            entry_number="000001",
+            date=date(2025, 8, 1),
+            account_number="411100",
+            label="Libelle manuel",
+            debit=Decimal("55"),
+            credit=Decimal("0"),
+            source_type=EntrySourceType.MANUAL,
+            source_id=None,
+        )
+    )
+    await db_session.commit()
+
+    content = _make_multi_sheet_xlsx(
+        {
+            "Journal": (
+                ["Date", "N° compte", "Libellé de l'écriture", "Débit", "Crédit"],
+                [["2025-08-01", "411100", "Libelle importe", 55, None]],
+            ),
+        }
+    )
+
+    preview_response = await client.post(
+        "/api/import/excel/comptabilite/preview",
+        files={"file": ("Comptabilite near-manual.xlsx", content, _XLSX_MIME)},
+        headers=auth_headers,
+    )
+
+    assert preview_response.status_code == 200
+    preview_data = preview_response.json()
+    assert preview_data["can_import"] is True
+    assert preview_data["estimated_entries"] == 1
+    assert preview_data["sheets"][0]["ignored_rows"] == 0
+    assert any(
+        "proche d'une ecriture manuelle existante" in warning.lower()
+        for warning in preview_data["sheets"][0]["warnings"]
+    )
+    assert any(
+        detail["category"] == "entry-near-manual"
+        for detail in preview_data["sheets"][0]["warning_details"]
+    )
+
+    import_response = await client.post(
+        "/api/import/excel/comptabilite",
+        files={"file": ("Comptabilite near-manual.xlsx", content, _XLSX_MIME)},
+        headers=auth_headers,
+    )
+
+    assert import_response.status_code == 200
+    import_data = import_response.json()
+    assert import_data["entries_created"] == 1
+    assert import_data["ignored_rows"] == 0
+    assert import_data["errors"] == []
+    assert any(
+        "proche d'une ecriture manuelle existante" in warning.lower()
+        for warning in import_data["warnings"]
+    )
+    assert any(
+        detail["category"] == "entry-near-manual" for detail in import_data["warning_details"]
+    )
+
+    manual_entries = (
+        (
+            await db_session.execute(
+                select(AccountingEntry).where(AccountingEntry.source_type == EntrySourceType.MANUAL)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(manual_entries) == 2
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_excel_import_policy.py
+++ b/tests/unit/test_excel_import_policy.py
@@ -23,10 +23,12 @@ from backend.services.excel_import_policy import (
     CONTACT_REQUIRED_NAME_MESSAGE,
     DUPLICATE_CONTACT_MESSAGE,
     DUPLICATE_INVOICE_MESSAGE,
+    ENTRY_COVERED_BY_SOLDE_MESSAGE,
     ENTRY_INVALID_CREDIT_MESSAGE,
     ENTRY_INVALID_DATE_MESSAGE,
     ENTRY_INVALID_DEBIT_MESSAGE,
     ENTRY_MISSING_ACCOUNT_MESSAGE,
+    ENTRY_NEAR_EXISTING_MANUAL_MESSAGE,
     ENTRY_REQUIRED_ACCOUNT_OR_AMOUNT_COLUMNS,
     EXISTING_CONTACT_MESSAGE,
     EXISTING_INVOICE_MESSAGE,
@@ -465,6 +467,8 @@ def test_issue_category_for_message_uses_global_prefixes() -> None:
         )
         == "comptabilite-coexistence"
     )
+    assert issue_category_for_message(ENTRY_COVERED_BY_SOLDE_MESSAGE) == "entry-covered-by-solde"
+    assert issue_category_for_message(ENTRY_NEAR_EXISTING_MANUAL_MESSAGE) == "entry-near-manual"
     assert issue_category_for_message("Erreur import gestion : boom") == "import-error"
 
 

--- a/tests/unit/test_excel_import_results.py
+++ b/tests/unit/test_excel_import_results.py
@@ -226,3 +226,66 @@ def test_preview_result_to_dict_categorizes_global_errors_and_warnings() -> None
             ),
         },
     ]
+
+
+def test_preview_result_to_dict_categorizes_sheet_warning_for_existing_solde_coverage() -> None:
+    preview = PreviewResult()
+    preview.sheets = [
+        {
+            "name": "Journal",
+            "kind": "entries",
+            "status": "recognized",
+            "rows": 0,
+            "source_rows": 1,
+            "detected_columns": [],
+            "missing_columns": [],
+            "ignored_rows": 1,
+            "policy_ignored_rows": 1,
+            "blocked_rows": 0,
+            "initial_blocked_rows": 0,
+            "sample_rows": [],
+            "warnings": ["Ligne 4 : ecriture deja couverte par Solde, ligne ignoree"],
+            "errors": [],
+        }
+    ]
+    preview.warnings = ["Journal — Ligne 4 : ecriture deja couverte par Solde, ligne ignoree"]
+
+    payload = preview.to_dict()
+
+    assert payload["sheets"][0]["warning_details"] == [
+        {
+            "category": "entry-covered-by-solde",
+            "severity": "warning",
+            "sheet_name": "Journal",
+            "kind": "entries",
+            "row_number": 4,
+            "message": "ecriture deja couverte par Solde, ligne ignoree",
+            "display_message": "Ligne 4 : ecriture deja couverte par Solde, ligne ignoree",
+        }
+    ]
+
+
+def test_import_result_to_dict_categorizes_sheet_warning_for_near_manual_entry() -> None:
+    result = ImportResult()
+    result.add_warning(
+        "Journal",
+        "entries",
+        "Ligne 7 : ecriture proche d'une ecriture manuelle existante, revue conseillee",
+    )
+
+    payload = result.to_dict()
+
+    assert payload["warning_details"] == [
+        {
+            "category": "entry-near-manual",
+            "severity": "warning",
+            "sheet_name": "Journal",
+            "kind": "entries",
+            "row_number": 7,
+            "message": "ecriture proche d'une ecriture manuelle existante, revue conseillee",
+            "display_message": (
+                "Journal — Ligne 7 : ecriture proche d'une ecriture manuelle "
+                "existante, revue conseillee"
+            ),
+        }
+    ]


### PR DESCRIPTION
## Summary
This PR clarifies and hardens the current BL-005 coexistence policy for historical Excel accounting imports.

It:
- distinguishes exact duplicate accounting rows from rows already covered by Solde-generated business groups
- adds a non-blocking `entry-near-manual` warning when an imported accounting row matches an existing manual row on date/account/amounts but differs on label
- documents the implemented coexistence policy and updates the backlog status accordingly

## Implementation Notes
- exact duplicates still stay ignored as `entry-existing`
- rows already represented by Solde-generated groups now use `entry-covered-by-solde`
- near matches with existing `MANUAL` entries remain importable and are surfaced as warnings in both preview and real import flows

## Validation
- `python -m ruff check .`
- `python -m ruff format --check .`
- `python -m mypy .`
- `python -m pytest tests/ -q`
- `npx prettier --check src/`
- `npm run type-check`
- `npx eslint src/`
- `npm run test:unit -- --run`

## Summary by Sourcery

Clarify coexistence behaviour between historical Excel accounting imports and existing entries by distinguishing duplicates, Solde-covered groups, and near-manual matches, and document the current policy.

New Features:
- Surface non-blocking entry-near-manual warnings when imported accounting lines closely match existing manual entries.
- Expose structured warning categories for entry-covered-by-solde and entry-near-manual in preview and import results.

Enhancements:
- Refine accounting import coexistence logic so groups already covered by Solde are reported as entry-covered-by-solde instead of generic duplicates.
- Introduce row-level warning handling in the Excel import pipeline to support non-blocking diagnostics.
- Improve backlog documentation to describe the implemented coexistence policy and update BL-related statuses and progress notes.

Documentation:
- Add a developer document detailing the current coexistence policy between imports, auto-generated entries, and manual accounting entries, and update backlog documentation to reflect this policy and related BL items.

Tests:
- Add integration coverage for Solde-covered accounting rows, exact manual duplicates, and near-manual entries during preview and import flows.
- Extend unit tests to assert categorization of new warning types in preview/import results and policy issue mapping.