### PR TITLE
feat(auth): add profile and account security flows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Ce projet respecte le [Versionnage sémantique](https://semver.org/lang/fr/).
 **Gestion des utilisateurs**
 - Documentation de cadrage `doc/dev/gestion-utilisateurs-et-permissions.md` pour clarifier la cible produit des rôles et la matrice simplifiée des permissions
 - Administration des comptes réservée à l'administrateur avec liste, création, activation/désactivation et changement de rôle
+- Espace `Mon profil` permettant à chaque utilisateur authentifié de consulter son compte, de mettre à jour son e-mail et de changer son mot de passe
+- Procédure de réinitialisation d'accès par l'administrateur avec mot de passe temporaire pour le contexte auto-hébergé
 
 **Frontend — filtre générique**
 - Composable `useTableFilter` + `applyFilter` (`composables/useTableFilter.ts`) : filtre client-side fuzzy sur tous les champs d'un tableau
@@ -51,6 +53,7 @@ Ce projet respecte le [Versionnage sémantique](https://semver.org/lang/fr/).
 ### Corrigé
 
 **Backend**
+- invalidation des anciens jetons JWT après changement ou réinitialisation de mot de passe pour éviter qu'une ancienne session reste active
 - `excel_import.py` : support des feuilles Caisse (`caisse`/`cash`) et Banque (`banque`/`bank`/`relev`) dans l'import Excel de gestion ; déduplication des numéros de factures dans le même batch ; création automatique du contact si absent (plutôt que saut de ligne silencieux)
 - sécurité et robustesse revues après commentaires de PR : secret JWT obligatoire hors dev/test, conversion propre des erreurs d'édition manuelle en réponses HTTP, metadata Alembic complétée pour l'autogénération
 - factures clients mixtes `cs+a` : quand la feuille `Factures` expose des montants distincts `cours` et `adhésion`, l'import historique crée les lignes de facture correspondantes et la génération comptable ventile désormais les produits sur les comptes dédiés au lieu d'un seul produit global

--- a/backend/alembic/versions/0016_add_user_password_changed_at.py
+++ b/backend/alembic/versions/0016_add_user_password_changed_at.py
@@ -1,0 +1,31 @@
+"""Migration 0016 - add user password changed timestamp."""
+
+from datetime import UTC, datetime
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0016"
+down_revision = "0015"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("users") as batch_op:
+        batch_op.add_column(sa.Column("password_changed_at", sa.DateTime(), nullable=True))
+
+    update_password_changed_at = sa.text(
+        "UPDATE users SET password_changed_at = :timestamp WHERE password_changed_at IS NULL"
+    )
+    op.execute(
+        update_password_changed_at.bindparams(timestamp=datetime.now(UTC).replace(tzinfo=None))
+    )
+
+    with op.batch_alter_table("users") as batch_op:
+        batch_op.alter_column("password_changed_at", existing_type=sa.DateTime(), nullable=False)
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("users") as batch_op:
+        batch_op.drop_column("password_changed_at")

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -1,6 +1,6 @@
 """User model — authentication and role management."""
 
-from datetime import datetime
+from datetime import UTC, datetime
 from enum import StrEnum
 
 from sqlalchemy import Boolean, DateTime, String, func
@@ -27,6 +27,11 @@ class User(Base):
     username: Mapped[str] = mapped_column(String(50), unique=True, nullable=False, index=True)
     email: Mapped[str] = mapped_column(String(255), unique=True, nullable=False, index=True)
     password_hash: Mapped[str] = mapped_column(String(255), nullable=False)
+    password_changed_at: Mapped[datetime] = mapped_column(
+        DateTime,
+        nullable=False,
+        default=lambda: datetime.now(UTC),
+    )
     role: Mapped[UserRole] = mapped_column(String(20), nullable=False, default=UserRole.READONLY)
     is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
     created_at: Mapped[datetime] = mapped_column(

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -1,9 +1,10 @@
-"""Authentication router — login, refresh, current user."""
+"""Authentication router — login, refresh, current user and account security."""
 
 from collections.abc import Callable
+from datetime import UTC, datetime
 from typing import Annotated, Any
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Response, status
 from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
 from sqlalchemy import func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -11,11 +12,14 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from backend.database import get_db
 from backend.models.user import User, UserRole
 from backend.schemas.auth import (
+    PasswordChangeRequest,
     RefreshRequest,
     TokenResponse,
     UserAdminUpdate,
     UserCreate,
+    UserPasswordReset,
     UserRead,
+    UserSelfUpdate,
 )
 from backend.services.auth import (
     create_access_token,
@@ -51,6 +55,12 @@ async def get_current_user(
     user = result.scalar_one_or_none()
     if user is None:
         raise credentials_exception
+
+    issued_at = payload.get("iat")
+    if isinstance(issued_at, (int, float)):
+        password_changed_at = user.password_changed_at.replace(tzinfo=UTC).timestamp()
+        if float(issued_at) < password_changed_at:
+            raise credentials_exception
     return user
 
 
@@ -82,6 +92,15 @@ def _admin_user_update_exception(
     status_code: int = status.HTTP_400_BAD_REQUEST,
 ) -> HTTPException:
     """Build a stable error payload for admin-managed user updates."""
+    return HTTPException(status_code=status_code, detail={"code": code, "message": message})
+
+
+def _account_security_exception(
+    code: str,
+    message: str,
+    status_code: int = status.HTTP_400_BAD_REQUEST,
+) -> HTTPException:
+    """Build a stable error payload for profile and password flows."""
     return HTTPException(status_code=status_code, detail={"code": code, "message": message})
 
 
@@ -179,6 +198,60 @@ async def get_me(
     return current_user
 
 
+@router.patch("/me", response_model=UserRead)
+async def update_me(
+    body: UserSelfUpdate,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    current_user: Annotated[User, Depends(get_current_user)],
+) -> User:
+    """Update the authenticated user's own profile fields."""
+    normalized_email = body.email.strip()
+    if not normalized_email:
+        raise _account_security_exception("email_required", "Email is required")
+
+    if normalized_email == current_user.email:
+        raise _account_security_exception("no_changes", "No changes requested")
+
+    existing = await db.execute(
+        select(User).where(User.email == normalized_email, User.id != current_user.id)
+    )
+    if existing.scalar_one_or_none() is not None:
+        raise _account_security_exception(
+            "email_exists",
+            "Email already exists",
+            status.HTTP_409_CONFLICT,
+        )
+
+    current_user.email = normalized_email
+    await db.commit()
+    await db.refresh(current_user)
+    return current_user
+
+
+@router.post("/me/change-password", status_code=status.HTTP_204_NO_CONTENT)
+async def change_my_password(
+    body: PasswordChangeRequest,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    current_user: Annotated[User, Depends(get_current_user)],
+) -> Response:
+    """Change the authenticated user's password and invalidate older tokens."""
+    if not verify_password(body.current_password, current_user.password_hash):
+        raise _account_security_exception(
+            "invalid_current_password",
+            "Current password is incorrect",
+        )
+    if verify_password(body.new_password, current_user.password_hash):
+        raise _account_security_exception(
+            "same_password",
+            "New password must differ from the current password",
+        )
+
+    current_user.password_hash = hash_password(body.new_password)
+    current_user.password_changed_at = datetime.now(UTC)
+    await db.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
 @router.post(
     "/users",
     response_model=UserRead,
@@ -256,3 +329,29 @@ async def update_user(
     await db.commit()
     await db.refresh(user)
     return user
+
+
+@router.post(
+    "/users/{user_id}/reset-password",
+    status_code=status.HTTP_204_NO_CONTENT,
+    dependencies=[Depends(require_role(UserRole.ADMIN))],
+)
+async def reset_user_password(
+    user_id: int,
+    body: UserPasswordReset,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> Response:
+    """Reset a user's password through an admin-managed procedure."""
+    result = await db.execute(select(User).where(User.id == user_id))
+    user = result.scalar_one_or_none()
+    if user is None:
+        raise _admin_user_update_exception(
+            "user_not_found",
+            "User not found",
+            status.HTTP_404_NOT_FOUND,
+        )
+
+    user.password_hash = hash_password(body.new_password)
+    user.password_changed_at = datetime.now(UTC)
+    await db.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -57,10 +57,12 @@ async def get_current_user(
         raise credentials_exception
 
     issued_at = payload.get("iat")
-    if isinstance(issued_at, (int, float)):
-        password_changed_at = user.password_changed_at.replace(tzinfo=UTC).timestamp()
-        if float(issued_at) < password_changed_at:
-            raise credentials_exception
+    if not isinstance(issued_at, (int, float)):
+        raise credentials_exception
+
+    password_changed_at = user.password_changed_at.replace(tzinfo=UTC).timestamp()
+    if float(issued_at) < password_changed_at:
+        raise credentials_exception
     return user
 
 

--- a/backend/schemas/auth.py
+++ b/backend/schemas/auth.py
@@ -58,4 +58,31 @@ class UserAdminUpdate(BaseModel):
     role: UserRole | None = None
     is_active: bool | None = None
 
+
+class UserSelfUpdate(BaseModel):
+    email: str
+
+
+class PasswordChangeRequest(BaseModel):
+    current_password: str
+    new_password: str
+
+    @field_validator("new_password")
+    @classmethod
+    def password_min_length(cls, v: str) -> str:
+        if len(v) < 8:
+            raise ValueError("Password must be at least 8 characters")
+        return v
+
+
+class UserPasswordReset(BaseModel):
+    new_password: str
+
+    @field_validator("new_password")
+    @classmethod
+    def password_min_length(cls, v: str) -> str:
+        if len(v) < 8:
+            raise ValueError("Password must be at least 8 characters")
+        return v
+
     model_config = {"from_attributes": True}

--- a/backend/schemas/auth.py
+++ b/backend/schemas/auth.py
@@ -6,6 +6,18 @@ from pydantic import BaseModel, field_validator
 
 from backend.models.user import UserRole
 
+PASSWORD_MIN_LENGTH = 8
+
+
+def _validate_password_min_length(value: str) -> str:
+    if len(value) < PASSWORD_MIN_LENGTH:
+        raise ValueError(f"Password must be at least {PASSWORD_MIN_LENGTH} characters")
+    return value
+
+
+class OrmReadModel(BaseModel):
+    model_config = {"from_attributes": True}
+
 
 class LoginRequest(BaseModel):
     username: str
@@ -31,9 +43,7 @@ class UserCreate(BaseModel):
     @field_validator("password")
     @classmethod
     def password_min_length(cls, v: str) -> str:
-        if len(v) < 8:
-            raise ValueError("Password must be at least 8 characters")
-        return v
+        return _validate_password_min_length(v)
 
     @field_validator("username")
     @classmethod
@@ -43,15 +53,13 @@ class UserCreate(BaseModel):
         return v
 
 
-class UserRead(BaseModel):
+class UserRead(OrmReadModel):
     id: int
     username: str
     email: str
     role: UserRole
     is_active: bool
     created_at: datetime
-
-    model_config = {"from_attributes": True}
 
 
 class UserAdminUpdate(BaseModel):
@@ -70,9 +78,7 @@ class PasswordChangeRequest(BaseModel):
     @field_validator("new_password")
     @classmethod
     def password_min_length(cls, v: str) -> str:
-        if len(v) < 8:
-            raise ValueError("Password must be at least 8 characters")
-        return v
+        return _validate_password_min_length(v)
 
 
 class UserPasswordReset(BaseModel):
@@ -81,8 +87,4 @@ class UserPasswordReset(BaseModel):
     @field_validator("new_password")
     @classmethod
     def password_min_length(cls, v: str) -> str:
-        if len(v) < 8:
-            raise ValueError("Password must be at least 8 characters")
-        return v
-
-    model_config = {"from_attributes": True}
+        return _validate_password_min_length(v)

--- a/backend/services/auth.py
+++ b/backend/services/auth.py
@@ -34,11 +34,13 @@ def create_access_token(
     """
     settings = get_settings()
     payload = data.copy()
-    expire = datetime.now(UTC) + (
+    now = datetime.now(UTC)
+    expire = now + (
         expires_delta
         if expires_delta is not None
         else timedelta(minutes=settings.jwt_access_token_expire_minutes)
     )
+    payload["iat"] = now.timestamp()
     payload["exp"] = expire
     return jwt.encode(payload, settings.jwt_secret_key, algorithm=settings.jwt_algorithm)
 
@@ -60,7 +62,6 @@ def decode_access_token(token: str) -> dict[str, Any] | None:
     """
     settings = get_settings()
     try:
-        payload = jwt.decode(token, settings.jwt_secret_key, algorithms=[settings.jwt_algorithm])
-        return payload
+        return jwt.decode(token, settings.jwt_secret_key, algorithms=[settings.jwt_algorithm])
     except JWTError:
         return None

--- a/doc/backlog.md
+++ b/doc/backlog.md
@@ -51,8 +51,8 @@ Tout sujet concret qui doit survivre au-delà de la séance en cours doit être 
 ## Priorités proposées pour la prochaine discussion
 
 1. **BL-024** — clarifier le workflow de saisie des paiements et corriger les remises en banque automatiques.
-2. **BL-022** — terminer les lots restants sur la gestion des utilisateurs, profils et sécurité de compte.
-3. **BL-021** — finaliser le manuel utilisateur illustré avec stabilisation éditoriale et enrichissement visuel.
+2. **BL-021** — finaliser le manuel utilisateur illustré avec stabilisation éditoriale et enrichissement visuel.
+3. **BL-019** — refaire le README et la documentation technique d'installation, mise à jour, pile techno, configuration et exploitation Docker.
 
 ## Récapitulatif des sujets ouverts
 
@@ -64,7 +64,6 @@ Tout sujet concret qui doit survivre au-delà de la séance en cours doit être 
 | BL-019 | 2026-04-13 | Documentation | Projet / Exploitation | P1 | Refaire le README et la documentation technique d'installation, mise à jour, pile techno, configuration et exploitation Docker |
 | BL-020 | 2026-04-13 | Documentation | Développement | P3 | Documenter clairement comment participer au projet : prérequis, environnement local, commandes utiles, qualité attendue et workflow PR |
 | BL-021 | 2026-04-13 | Documentation | Utilisateur / Parcours | P1 | Rédiger un manuel utilisateur illustré et pas à pas aligné sur les écrans réellement disponibles |
-| BL-022 | 2026-04-13 | Évolution | Utilisateurs / Sécurité | P1 | Renforcer la gestion des utilisateurs avec des rôles métier plus clairs, la création et l'administration des comptes, l'autonomie sur le profil et un socle de sécurité de compte plus complet |
 | BL-024 | 2026-04-13 | Correction | Paiements / Banque | P1 | Clarifier le workflow cible de saisie des paiements et corriger l'automatisme qui remet en banque les paiements `espèces` et `virement` dès leur encodage |
 | BL-030 | 2026-04-16 | Décision | Métier / Edition des données | P1 | Définir une politique explicite de modification des objets métier déjà créés ou validés (factures, paiements, achats, etc.) avec règles de recalcul, traçabilité et limites selon le statut |
 
@@ -320,35 +319,13 @@ Tout sujet concret qui doit survivre au-delà de la séance en cours doit être 
 
 ### BL-022 — Gestion des utilisateurs, rôles et sécurité de compte
 
-- **Dates** : `created=2026-04-13`, `started=2026-04-13`
+- **Dates** : `created=2026-04-13`, `started=2026-04-13`, `completed=2026-04-19`
 - **Pourquoi** : l'authentification existe déjà, mais la gestion des utilisateurs reste encore trop limitée pour un usage réel durable avec plusieurs profils, une administration claire des comptes et des attentes minimales de sécurité.
 - **Résultat attendu** : faire évoluer la gestion des comptes pour couvrir un vrai cycle de vie utilisateur : rôles métier lisibles, création et administration des comptes, autonomie minimale des utilisateurs sur leur propre profil et mécanismes de sécurité cohérents pour l'accès au compte.
-- **Périmètre fonctionnel visé** :
-	- revoir les rôles pour coller aux usages métier cibles (`admin`, `gestionnaire`, `comptable`) avec une matrice d'autorisations compréhensible ;
-	- permettre la création, l'activation, la désactivation et la gestion courante des comptes ;
-	- permettre à chaque utilisateur de consulter et modifier son profil dans un périmètre maîtrisé ;
-	- couvrir au minimum le changement de mot de passe, la réinitialisation ou récupération de compte, et les garde-fous usuels d'authentification.
-- **Questions à trancher** :
-	- comment faire correspondre les rôles actuels aux rôles métier attendus sans casser les règles d'autorisation déjà en place ;
-	- quelle part de gestion du profil est laissée à l'utilisateur lui-même versus à l'administrateur ;
-	- quel mécanisme réaliste retenir pour le mot de passe perdu dans un contexte associatif auto-hébergé.
 - **Critère d'acceptation** : un administrateur doit pouvoir gérer les comptes et leurs rôles sans intervention technique, et un utilisateur doit pouvoir accéder à son compte, gérer son profil essentiel et récupérer ou faire réinitialiser son accès selon un processus clair et sûr.
 - **État de départ actuel** : l'application dispose déjà d'une authentification JWT, d'un utilisateur courant, d'une création de compte réservée à l'admin et de rôles techniques (`readonly`, `secretaire`, `tresorier`, `admin`), mais pas encore d'interface complète ni de cycle de vie cohérent du compte.
-- **Avancement actuel** : les lots 1 et 2 sont désormais intégrés dans `develop` avec la documentation des rôles et l'administration des comptes ; le retest métier laisse toutefois ouverte la question de la matrice d'autorisations réellement observée, capturée séparément dans `BL-023`.
-- **Lotissement recommandé** :
-	- lot 1 : clarifier la cible produit des rôles et produire une matrice d'autorisations lisible ;
-	- lot 2 : ajouter l'administration des comptes (`liste`, `création`, `activation/désactivation`, changement de rôle) ;
-	- lot 3 : ajouter l'espace `mon profil` pour consultation et modification des données autorisées par l'utilisateur lui-même ;
-	- lot 4 : compléter la sécurité de compte (`changer le mot de passe`, `mot de passe oublié` ou procédure de réinitialisation adaptée au contexte d'hébergement, garde-fous de session) ;
-	- lot 5 : aligner la documentation utilisateur et admin sur ces nouveaux parcours.
-- **Séquence recommandée** : commencer par les rôles et l'administration, puis seulement ouvrir l'autonomie utilisateur et la récupération d'accès, car ces deux derniers points dépendent directement du modèle d'autorisation retenu.
-- **Format attendu des livrables** :
-	- une décision produit sur les rôles cibles ;
-	- une matrice permissions par rôle et par écran ou action critique ;
-	- les écrans et API d'administration correspondants ;
-	- une procédure de récupération d'accès adaptée à un contexte associatif auto-hébergé ;
-	- les tests et la documentation associés.
-- **Point d'attention** : ce sujet touche à la sécurité et aux permissions ; toute simplification produit doit rester cohérente avec le modèle d'autorisation backend déjà en place.
+- **Résultat livré** : BL-022 couvre désormais l'ensemble du cycle de vie visé pour les comptes applicatifs : rôles métier clarifiés, administration des comptes côté `admin`, espace `Mon profil` pour consultation et mise à jour de l'e-mail, changement du mot de passe par l'utilisateur lui-même, procédure de réinitialisation administrateur adaptée au contexte auto-hébergé, invalidation des anciens jetons après changement ou reset, et documentation utilisateur/admin alignée sur ces parcours.
+- **Livré parce que** : les lots 3 à 5 ont été implémentés sur `feature/bl-022-profile-account-security` avec migration de sécurité, endpoints backend dédiés, vue frontend `Mon profil`, dialogue de réinitialisation administrateur, mises à jour de navigation et de documentation, puis validation backend/frontend complète avant PR.
 
 ### BL-023 — Revalider les droits réels par rôle et la visibilité des écrans comptables
 
@@ -472,7 +449,6 @@ Tout sujet concret qui doit survivre au-delà de la séance en cours doit être 
 ## En cours
 
 - **BL-021** — `created=2026-04-13`, `started=2026-04-13` — Les lots 1 à 3 du manuel utilisateur sont livrés, mais le lot 4 reste à réaliser pour finaliser la stabilisation éditoriale et l'enrichissement visuel.
-- **BL-022** — `created=2026-04-13`, `started=2026-04-13` — Les lots 1 et 2 sont intégrés dans `develop` ; les lots suivants restent à traiter et le retest des droits réels a été traité séparément dans `BL-023`, désormais terminé.
 
 ## Fait
 
@@ -491,6 +467,7 @@ Tout sujet concret qui doit survivre au-delà de la séance en cours doit être 
 - **BL-016** — `created=2026-04-13`, `started=2026-04-14`, `completed=2026-04-14` — Les microcopies et états visibles les plus incohérents ont été harmonisés sur `Banque`, `Caisse` et `Salaires` via des clés i18n dédiées.
 - **BL-017** — `created=2026-04-13`, `started=2026-04-14`, `completed=2026-04-14` — L'affichage des mois et périodes métier est maintenant uniformisé au format français sur `Salaires` et le `Dashboard` sans changer les formats d'échange ISO.
 - **BL-018** — `created=2026-04-13`, `started=2026-04-14`, `completed=2026-04-14` — Les écrans de liste principaux partagent maintenant un socle commun de tri, filtres et compteurs d'état, avec filtres de date FR/ISO et exclusion explicite des tableaux fixes `bilan` / `résultat`.
+- **BL-022** — `created=2026-04-13`, `started=2026-04-13`, `completed=2026-04-19` — La gestion des comptes couvre désormais l'administration, l'espace `Mon profil`, le changement de mot de passe utilisateur, la réinitialisation administrateur adaptée au contexte auto-hébergé et l'invalidation des anciennes sessions après changement de mot de passe.
 - **BL-023** — `created=2026-04-13`, `started=2026-04-14`, `completed=2026-04-14` — Les rôles métier `Gestionnaire` / `Comptable` / `Administrateur` sont maintenant alignés entre docs, navigation, guards frontend et permissions backend, avec séparation visible `Gestion` / `Comptabilité` et couverture de test ciblée.
 - **BL-025** — `created=2026-04-13`, `started=2026-04-13`, `completed=2026-04-13` — Le grand livre est maintenant borné à l'exercice choisi, sans option multi-exercices, avec un solde d'ouverture cohérent quand la période démarre en cours d'exercice.
 - **BL-026** — `created=2026-04-15`, `started=2026-04-15`, `completed=2026-04-16` — Le ticket a livré un cadrage de recette et un constat exploitable sur la reprise `2024`, puis a été clos une fois les écarts résiduels requalifiés en différences de modélisation assumées ou en suites dédiées (`BL-008`, `BL-029`).

--- a/doc/dev/gestion-utilisateurs-et-permissions.md
+++ b/doc/dev/gestion-utilisateurs-et-permissions.md
@@ -77,7 +77,7 @@ Précisions d'implémentation utiles :
 - l'écran de gestion des exercices reste réservé à `Comptable` et `Administrateur` ;
 - la carte `Exercice en cours` du tableau de bord suit la même logique que le sélecteur global : exercice ouvert couvrant la date du jour, sinon exercice ouvert le plus récent.
 
-## Portée du lot 2
+## Portée des lots BL-022
 
 Le lot 2 ajoute l'administration des comptes avec les capacités suivantes :
 
@@ -86,17 +86,37 @@ Le lot 2 ajoute l'administration des comptes avec les capacités suivantes :
 - changer le rôle d'un compte ;
 - activer ou désactiver un compte.
 
-Le lot 2 ne couvre pas encore :
+Le lot 3 ajoute l'espace `Mon profil` avec les capacités suivantes :
 
-- l'espace `Mon profil` ;
-- le changement de mot de passe par l'utilisateur lui-même ;
-- le mot de passe oublié ou la récupération d'accès ;
-- l'alignement complet backend/frontend avec la nouvelle matrice BL-023.
+- consulter son identifiant, son rôle métier effectif et la date de création du compte ;
+- modifier son e-mail de contact dans un périmètre maîtrisé ;
+- conserver un identifiant de connexion stable, non modifiable depuis l'interface.
+
+Le lot 4 complète la sécurité de compte avec les capacités suivantes :
+
+- changer son mot de passe en fournissant le mot de passe actuel ;
+- invalider les anciens jetons JWT après changement de mot de passe ou réinitialisation ;
+- permettre à l'administrateur de définir un mot de passe temporaire pour un autre utilisateur, afin de couvrir la récupération d'accès dans un contexte associatif auto-hébergé.
+
+À ce stade, BL-022 ne couvre toujours pas l'alignement complet backend/frontend avec la nouvelle matrice BL-023.
+
+## Procédure retenue pour la récupération d'accès
+
+Le ticket ne met pas en place de flux autonome `mot de passe oublié` par e-mail. La procédure retenue est volontairement plus simple et plus robuste pour le contexte cible :
+
+1. l'utilisateur qui ne peut plus se connecter contacte un administrateur ;
+2. l'administrateur ouvre `Utilisateurs` et définit un mot de passe temporaire ;
+3. l'utilisateur se reconnecte avec ce mot de passe temporaire ;
+4. l'utilisateur le change immédiatement depuis `Mon profil`.
+
+Cette approche évite de rendre la récupération d'accès dépendante d'un SMTP correctement configuré, tout en gardant un processus explicite et sûr.
 
 ## Garde-fous retenus
 
-Pour éviter une perte d'accès administrative dans ce lot :
+Pour éviter une perte d'accès administrative ou une persistance de session non voulue dans ce lot :
 
 - un administrateur ne peut pas se désactiver lui-même ;
 - un administrateur ne peut pas se retirer lui-même son rôle d'administration ;
 - le dernier administrateur actif ne peut pas être désactivé ni rétrogradé.
+- un changement de mot de passe ou une réinitialisation invalide les anciens jetons d'accès et de refresh ;
+- la réinitialisation administrateur reste séparée du changement de mot de passe utilisateur pour éviter de mélanger support et autonomie.

--- a/doc/user/manuel-utilisateur.md
+++ b/doc/user/manuel-utilisateur.md
@@ -556,6 +556,14 @@ Vous savez vers quel écran vous diriger selon que vous cherchez une écriture p
 
 Certains écrans ou certaines actions dépendent de votre rôle utilisateur. Les écrans d'administration ne sont pas visibles pour tous les profils.
 
+### Où modifier mon e-mail ou mon mot de passe ?
+
+Utilisez l'écran `Mon profil`, accessible depuis le menu principal. Vous pouvez y mettre à jour votre e-mail de contact et changer votre mot de passe en renseignant le mot de passe actuel.
+
+### J'ai oublié mon mot de passe, que faire ?
+
+Demandez à un administrateur de réinitialiser temporairement votre accès depuis l'écran `Utilisateurs`. Une fois reconnecté, changez immédiatement ce mot de passe temporaire depuis `Mon profil`.
+
 ### Pourquoi une facture n'apparaît pas comme payée ?
 
 Le statut dépend des paiements réellement rattachés à cette facture. Vérifiez l'historique de la facture et la présence des paiements attendus.
@@ -571,6 +579,10 @@ La prévisualisation signale les colonnes manquantes, lignes ambiguës ou erreur
 ### Où saisir un paiement manuellement ?
 
 L'écran `Paiements` permet aujourd'hui surtout la consultation, le filtrage et la suppression. Le parcours standard de saisie manuelle d'un paiement n'est pas encore exposé comme formulaire dédié dans cet écran principal.
+
+### Que se passe-t-il après un changement de mot de passe ?
+
+Les anciennes sessions sont invalidées. Reconnectez-vous simplement avec votre nouveau mot de passe.
 
 ## 12. Glossaire simple
 

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -1,5 +1,12 @@
 import axios from 'axios'
-import type { LoginRequest, TokenResponse, UserRead } from './types'
+import apiClient from './client'
+import type {
+  LoginRequest,
+  PasswordChangeRequest,
+  TokenResponse,
+  UserRead,
+  UserSelfUpdate,
+} from './types'
 
 export async function loginApi(request: LoginRequest): Promise<TokenResponse> {
   // FastAPI OAuth2PasswordRequestForm expects form data
@@ -25,4 +32,13 @@ export async function getMeApi(accessToken: string): Promise<UserRead> {
     headers: { Authorization: `Bearer ${accessToken}` },
   })
   return response.data
+}
+
+export async function updateMyProfileApi(payload: UserSelfUpdate): Promise<UserRead> {
+  const response = await apiClient.patch<UserRead>('/api/auth/me', payload)
+  return response.data
+}
+
+export async function changeMyPasswordApi(payload: PasswordChangeRequest): Promise<void> {
+  await apiClient.post('/api/auth/me/change-password', payload)
 }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -20,6 +20,19 @@ export interface UserRead {
   created_at: string
 }
 
+export interface UserSelfUpdate {
+  email: string
+}
+
+export interface PasswordChangeRequest {
+  current_password: string
+  new_password: string
+}
+
+export interface UserPasswordResetRequest {
+  new_password: string
+}
+
 export type ContactType = 'client' | 'fournisseur' | 'les_deux'
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/api/users.ts
+++ b/frontend/src/api/users.ts
@@ -1,5 +1,5 @@
 import apiClient from './client'
-import type { UserRead, UserRole } from './types'
+import type { UserPasswordResetRequest, UserRead, UserRole } from './types'
 
 export interface UserCreatePayload {
   username: string
@@ -29,4 +29,11 @@ export async function updateUserApi(
 ): Promise<UserRead> {
   const response = await apiClient.patch<UserRead>(`/api/auth/users/${userId}`, payload)
   return response.data
+}
+
+export async function resetUserPasswordApi(
+  userId: number,
+  payload: UserPasswordResetRequest,
+): Promise<void> {
+  await apiClient.post(`/api/auth/users/${userId}/reset-password`, payload)
 }

--- a/frontend/src/components/NavMenu.vue
+++ b/frontend/src/components/NavMenu.vue
@@ -44,6 +44,7 @@ type MenuItem = {
 
 const homeItems = computed<MenuItem[]>(() => [
   { to: '/dashboard', icon: 'pi-home', label: t('nav.dashboard') },
+  { to: '/profile', icon: 'pi-user', label: t('nav.profile') },
 ])
 
 const managementItems = computed<MenuItem[]>(() => {

--- a/frontend/src/constants/auth.ts
+++ b/frontend/src/constants/auth.ts
@@ -1,0 +1,1 @@
+export const PASSWORD_MIN_LENGTH = 8

--- a/frontend/src/i18n/fr.ts
+++ b/frontend/src/i18n/fr.ts
@@ -11,6 +11,8 @@ export default {
       username: 'Identifiant',
       password: 'Mot de passe',
       submit: 'Se connecter',
+      reset_hint:
+        'Mot de passe oublié ? Demandez à un administrateur de réinitialiser temporairement votre accès.',
       error: {
         invalid: 'Identifiant ou mot de passe incorrect.',
         network: 'Impossible de contacter le serveur. Veuillez réessayer.',
@@ -29,6 +31,7 @@ export default {
     section_accounting: 'Comptabilité',
     section_administration: 'Administration',
     dashboard: 'Tableau de bord',
+    profile: 'Mon profil',
     contacts: 'Contacts',
     invoices_client: 'Factures clients',
     invoices_supplier: 'Factures fournisseurs',
@@ -75,7 +78,12 @@ export default {
     email: 'E-mail',
     password: 'Mot de passe initial',
     password_help:
-      'Minimum 8 caractères. Le changement de mot de passe utilisateur sera traité dans un lot suivant.',
+      'Minimum 8 caractères. L’utilisateur pourra ensuite le changer depuis son profil.',
+    reset_password: 'Mot de passe temporaire',
+    reset_password_action: 'Réinitialiser le mot de passe',
+    reset_dialog_title: 'Réinitialiser l’accès',
+    reset_password_help:
+      'Définissez un mot de passe temporaire puis communiquez-le à l’utilisateur par un canal sûr. Il pourra ensuite le changer depuis Mon profil.',
     role: 'Rôle',
     status: 'Statut',
     created_at: 'Créé le',
@@ -86,6 +94,7 @@ export default {
     update: 'Mettre à jour le compte',
     created: 'Compte utilisateur créé.',
     updated: 'Compte utilisateur mis à jour.',
+    password_reset: 'Mot de passe réinitialisé.',
     duplicate_error: 'Cet identifiant ou cet e-mail existe déjà.',
     self_guard:
       'Ce lot ne permet pas de modifier votre propre rôle ni de désactiver votre propre compte.',
@@ -126,6 +135,45 @@ export default {
         subtitle: 'Valeur technique : admin',
         description: 'Administration complète de l’application, des comptes et des paramètres.',
       },
+    },
+  },
+  profile: {
+    title: 'Mon profil',
+    subtitle:
+      'Consultez vos informations de compte, mettez à jour votre e-mail et changez votre mot de passe sans passer par l’administration.',
+    account_title: 'Informations du compte',
+    account_subtitle:
+      'Votre identifiant reste stable ; seul l’e-mail de contact peut être modifié directement.',
+    password_title: 'Sécurité du compte',
+    password_subtitle:
+      'Changez votre mot de passe pour sécuriser votre accès. Cette action vous reconnectera ensuite.',
+    username: 'Identifiant',
+    username_help: 'L’identifiant sert à la connexion et ne peut pas être modifié dans ce lot.',
+    email: 'E-mail',
+    save_profile: 'Enregistrer le profil',
+    profile_updated: 'Profil mis à jour.',
+    current_password: 'Mot de passe actuel',
+    new_password: 'Nouveau mot de passe',
+    confirm_password: 'Confirmer le nouveau mot de passe',
+    password_help:
+      'Minimum 8 caractères. Après le changement, les anciennes sessions seront invalidées et une nouvelle connexion sera demandée.',
+    password_mismatch: 'La confirmation ne correspond pas au nouveau mot de passe.',
+    change_password: 'Changer le mot de passe',
+    password_changed: 'Mot de passe modifié. Veuillez vous reconnecter.',
+    stats: {
+      role: 'Rôle actif',
+      role_caption: 'Permission actuellement appliquée',
+      username: 'Identifiant',
+      username_caption: 'Référence de connexion',
+      created_at: 'Compte créé',
+      created_at_caption: 'Date de création du compte',
+    },
+    api_errors: {
+      email_exists: 'Cet e-mail est déjà utilisé par un autre compte.',
+      email_required: 'Un e-mail est requis pour mettre à jour le profil.',
+      no_changes: 'Aucune modification n’a été demandée.',
+      invalid_current_password: 'Le mot de passe actuel est incorrect.',
+      same_password: 'Le nouveau mot de passe doit être différent de l’actuel.',
     },
   },
   common: {

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -26,6 +26,11 @@ const router = createRouter({
           component: () => import('../views/DashboardView.vue'),
         },
         {
+          path: 'profile',
+          name: 'profile',
+          component: () => import('../views/ProfileView.vue'),
+        },
+        {
           path: 'contacts',
           name: 'contacts',
           component: () => import('../views/ContactsView.vue'),

--- a/frontend/src/tests/views/NavMenu.spec.ts
+++ b/frontend/src/tests/views/NavMenu.spec.ts
@@ -57,6 +57,7 @@ describe('NavMenu', () => {
     expect(text).not.toContain('nav.section_administration')
     expect(links).toEqual([
       'nav.dashboard',
+      'nav.profile',
       'nav.contacts',
       'nav.invoices_client',
       'nav.invoices_supplier',
@@ -88,6 +89,7 @@ describe('NavMenu', () => {
     expect(text).not.toContain('nav.section_administration')
     expect(links).toEqual([
       'nav.dashboard',
+      'nav.profile',
       'nav.contacts',
       'nav.invoices_client',
       'nav.invoices_supplier',
@@ -127,6 +129,6 @@ describe('NavMenu', () => {
     expect(text).not.toContain('nav.section_management')
     expect(text).not.toContain('nav.section_accounting')
     expect(text).not.toContain('nav.section_administration')
-    expect(links).toEqual(['nav.dashboard'])
+    expect(links).toEqual(['nav.dashboard', 'nav.profile'])
   })
 })

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -47,6 +47,8 @@
             :loading="auth.loading"
             class="w-full"
           />
+
+          <p class="login-help">{{ t('auth.login.reset_hint') }}</p>
         </form>
       </template>
     </Card>
@@ -156,5 +158,12 @@ async function handleSubmit(): Promise<void> {
   font-weight: 500;
   font-size: 0.875rem;
   color: var(--p-text-color);
+}
+
+.login-help {
+  margin: 0;
+  text-align: center;
+  font-size: 0.875rem;
+  color: var(--p-text-muted-color);
 }
 </style>

--- a/frontend/src/views/ProfileView.vue
+++ b/frontend/src/views/ProfileView.vue
@@ -135,6 +135,7 @@ import AppPageHeader from '@/components/ui/AppPageHeader.vue'
 import AppPanel from '@/components/ui/AppPanel.vue'
 import AppStatCard from '@/components/ui/AppStatCard.vue'
 import { changeMyPasswordApi, updateMyProfileApi } from '@/api/auth'
+import { PASSWORD_MIN_LENGTH } from '@/constants/auth'
 import { useAuthStore } from '@/stores/auth'
 
 interface ProfileForm {
@@ -201,7 +202,7 @@ const passwordMismatch = computed(() => {
 const canChangePassword = computed(() => {
   return (
     passwordForm.value.current_password.length > 0 &&
-    passwordForm.value.new_password.length >= 8 &&
+    passwordForm.value.new_password.length >= PASSWORD_MIN_LENGTH &&
     passwordForm.value.confirm_password.length > 0 &&
     !passwordMismatch.value
   )

--- a/frontend/src/views/ProfileView.vue
+++ b/frontend/src/views/ProfileView.vue
@@ -1,0 +1,273 @@
+<template>
+  <AppPage>
+    <AppPageHeader
+      :eyebrow="t('ui.page.collection_eyebrow')"
+      :title="t('profile.title')"
+      :subtitle="t('profile.subtitle')"
+    />
+
+    <section class="app-stat-grid">
+      <AppStatCard
+        :label="t('profile.stats.role')"
+        :value="displayedRole"
+        :caption="t('profile.stats.role_caption')"
+      />
+      <AppStatCard
+        :label="t('profile.stats.username')"
+        :value="auth.user?.username ?? '—'"
+        :caption="t('profile.stats.username_caption')"
+        tone="success"
+      />
+      <AppStatCard
+        :label="t('profile.stats.created_at')"
+        :value="createdAtLabel"
+        :caption="t('profile.stats.created_at_caption')"
+        tone="warn"
+      />
+    </section>
+
+    <div class="profile-grid">
+      <AppPanel :title="t('profile.account_title')" :subtitle="t('profile.account_subtitle')">
+        <form class="app-form-stack" @submit.prevent="submitProfile">
+          <div class="app-field">
+            <label class="app-field__label" for="profile-username">{{
+              t('profile.username')
+            }}</label>
+            <InputText
+              id="profile-username"
+              :model-value="auth.user?.username ?? ''"
+              disabled
+              class="w-full"
+            />
+            <small class="app-field__help">{{ t('profile.username_help') }}</small>
+          </div>
+
+          <div class="app-field">
+            <label class="app-field__label" for="profile-email">{{ t('profile.email') }}</label>
+            <InputText id="profile-email" v-model="profileForm.email" type="email" class="w-full" />
+          </div>
+
+          <div class="app-form-actions">
+            <Button
+              type="submit"
+              :label="t('profile.save_profile')"
+              :disabled="!canSaveProfile"
+              :loading="savingProfile"
+            />
+          </div>
+        </form>
+      </AppPanel>
+
+      <AppPanel :title="t('profile.password_title')" :subtitle="t('profile.password_subtitle')">
+        <form class="app-form-stack" @submit.prevent="submitPassword">
+          <div class="app-field">
+            <label class="app-field__label" for="profile-current-password">
+              {{ t('profile.current_password') }}
+            </label>
+            <Password
+              id="profile-current-password"
+              v-model="passwordForm.current_password"
+              :feedback="false"
+              toggle-mask
+              class="w-full"
+              input-class="w-full"
+            />
+          </div>
+
+          <div class="app-field">
+            <label class="app-field__label" for="profile-new-password">
+              {{ t('profile.new_password') }}
+            </label>
+            <Password
+              id="profile-new-password"
+              v-model="passwordForm.new_password"
+              :feedback="false"
+              toggle-mask
+              class="w-full"
+              input-class="w-full"
+            />
+          </div>
+
+          <div class="app-field">
+            <label class="app-field__label" for="profile-confirm-password">
+              {{ t('profile.confirm_password') }}
+            </label>
+            <Password
+              id="profile-confirm-password"
+              v-model="passwordForm.confirm_password"
+              :feedback="false"
+              toggle-mask
+              class="w-full"
+              input-class="w-full"
+            />
+            <small class="app-field__help">{{ t('profile.password_help') }}</small>
+          </div>
+
+          <Message v-if="passwordMismatch" severity="warn" :closable="false">
+            {{ t('profile.password_mismatch') }}
+          </Message>
+
+          <div class="app-form-actions">
+            <Button
+              type="submit"
+              :label="t('profile.change_password')"
+              :disabled="!canChangePassword"
+              :loading="savingPassword"
+            />
+          </div>
+        </form>
+      </AppPanel>
+    </div>
+  </AppPage>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { useRouter } from 'vue-router'
+import { useI18n } from 'vue-i18n'
+import Button from 'primevue/button'
+import InputText from 'primevue/inputtext'
+import Message from 'primevue/message'
+import Password from 'primevue/password'
+import { useToast } from 'primevue/usetoast'
+import AppPage from '@/components/ui/AppPage.vue'
+import AppPageHeader from '@/components/ui/AppPageHeader.vue'
+import AppPanel from '@/components/ui/AppPanel.vue'
+import AppStatCard from '@/components/ui/AppStatCard.vue'
+import { changeMyPasswordApi, updateMyProfileApi } from '@/api/auth'
+import { useAuthStore } from '@/stores/auth'
+
+interface ProfileForm {
+  email: string
+}
+
+interface PasswordForm {
+  current_password: string
+  new_password: string
+  confirm_password: string
+}
+
+interface ApiErrorDetail {
+  code?: string
+}
+
+const { t } = useI18n()
+const router = useRouter()
+const toast = useToast()
+const auth = useAuthStore()
+
+const savingProfile = ref(false)
+const savingPassword = ref(false)
+const profileForm = ref<ProfileForm>({ email: auth.user?.email ?? '' })
+const passwordForm = ref<PasswordForm>({
+  current_password: '',
+  new_password: '',
+  confirm_password: '',
+})
+
+watch(
+  () => auth.user,
+  (user) => {
+    profileForm.value.email = user?.email ?? ''
+  },
+  { immediate: true },
+)
+
+const profileApiErrorMessages: Record<string, string> = {
+  email_exists: 'profile.api_errors.email_exists',
+  email_required: 'profile.api_errors.email_required',
+  no_changes: 'profile.api_errors.no_changes',
+  invalid_current_password: 'profile.api_errors.invalid_current_password',
+  same_password: 'profile.api_errors.same_password',
+}
+
+const displayedRole = computed(() => (auth.user?.role ? t(`user.role.${auth.user.role}`) : '—'))
+const createdAtLabel = computed(() => {
+  if (!auth.user?.created_at) return '—'
+  return new Intl.DateTimeFormat('fr-FR', { dateStyle: 'medium' }).format(
+    new Date(auth.user.created_at),
+  )
+})
+const canSaveProfile = computed(() => {
+  const email = profileForm.value.email.trim()
+  return email.length > 0 && email !== (auth.user?.email ?? '')
+})
+const passwordMismatch = computed(() => {
+  return (
+    passwordForm.value.confirm_password.length > 0 &&
+    passwordForm.value.confirm_password !== passwordForm.value.new_password
+  )
+})
+const canChangePassword = computed(() => {
+  return (
+    passwordForm.value.current_password.length > 0 &&
+    passwordForm.value.new_password.length >= 8 &&
+    passwordForm.value.confirm_password.length > 0 &&
+    !passwordMismatch.value
+  )
+})
+
+function getApiErrorSummary(error: unknown): string {
+  const status = (error as { response?: { status?: number } }).response?.status
+  const detail = (error as { response?: { data?: { detail?: ApiErrorDetail | string } } }).response
+    ?.data?.detail
+
+  if (typeof detail === 'object' && detail !== null && typeof detail.code === 'string') {
+    const translationKey = profileApiErrorMessages[detail.code]
+    if (translationKey) {
+      return t(translationKey)
+    }
+  }
+
+  if (status === 403) {
+    return t('common.error.forbidden')
+  }
+  if (status === 404) {
+    return t('common.error.notFound')
+  }
+
+  return t('common.error.unknown')
+}
+
+async function submitProfile(): Promise<void> {
+  if (!canSaveProfile.value) return
+
+  savingProfile.value = true
+  try {
+    const updatedUser = await updateMyProfileApi({ email: profileForm.value.email.trim() })
+    auth.user = updatedUser
+    toast.add({ severity: 'success', summary: t('profile.profile_updated'), life: 3000 })
+  } catch (error: unknown) {
+    toast.add({ severity: 'error', summary: getApiErrorSummary(error), life: 3500 })
+  } finally {
+    savingProfile.value = false
+  }
+}
+
+async function submitPassword(): Promise<void> {
+  if (!canChangePassword.value) return
+
+  savingPassword.value = true
+  try {
+    await changeMyPasswordApi({
+      current_password: passwordForm.value.current_password,
+      new_password: passwordForm.value.new_password,
+    })
+    toast.add({ severity: 'success', summary: t('profile.password_changed'), life: 3500 })
+    auth.logout({ preventDevAutoLogin: true })
+    await router.push('/login')
+  } catch (error: unknown) {
+    toast.add({ severity: 'error', summary: getApiErrorSummary(error), life: 3500 })
+  } finally {
+    savingPassword.value = false
+  }
+}
+</script>
+
+<style scoped>
+.profile-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(20rem, 1fr));
+}
+</style>

--- a/frontend/src/views/UsersView.vue
+++ b/frontend/src/views/UsersView.vue
@@ -173,6 +173,14 @@
                 text
                 @click="openEditDialog(data)"
               />
+              <Button
+                icon="pi pi-key"
+                size="small"
+                severity="secondary"
+                text
+                :disabled="data.id === auth.user?.id"
+                @click="openResetDialog(data)"
+              />
             </div>
           </template>
         </Column>
@@ -300,6 +308,48 @@
         </div>
       </form>
     </Dialog>
+
+    <Dialog
+      v-model:visible="resetDialogVisible"
+      :header="t('users.reset_dialog_title')"
+      modal
+      class="app-dialog app-dialog--medium"
+    >
+      <form class="app-form-stack" @submit.prevent="submitResetPassword">
+        <Message severity="info" :closable="false">{{ t('users.reset_password_help') }}</Message>
+        <div class="app-field">
+          <label class="app-field__label">{{ t('users.username') }}</label>
+          <InputText :model-value="resetPasswordUser?.username ?? ''" disabled class="w-full" />
+        </div>
+        <div class="app-field">
+          <label class="app-field__label" for="user-reset-password">{{
+            t('users.reset_password')
+          }}</label>
+          <Password
+            id="user-reset-password"
+            v-model="resetPasswordForm.new_password"
+            :feedback="false"
+            toggle-mask
+            class="w-full"
+            input-class="w-full"
+          />
+        </div>
+        <div class="app-form-actions">
+          <Button
+            type="button"
+            :label="t('common.cancel')"
+            severity="secondary"
+            @click="closeResetDialog"
+          />
+          <Button
+            type="submit"
+            :label="t('users.reset_password_action')"
+            :disabled="!canResetPassword"
+            :loading="savingResetPassword"
+          />
+        </div>
+      </form>
+    </Dialog>
   </AppPage>
 </template>
 
@@ -324,8 +374,8 @@ import AppPage from '@/components/ui/AppPage.vue'
 import AppPageHeader from '@/components/ui/AppPageHeader.vue'
 import AppPanel from '@/components/ui/AppPanel.vue'
 import AppStatCard from '@/components/ui/AppStatCard.vue'
-import { createUserApi, listUsersApi, updateUserApi } from '@/api/users'
-import type { UserRead, UserRole } from '@/api/types'
+import { createUserApi, listUsersApi, resetUserPasswordApi, updateUserApi } from '@/api/users'
+import type { UserPasswordResetRequest, UserRead, UserRole } from '@/api/types'
 import { useAuthStore } from '@/stores/auth'
 import {
   dateRangeFilter,
@@ -345,6 +395,8 @@ interface EditUserForm {
   role: UserRole
   is_active: boolean
 }
+
+type ResetPasswordForm = UserPasswordResetRequest
 
 interface RoleDefinition {
   value: UserRole
@@ -369,11 +421,15 @@ const userRows = ref<
 const loading = ref(false)
 const savingCreate = ref(false)
 const savingEdit = ref(false)
+const savingResetPassword = ref(false)
 const createDialogVisible = ref(false)
 const editDialogVisible = ref(false)
+const resetDialogVisible = ref(false)
 const editingUser = ref<UserRead | null>(null)
+const resetPasswordUser = ref<UserRead | null>(null)
 const createForm = ref<CreateUserForm>(defaultCreateForm())
 const editForm = ref<EditUserForm>(defaultEditForm())
+const resetPasswordForm = ref<ResetPasswordForm>(defaultResetPasswordForm())
 const yesNoOptions = [
   { label: t('common.yes'), value: true },
   { label: t('common.no'), value: false },
@@ -421,6 +477,12 @@ function defaultEditForm(): EditUserForm {
   return {
     role: 'secretaire',
     is_active: true,
+  }
+}
+
+function defaultResetPasswordForm(): ResetPasswordForm {
+  return {
+    new_password: '',
   }
 }
 
@@ -495,6 +557,9 @@ const canEdit = computed(() => {
     editForm.value.role !== editingUser.value.role ||
     editForm.value.is_active !== editingUser.value.is_active
   )
+})
+const canResetPassword = computed(() => {
+  return resetPasswordForm.value.new_password.length >= 8 && resetPasswordUser.value !== null
 })
 
 function roleLabel(role: UserRole): string {
@@ -586,6 +651,18 @@ function closeEditDialog(): void {
   editForm.value = defaultEditForm()
 }
 
+function openResetDialog(user: UserRead): void {
+  resetPasswordUser.value = user
+  resetPasswordForm.value = defaultResetPasswordForm()
+  resetDialogVisible.value = true
+}
+
+function closeResetDialog(): void {
+  resetDialogVisible.value = false
+  resetPasswordUser.value = null
+  resetPasswordForm.value = defaultResetPasswordForm()
+}
+
 async function submitCreate(): Promise<void> {
   if (!canCreate.value) return
 
@@ -630,6 +707,23 @@ async function submitEdit(): Promise<void> {
   }
 }
 
+async function submitResetPassword(): Promise<void> {
+  if (!resetPasswordUser.value || !canResetPassword.value) return
+
+  savingResetPassword.value = true
+  try {
+    await resetUserPasswordApi(resetPasswordUser.value.id, {
+      new_password: resetPasswordForm.value.new_password,
+    })
+    toast.add({ severity: 'success', summary: t('users.password_reset'), life: 3000 })
+    closeResetDialog()
+  } catch (error: unknown) {
+    toast.add({ severity: 'error', summary: getApiErrorSummary(error), life: 3500 })
+  } finally {
+    savingResetPassword.value = false
+  }
+}
+
 onMounted(loadUsers)
 </script>
 
@@ -660,7 +754,7 @@ onMounted(loadUsers)
 }
 
 .users-actions {
-  width: 6rem;
+  width: 8rem;
 }
 
 .users-switch-row {

--- a/frontend/src/views/UsersView.vue
+++ b/frontend/src/views/UsersView.vue
@@ -376,6 +376,7 @@ import AppPanel from '@/components/ui/AppPanel.vue'
 import AppStatCard from '@/components/ui/AppStatCard.vue'
 import { createUserApi, listUsersApi, resetUserPasswordApi, updateUserApi } from '@/api/users'
 import type { UserPasswordResetRequest, UserRead, UserRole } from '@/api/types'
+import { PASSWORD_MIN_LENGTH } from '@/constants/auth'
 import { useAuthStore } from '@/stores/auth'
 import {
   dateRangeFilter,
@@ -546,7 +547,7 @@ const canCreate = computed(() => {
   return (
     createForm.value.username.trim().length > 0 &&
     createForm.value.email.trim().length > 0 &&
-    createForm.value.password.length >= 8
+    createForm.value.password.length >= PASSWORD_MIN_LENGTH
   )
 })
 const canEdit = computed(() => {
@@ -559,7 +560,10 @@ const canEdit = computed(() => {
   )
 })
 const canResetPassword = computed(() => {
-  return resetPasswordForm.value.new_password.length >= 8 && resetPasswordUser.value !== null
+  return (
+    resetPasswordForm.value.new_password.length >= PASSWORD_MIN_LENGTH &&
+    resetPasswordUser.value !== null
+  )
 })
 
 function roleLabel(role: UserRole): string {

--- a/tests/integration/test_auth_api.py
+++ b/tests/integration/test_auth_api.py
@@ -2,8 +2,10 @@
 
 import pytest
 from httpx import ASGITransport, AsyncClient
+from jose import jwt
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from backend.config import get_settings
 from backend.database import get_db
 from backend.main import create_app
 from backend.models.user import User, UserRole
@@ -144,6 +146,27 @@ async def test_change_my_password_invalidates_existing_access_token(
         data={"username": "admin", "password": "newsecurepassword123"},
     )
     assert login_response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_get_me_rejects_access_token_without_iat(
+    client: AsyncClient,
+    admin_user: User,
+) -> None:
+    """Access tokens without an iat claim are rejected."""
+    settings = get_settings()
+    token_without_iat = jwt.encode(
+        {"sub": admin_user.username},
+        settings.jwt_secret_key,
+        algorithm=settings.jwt_algorithm,
+    )
+
+    response = await client.get(
+        "/api/auth/me",
+        headers={"Authorization": f"Bearer {token_without_iat}"},
+    )
+
+    assert response.status_code == 401
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_auth_api.py
+++ b/tests/integration/test_auth_api.py
@@ -57,6 +57,141 @@ async def test_get_me_authenticated(
 
 
 @pytest.mark.asyncio
+async def test_update_me_email(
+    client: AsyncClient, admin_user: User, auth_headers: dict, db_session: AsyncSession
+) -> None:
+    """Authenticated users can update their own email address."""
+    response = await client.patch(
+        "/api/auth/me",
+        headers=auth_headers,
+        json={"email": "updated-admin@test.com"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["email"] == "updated-admin@test.com"
+
+    await db_session.refresh(admin_user)
+    assert admin_user.email == "updated-admin@test.com"
+
+
+@pytest.mark.asyncio
+async def test_update_me_rejects_duplicate_email(
+    client: AsyncClient,
+    admin_user: User,
+    readonly_user: User,
+    auth_headers: dict,
+) -> None:
+    """Users cannot take another account's email address."""
+    response = await client.patch(
+        "/api/auth/me",
+        headers=auth_headers,
+        json={"email": readonly_user.email},
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == {
+        "code": "email_exists",
+        "message": "Email already exists",
+    }
+
+
+@pytest.mark.asyncio
+async def test_change_my_password_requires_current_password(
+    client: AsyncClient,
+    admin_user: User,
+    auth_headers: dict,
+) -> None:
+    """The current password must be provided correctly to change it."""
+    response = await client.post(
+        "/api/auth/me/change-password",
+        headers=auth_headers,
+        json={
+            "current_password": "wrongpassword",
+            "new_password": "newsecurepassword123",
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == {
+        "code": "invalid_current_password",
+        "message": "Current password is incorrect",
+    }
+
+
+@pytest.mark.asyncio
+async def test_change_my_password_invalidates_existing_access_token(
+    client: AsyncClient,
+    admin_user: User,
+    auth_headers: dict,
+) -> None:
+    """Changing a password invalidates tokens issued before the change."""
+    response = await client.post(
+        "/api/auth/me/change-password",
+        headers=auth_headers,
+        json={
+            "current_password": "adminpassword123",
+            "new_password": "newsecurepassword123",
+        },
+    )
+
+    assert response.status_code == 204
+
+    stale_response = await client.get("/api/auth/me", headers=auth_headers)
+    assert stale_response.status_code == 401
+
+    login_response = await client.post(
+        "/api/auth/login",
+        data={"username": "admin", "password": "newsecurepassword123"},
+    )
+    assert login_response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_admin_can_reset_user_password(
+    client: AsyncClient,
+    admin_user: User,
+    readonly_user: User,
+    auth_headers: dict,
+) -> None:
+    """Admin can reset another user's password through the admin-managed flow."""
+    response = await client.post(
+        f"/api/auth/users/{readonly_user.id}/reset-password",
+        headers=auth_headers,
+        json={"new_password": "temporaryreset123"},
+    )
+
+    assert response.status_code == 204
+
+    old_login = await client.post(
+        "/api/auth/login",
+        data={"username": "readonly", "password": "readonlypassword123"},
+    )
+    assert old_login.status_code == 401
+
+    new_login = await client.post(
+        "/api/auth/login",
+        data={"username": "readonly", "password": "temporaryreset123"},
+    )
+    assert new_login.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_reset_user_password_requires_admin(
+    client: AsyncClient,
+    admin_user: User,
+    readonly_auth_headers: dict,
+) -> None:
+    """Only admins can reset another user's password."""
+    response = await client.post(
+        f"/api/auth/users/{admin_user.id}/reset-password",
+        headers=readonly_auth_headers,
+        json={"new_password": "temporaryreset123"},
+    )
+
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
 async def test_get_me_unauthenticated(client: AsyncClient) -> None:
     """Unauthenticated request to /me returns 401."""
     response = await client.get("/api/auth/me")

--- a/tests/unit/test_auth_service.py
+++ b/tests/unit/test_auth_service.py
@@ -56,6 +56,7 @@ def test_decode_access_token_valid() -> None:
     payload = decode_access_token(token)
     assert payload is not None
     assert payload.get("sub") == "testuser"
+    assert isinstance(payload.get("iat"), (int, float))
 
 
 def test_decode_access_token_invalid() -> None:


### PR DESCRIPTION
## Summary
- add self-service profile management for users with a dedicated `Mon profil` view and API support for email updates
- add account security flows for password changes and admin password resets, including session invalidation based on `password_changed_at`
- document the new user/admin flows and close BL-022 in the backlog

## Testing
- `d:/dev/_misc/solde/.venv/Scripts/python.exe -m ruff check .`
- `d:/dev/_misc/solde/.venv/Scripts/python.exe -m ruff format --check .`
- `d:/dev/_misc/solde/.venv/Scripts/python.exe -m mypy .`
- `d:/dev/_misc/solde/.venv/Scripts/python.exe -m pytest tests/ -q`
- `cd frontend && npx prettier --check src/`
- `cd frontend && npm run type-check`
- `cd frontend && npx eslint src/`
- `cd frontend && npm run test:unit -- --run`

## Migration notes
- apply the Alembic migration adding `users.password_changed_at` before deploying the backend changes

## Summary by Sourcery

Add self-service profile and account security flows for authenticated users, including email updates, password changes, and admin-managed password resets, with token invalidation and updated documentation.

New Features:
- Expose a Mon profil view and navigation entry for authenticated users to inspect their account details and update their email address from the frontend.
- Introduce backend and frontend flows for users to change their own password, including validation and enforced reauthentication.
- Add an admin-facing password reset flow that lets administrators set a temporary password for another user from the Users screen.

Bug Fixes:
- Invalidate existing JWT sessions after a password change or admin reset by tracking a per-user password_changed_at timestamp and checking it on token validation.

Enhancements:
- Extend auth API schemas and client types to cover self-update and password change/reset requests.
- Add contextual UI copy in login and users screens explaining how password reset is handled in the self-hosted context.
- Update navigation, menu tests, and changelog to reflect the new profile and recovery flows.
- Document the delivered scope of BL-022, including profile, password security, and recovery procedure, and mark the backlog item as completed.

Deployment:
- Add an Alembic migration introducing the non-null users.password_changed_at column and backfilling it for existing accounts.

Tests:
- Add backend integration tests for profile email updates, user-initiated password changes with token invalidation, and admin-only password reset behavior.
- Extend frontend navigation tests to cover the new Mon profil entry for different roles.