### PR TITLE
feat: deliver BL-031 bank reconciliation workflow

### DIFF
--- a/backend/alembic/versions/0017_add_bank_transaction_category.py
+++ b/backend/alembic/versions/0017_add_bank_transaction_category.py
@@ -1,0 +1,33 @@
+"""add bank transaction category
+
+Revision ID: 0017
+Revises: 0016
+Create Date: 2026-04-19
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0017"
+down_revision = "0016"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("bank_transactions") as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "detected_category",
+                sa.String(length=30),
+                nullable=False,
+                server_default="uncategorized",
+            )
+        )
+        batch_op.create_index("ix_bank_transactions_detected_category", ["detected_category"])
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("bank_transactions") as batch_op:
+        batch_op.drop_index("ix_bank_transactions_detected_category")
+        batch_op.drop_column("detected_category")

--- a/backend/alembic/versions/0018_add_bank_transaction_payment_link.py
+++ b/backend/alembic/versions/0018_add_bank_transaction_payment_link.py
@@ -1,0 +1,33 @@
+"""add bank transaction payment link
+
+Revision ID: 0018
+Revises: 0017
+Create Date: 2026-04-19
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0018"
+down_revision = "0017"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("bank_transactions") as batch_op:
+        batch_op.add_column(sa.Column("payment_id", sa.Integer(), nullable=True))
+        batch_op.create_index("ix_bank_transactions_payment_id", ["payment_id"])
+        batch_op.create_foreign_key(
+            "fk_bank_transactions_payment_id_payments",
+            "payments",
+            ["payment_id"],
+            ["id"],
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("bank_transactions") as batch_op:
+        batch_op.drop_constraint("fk_bank_transactions_payment_id_payments", type_="foreignkey")
+        batch_op.drop_index("ix_bank_transactions_payment_id")
+        batch_op.drop_column("payment_id")

--- a/backend/alembic/versions/0019_add_bank_transaction_payments.py
+++ b/backend/alembic/versions/0019_add_bank_transaction_payments.py
@@ -1,0 +1,44 @@
+"""add bank transaction payments
+
+Revision ID: 0019
+Revises: 0018
+Create Date: 2026-04-19
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0019"
+down_revision = "0018"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "bank_transaction_payments",
+        sa.Column("transaction_id", sa.Integer(), nullable=False),
+        sa.Column("payment_id", sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(["transaction_id"], ["bank_transactions.id"]),
+        sa.ForeignKeyConstraint(["payment_id"], ["payments.id"]),
+        sa.PrimaryKeyConstraint("transaction_id", "payment_id"),
+    )
+    op.create_index(
+        "ix_bank_transaction_payments_payment_id",
+        "bank_transaction_payments",
+        ["payment_id"],
+        unique=False,
+    )
+    op.execute(
+        """
+        INSERT INTO bank_transaction_payments (transaction_id, payment_id)
+        SELECT id, payment_id
+        FROM bank_transactions
+        WHERE payment_id IS NOT NULL
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_bank_transaction_payments_payment_id", table_name="bank_transaction_payments")
+    op.drop_table("bank_transaction_payments")

--- a/backend/models/bank.py
+++ b/backend/models/bank.py
@@ -22,6 +22,22 @@ class BankTransactionSource(StrEnum):
     SYSTEM_OPENING = "system_opening"
 
 
+class BankTransactionCategory(StrEnum):
+    UNCATEGORIZED = "uncategorized"
+    CUSTOMER_PAYMENT = "customer_payment"
+    CHEQUE_DEPOSIT = "cheque_deposit"
+    CASH_DEPOSIT = "cash_deposit"
+    SUPPLIER_PAYMENT = "supplier_payment"
+    SALARY = "salary"
+    SOCIAL_CHARGE = "social_charge"
+    BANK_FEE = "bank_fee"
+    INTERNAL_TRANSFER = "internal_transfer"
+    GRANT = "grant"
+    SEPA_DEBIT = "sepa_debit"
+    OTHER_CREDIT = "other_credit"
+    OTHER_DEBIT = "other_debit"
+
+
 class DepositType(StrEnum):
     CHEQUES = "cheques"
     ESPECES = "especes"
@@ -32,6 +48,15 @@ deposit_payments = Table(
     "deposit_payments",
     Base.metadata,
     SAColumn("deposit_id", ForeignKey("deposits.id"), primary_key=True),
+    SAColumn("payment_id", ForeignKey("payments.id"), primary_key=True),
+)
+
+
+# Association table: bank transaction ↔ payments
+bank_transaction_payments = Table(
+    "bank_transaction_payments",
+    Base.metadata,
+    SAColumn("transaction_id", ForeignKey("bank_transactions.id"), primary_key=True),
     SAColumn("payment_id", ForeignKey("payments.id"), primary_key=True),
 )
 
@@ -51,6 +76,12 @@ class BankTransaction(Base):
     reconciled_with: Mapped[str | None] = mapped_column(String(100), nullable=True)
     source: Mapped[BankTransactionSource] = mapped_column(
         String(10), nullable=False, default=BankTransactionSource.MANUAL
+    )
+    detected_category: Mapped[BankTransactionCategory] = mapped_column(
+        String(30), nullable=False, default=BankTransactionCategory.UNCATEGORIZED, index=True
+    )
+    payment_id: Mapped[int | None] = mapped_column(
+        ForeignKey("payments.id"), nullable=True, index=True
     )
     created_at: Mapped[datetime] = mapped_column(
         DateTime, nullable=False, server_default=func.now()

--- a/backend/routers/bank.py
+++ b/backend/routers/bank.py
@@ -5,13 +5,19 @@ from decimal import Decimal
 from typing import Annotated, cast
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.database import get_db
+from backend.models.bank import BankTransaction
 from backend.models.user import User, UserRole
 from backend.routers.auth import require_role
 from backend.schemas.bank import (
     BankBalanceRead,
+    BankTransactionClientPaymentCreate,
+    BankTransactionClientPaymentLink,
+    BankTransactionClientPaymentLinks,
+    BankTransactionClientPaymentsCreate,
     BankTransactionCreate,
     BankTransactionRead,
     BankTransactionUpdate,
@@ -36,6 +42,21 @@ _ReadAccess = Annotated[
     User,
     Depends(require_role(UserRole.SECRETAIRE, UserRole.TRESORIER, UserRole.ADMIN)),
 ]
+
+
+async def _serialize_transaction(
+    db: AsyncSession,
+    tx: BankTransaction,
+) -> BankTransactionRead:
+    payment_ids = await bank_service.get_transaction_payment_ids(db, tx.id)
+    return BankTransactionRead.model_validate(tx).model_copy(update={"payment_ids": payment_ids})
+
+
+async def _serialize_transactions(
+    db: AsyncSession,
+    txs: list[BankTransaction],
+) -> list[BankTransactionRead]:
+    return [await _serialize_transaction(db, tx) for tx in txs]
 
 
 # ---------------------------------------------------------------------------
@@ -70,7 +91,7 @@ async def list_transactions(
         skip=skip,
         limit=limit,
     )
-    return cast(list[BankTransactionRead], txs)
+    return await _serialize_transactions(db, txs)
 
 
 @router.post(
@@ -84,7 +105,7 @@ async def add_transaction(
     _current_user: _WriteAccess,
 ) -> BankTransactionRead:
     tx = await bank_service.add_transaction(db, payload)
-    return cast(BankTransactionRead, tx)
+    return await _serialize_transaction(db, tx)
 
 
 @router.put("/transactions/{tx_id}", response_model=BankTransactionRead)
@@ -98,7 +119,157 @@ async def update_transaction(
     if tx is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Transaction not found")
     updated = await bank_service.update_transaction(db, tx, payload)
-    return cast(BankTransactionRead, updated)
+    return await _serialize_transaction(db, updated)
+
+
+@router.post(
+    "/transactions/{tx_id}/create-client-payment",
+    response_model=BankTransactionRead,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_client_payment_from_transaction(
+    tx_id: int,
+    payload: BankTransactionClientPaymentCreate,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    _current_user: _WriteAccess,
+) -> BankTransactionRead:
+    try:
+        tx = await bank_service.create_client_payment_from_transaction(
+            db,
+            tx_id=tx_id,
+            invoice_id=payload.invoice_id,
+        )
+    except LookupError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=str(exc),
+        ) from exc
+    return await _serialize_transaction(db, tx)
+
+
+@router.post(
+    "/transactions/{tx_id}/create-client-payments",
+    response_model=BankTransactionRead,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_client_payments_from_transaction(
+    tx_id: int,
+    payload: BankTransactionClientPaymentsCreate,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    _current_user: _WriteAccess,
+) -> BankTransactionRead:
+    try:
+        tx = await bank_service.create_client_payments_from_transaction(
+            db,
+            tx_id=tx_id,
+            payload=payload,
+        )
+    except LookupError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=str(exc),
+        ) from exc
+    return await _serialize_transaction(db, tx)
+
+
+@router.post(
+    "/transactions/{tx_id}/create-supplier-payment",
+    response_model=BankTransactionRead,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_supplier_payment_from_transaction(
+    tx_id: int,
+    payload: BankTransactionClientPaymentCreate,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    _current_user: _WriteAccess,
+) -> BankTransactionRead:
+    try:
+        tx = await bank_service.create_supplier_payment_from_transaction(
+            db,
+            tx_id=tx_id,
+            invoice_id=payload.invoice_id,
+        )
+    except LookupError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=str(exc),
+        ) from exc
+    return await _serialize_transaction(db, tx)
+
+
+@router.post("/transactions/{tx_id}/link-client-payment", response_model=BankTransactionRead)
+async def link_client_payment_to_transaction(
+    tx_id: int,
+    payload: BankTransactionClientPaymentLink,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    _current_user: _WriteAccess,
+) -> BankTransactionRead:
+    try:
+        tx = await bank_service.link_client_payment_to_transaction(
+            db,
+            tx_id=tx_id,
+            payment_id=payload.payment_id,
+        )
+    except LookupError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=str(exc),
+        ) from exc
+    return await _serialize_transaction(db, tx)
+
+
+@router.post("/transactions/{tx_id}/link-client-payments", response_model=BankTransactionRead)
+async def link_client_payments_to_transaction(
+    tx_id: int,
+    payload: BankTransactionClientPaymentLinks,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    _current_user: _WriteAccess,
+) -> BankTransactionRead:
+    try:
+        tx = await bank_service.link_client_payments_to_transaction(
+            db,
+            tx_id=tx_id,
+            payment_ids=payload.payment_ids,
+        )
+    except LookupError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=str(exc),
+        ) from exc
+    return await _serialize_transaction(db, tx)
+
+
+@router.post("/transactions/{tx_id}/link-supplier-payment", response_model=BankTransactionRead)
+async def link_supplier_payment_to_transaction(
+    tx_id: int,
+    payload: BankTransactionClientPaymentLink,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    _current_user: _WriteAccess,
+) -> BankTransactionRead:
+    try:
+        tx = await bank_service.link_supplier_payment_to_transaction(
+            db,
+            tx_id=tx_id,
+            payment_id=payload.payment_id,
+        )
+    except LookupError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=str(exc),
+        ) from exc
+    return await _serialize_transaction(db, tx)
 
 
 # ---------------------------------------------------------------------------
@@ -112,9 +283,6 @@ class _CsvImportBody(BankTransactionCreate):
 
 class _CsvImportRequest:
     content: str
-
-
-from pydantic import BaseModel  # noqa: E402
 
 
 class CsvImportRequest(BaseModel):
@@ -150,7 +318,7 @@ async def import_csv(
             source="import",
         )
         tx = await bank_service.add_transaction(db, tx_payload)
-        created.append(cast(BankTransactionRead, tx))
+        created.append(await _serialize_transaction(db, tx))
     return created
 
 
@@ -170,7 +338,7 @@ async def _import_rows(
             source="import",
         )
         tx = await bank_service.add_transaction(db, tx_payload)
-        created.append(cast(BankTransactionRead, tx))
+        created.append(await _serialize_transaction(db, tx))
     return created
 
 

--- a/backend/routers/bank.py
+++ b/backend/routers/bank.py
@@ -44,19 +44,36 @@ _ReadAccess = Annotated[
 ]
 
 
+def _serialize_transaction_with_payment_ids(
+    tx: BankTransaction,
+    payment_ids: list[int],
+) -> BankTransactionRead:
+    return BankTransactionRead.model_validate(tx).model_copy(update={"payment_ids": payment_ids})
+
+
 async def _serialize_transaction(
     db: AsyncSession,
     tx: BankTransaction,
 ) -> BankTransactionRead:
     payment_ids = await bank_service.get_transaction_payment_ids(db, tx.id)
-    return BankTransactionRead.model_validate(tx).model_copy(update={"payment_ids": payment_ids})
+    return _serialize_transaction_with_payment_ids(tx, payment_ids)
 
 
 async def _serialize_transactions(
     db: AsyncSession,
     txs: list[BankTransaction],
 ) -> list[BankTransactionRead]:
-    return [await _serialize_transaction(db, tx) for tx in txs]
+    if not txs:
+        return []
+
+    payment_ids_by_tx_id = await bank_service.get_transaction_payment_ids_map(
+        db,
+        [tx.id for tx in txs],
+    )
+    return [
+        _serialize_transaction_with_payment_ids(tx, payment_ids_by_tx_id.get(tx.id, []))
+        for tx in txs
+    ]
 
 
 # ---------------------------------------------------------------------------

--- a/backend/schemas/bank.py
+++ b/backend/schemas/bank.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 from datetime import date as _Date
 from decimal import Decimal as _Decimal
 
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, Field, field_validator
 
-from backend.models.bank import BankTransactionSource, DepositType
+from backend.models.bank import BankTransactionCategory, BankTransactionSource, DepositType
 
 
 class BankTransactionCreate(BaseModel):
@@ -29,6 +29,9 @@ class BankTransactionRead(BaseModel):
     reconciled: bool
     reconciled_with: str | None
     source: BankTransactionSource
+    detected_category: BankTransactionCategory
+    payment_id: int | None
+    payment_ids: list[int] = Field(default_factory=list)
 
     model_config = {"from_attributes": True}
 
@@ -38,6 +41,55 @@ class BankTransactionUpdate(BaseModel):
     reconciled_with: str | None = None
     reference: str | None = None
     description: str | None = None
+
+
+class BankTransactionClientPaymentCreate(BaseModel):
+    invoice_id: int
+
+
+class BankTransactionClientPaymentAllocation(BaseModel):
+    invoice_id: int
+    amount: _Decimal
+
+    @field_validator("amount")
+    @classmethod
+    def amount_positive(cls, v: _Decimal) -> _Decimal:
+        if v <= 0:
+            raise ValueError("amount must be positive")
+        return v
+
+
+class BankTransactionClientPaymentsCreate(BaseModel):
+    allocations: list[BankTransactionClientPaymentAllocation]
+
+    @field_validator("allocations")
+    @classmethod
+    def at_least_one_allocation(
+        cls, v: list[BankTransactionClientPaymentAllocation]
+    ) -> list[BankTransactionClientPaymentAllocation]:
+        if not v:
+            raise ValueError("at least one allocation is required")
+        invoice_ids = [allocation.invoice_id for allocation in v]
+        if len(invoice_ids) != len(set(invoice_ids)):
+            raise ValueError("duplicate invoice allocations are not allowed")
+        return v
+
+
+class BankTransactionClientPaymentLink(BaseModel):
+    payment_id: int
+
+
+class BankTransactionClientPaymentLinks(BaseModel):
+    payment_ids: list[int]
+
+    @field_validator("payment_ids")
+    @classmethod
+    def at_least_one_payment(cls, v: list[int]) -> list[int]:
+        if not v:
+            raise ValueError("at least one payment is required")
+        if len(v) != len(set(v)):
+            raise ValueError("duplicate payments are not allowed")
+        return v
 
 
 class DepositCreate(BaseModel):

--- a/backend/services/bank_import.py
+++ b/backend/services/bank_import.py
@@ -5,12 +5,75 @@ from __future__ import annotations
 import csv
 import io
 import re
+import unicodedata
 from datetime import date
 from decimal import Decimal, InvalidOperation
+
+from backend.models.bank import BankTransactionCategory
 
 
 class BankImportError(ValueError):
     """Raised when a bank statement file cannot be parsed."""
+
+
+def _normalise_label(value: str) -> str:
+    normalised = unicodedata.normalize("NFKD", value)
+    ascii_value = normalised.encode("ascii", "ignore").decode("ascii")
+    return re.sub(r"\s+", " ", ascii_value.upper()).strip()
+
+
+def detect_transaction_category(
+    *,
+    amount: Decimal,
+    description: str,
+    reference: str | None = None,
+) -> BankTransactionCategory:
+    """Return an initial category guess for a bank transaction."""
+    label = _normalise_label(description)
+    ref = _normalise_label(reference or "")
+    combined = f"{label} {ref}".strip()
+
+    if amount == 0:
+        return BankTransactionCategory.UNCATEGORIZED
+
+    if "REM CHQ" in combined or "REMISE CHEQUE" in combined:
+        return BankTransactionCategory.CHEQUE_DEPOSIT
+
+    if combined.startswith("VRST ") or "VERSEMENT" in combined or "REM ESP" in combined:
+        return BankTransactionCategory.CASH_DEPOSIT
+
+    if "URSSAF" in combined:
+        return BankTransactionCategory.SOCIAL_CHARGE
+
+    if "SALAIRE" in combined:
+        return BankTransactionCategory.SALARY
+
+    if "FACT SGT" in combined or (amount < 0 and combined.startswith("FACT ")):
+        return BankTransactionCategory.BANK_FEE
+
+    if "PRLV" in combined or "PRLV SEPA" in combined or "PRELEVEMENT" in combined:
+        return BankTransactionCategory.SEPA_DEBIT
+
+    if "VIR INT" in combined or "VIREMENT INTERNE" in combined:
+        return BankTransactionCategory.INTERNAL_TRANSFER
+
+    if amount < 0 and ("VIR INST FF-" in combined or "FF-" in combined or "FOURN" in combined):
+        return BankTransactionCategory.SUPPLIER_PAYMENT
+
+    if amount > 0 and (
+        "SUBVENTION" in combined or combined.startswith("DON ") or "DONATION" in combined
+    ):
+        return BankTransactionCategory.GRANT
+
+    if amount > 0 and (
+        combined.startswith("VIR") or "VIREMENT" in combined or re.match(r"^\d{4}-\d{4}", combined)
+    ):
+        return BankTransactionCategory.CUSTOMER_PAYMENT
+
+    if amount > 0:
+        return BankTransactionCategory.OTHER_CREDIT
+
+    return BankTransactionCategory.OTHER_DEBIT
 
 
 def parse_credit_mutuel_csv(content: str) -> list[dict[str, object]]:

--- a/backend/services/bank_service.py
+++ b/backend/services/bank_service.py
@@ -42,8 +42,18 @@ def _require_transaction_direction(
         raise ValueError(f"only negative bank transactions can {purpose}")
 
 
-def _require_unreconciled_transaction(tx: BankTransaction) -> None:
+async def _require_unreconciled_transaction(
+    db: AsyncSession,
+    tx: BankTransaction,
+) -> None:
     if tx.reconciled or tx.payment_id is not None:
+        raise ValueError("bank transaction is already reconciled")
+    linked_result = await db.execute(
+        select(bank_transaction_payments.c.transaction_id).where(
+            bank_transaction_payments.c.transaction_id == tx.id
+        )
+    )
+    if linked_result.scalar_one_or_none() is not None:
         raise ValueError("bank transaction is already reconciled")
 
 
@@ -259,7 +269,7 @@ async def create_client_payment_from_transaction(
     if tx is None:
         raise LookupError("Transaction not found")
     _require_transaction_direction(tx, positive=True, purpose="create client payments")
-    _require_unreconciled_transaction(tx)
+    await _require_unreconciled_transaction(db, tx)
 
     payment = await payment_service.create_bank_reconciled_client_payment(
         db,
@@ -288,7 +298,7 @@ async def create_client_payments_from_transaction(
     if tx is None:
         raise LookupError("Transaction not found")
     _require_transaction_direction(tx, positive=True, purpose="create client payments")
-    _require_unreconciled_transaction(tx)
+    await _require_unreconciled_transaction(db, tx)
 
     expected_amount = Decimal(str(tx.amount))
     allocated_amount = sum(
@@ -329,7 +339,7 @@ async def create_supplier_payment_from_transaction(
     if tx is None:
         raise LookupError("Transaction not found")
     _require_transaction_direction(tx, positive=False, purpose="create supplier payments")
-    _require_unreconciled_transaction(tx)
+    await _require_unreconciled_transaction(db, tx)
 
     payment = await payment_service.create_bank_reconciled_supplier_payment(
         db,
@@ -362,7 +372,7 @@ async def link_client_payment_to_transaction(
         positive=True,
         purpose="link existing client payments",
     )
-    _require_unreconciled_transaction(tx)
+    await _require_unreconciled_transaction(db, tx)
 
     payment = await _require_linkable_payment(
         db,
@@ -392,7 +402,7 @@ async def link_client_payments_to_transaction(
         positive=True,
         purpose="link existing client payments",
     )
-    _require_unreconciled_transaction(tx)
+    await _require_unreconciled_transaction(db, tx)
 
     payments: list[Payment] = []
     for payment_id in payment_ids:
@@ -427,7 +437,7 @@ async def link_supplier_payment_to_transaction(
         positive=False,
         purpose="link existing supplier payments",
     )
-    _require_unreconciled_transaction(tx)
+    await _require_unreconciled_transaction(db, tx)
 
     payment = await _require_linkable_payment(
         db,
@@ -519,16 +529,43 @@ async def create_deposit(db: AsyncSession, payload: DepositCreate) -> Deposit:
 
 
 async def get_transaction_payment_ids(db: AsyncSession, tx_id: int) -> list[int]:
-    result = await db.execute(
-        select(bank_transaction_payments.c.payment_id)
-        .where(bank_transaction_payments.c.transaction_id == tx_id)
-        .order_by(bank_transaction_payments.c.payment_id.asc())
-    )
-    if payment_ids := list(result.scalars().all()):
-        return payment_ids
+    return (await get_transaction_payment_ids_map(db, [tx_id])).get(tx_id, [])
 
-    tx = await get_transaction(db, tx_id)
-    return [] if tx is None or tx.payment_id is None else [tx.payment_id]
+
+async def get_transaction_payment_ids_map(
+    db: AsyncSession,
+    tx_ids: list[int],
+) -> dict[int, list[int]]:
+    if not tx_ids:
+        return {}
+
+    payment_ids_by_tx_id: dict[int, list[int]] = {tx_id: [] for tx_id in tx_ids}
+
+    association_result = await db.execute(
+        select(
+            bank_transaction_payments.c.transaction_id,
+            bank_transaction_payments.c.payment_id,
+        )
+        .where(bank_transaction_payments.c.transaction_id.in_(tx_ids))
+        .order_by(
+            bank_transaction_payments.c.transaction_id.asc(),
+            bank_transaction_payments.c.payment_id.asc(),
+        )
+    )
+    for transaction_id, payment_id in association_result.all():
+        payment_ids_by_tx_id[transaction_id].append(payment_id)
+
+    legacy_result = await db.execute(
+        select(BankTransaction.id, BankTransaction.payment_id).where(
+            BankTransaction.id.in_(tx_ids),
+            BankTransaction.payment_id.is_not(None),
+        )
+    )
+    for transaction_id, payment_id in legacy_result.all():
+        if payment_id is not None and not payment_ids_by_tx_id[transaction_id]:
+            payment_ids_by_tx_id[transaction_id] = [payment_id]
+
+    return payment_ids_by_tx_id
 
 
 async def get_deposit(db: AsyncSession, deposit_id: int) -> Deposit | None:

--- a/backend/services/bank_service.py
+++ b/backend/services/bank_service.py
@@ -10,14 +10,132 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.models.bank import (
     BankTransaction,
+    BankTransactionCategory,
     BankTransactionSource,
     Deposit,
     DepositType,
+    bank_transaction_payments,
     deposit_payments,
 )
 from backend.models.cash import CashEntrySource, CashMovementType
+from backend.models.invoice import InvoiceType
 from backend.models.payment import Payment, PaymentMethod
-from backend.schemas.bank import BankTransactionCreate, BankTransactionUpdate, DepositCreate
+from backend.schemas.bank import (
+    BankTransactionClientPaymentsCreate,
+    BankTransactionCreate,
+    BankTransactionUpdate,
+    DepositCreate,
+)
+from backend.services import payment as payment_service
+from backend.services.bank_import import detect_transaction_category
+
+
+def _require_transaction_direction(
+    tx: BankTransaction,
+    *,
+    positive: bool,
+    purpose: str,
+) -> None:
+    if positive and tx.amount <= 0:
+        raise ValueError(f"only positive bank transactions can {purpose}")
+    if not positive and tx.amount >= 0:
+        raise ValueError(f"only negative bank transactions can {purpose}")
+
+
+def _require_unreconciled_transaction(tx: BankTransaction) -> None:
+    if tx.reconciled or tx.payment_id is not None:
+        raise ValueError("bank transaction is already reconciled")
+
+
+async def _require_linkable_payment(
+    db: AsyncSession,
+    *,
+    payment_id: int,
+    invoice_type: InvoiceType,
+) -> Payment:
+    payment = await payment_service.get_payment(db, payment_id)
+    if payment is None:
+        raise LookupError("Payment not found")
+    if payment.invoice_type != invoice_type or payment.method != PaymentMethod.VIREMENT:
+        invoice_kind = "client" if invoice_type == InvoiceType.CLIENT else "supplier"
+        raise ValueError(f"only existing {invoice_kind} virement payments can be linked")
+
+    linked_payment_result = await db.execute(
+        select(bank_transaction_payments.c.transaction_id).where(
+            bank_transaction_payments.c.payment_id == payment.id
+        )
+    )
+    if linked_payment_result.scalar_one_or_none() is not None:
+        raise ValueError("payment is already linked to another bank transaction")
+    legacy_linked_payment_result = await db.execute(
+        select(BankTransaction.id).where(BankTransaction.payment_id == payment.id)
+    )
+    if legacy_linked_payment_result.scalar_one_or_none() is not None:
+        raise ValueError("payment is already linked to another bank transaction")
+    return payment
+
+
+def _build_reconciled_with_value(payments: list[Payment]) -> str | None:
+    if not payments:
+        return None
+    if len(payments) == 1:
+        return payments[0].invoice_number or payments[0].reference
+    first_label = payments[0].invoice_number or payments[0].reference or f"payment-{payments[0].id}"
+    return f"{first_label} +{len(payments) - 1}"
+
+
+async def _store_transaction_payment_links(
+    db: AsyncSession,
+    *,
+    tx: BankTransaction,
+    payments: list[Payment],
+) -> None:
+    await db.execute(
+        insert(bank_transaction_payments),
+        [{"transaction_id": tx.id, "payment_id": payment.id} for payment in payments],
+    )
+    tx.reconciled = True
+    tx.reconciled_with = _build_reconciled_with_value(payments)
+    tx.payment_id = payments[0].id if len(payments) == 1 else None
+
+
+async def _finalize_payment_link(
+    db: AsyncSession,
+    *,
+    tx: BankTransaction,
+    payment: Payment,
+    expected_amount: Decimal,
+) -> BankTransaction:
+    return await _finalize_payment_links(
+        db,
+        tx=tx,
+        payments=[payment],
+        expected_amount=expected_amount,
+        error_message="bank transaction amount must match payment amount",
+    )
+
+
+async def _finalize_payment_links(
+    db: AsyncSession,
+    *,
+    tx: BankTransaction,
+    payments: list[Payment],
+    expected_amount: Decimal,
+    error_message: str,
+) -> BankTransaction:
+    payments_total = sum((Decimal(str(payment.amount)) for payment in payments), start=Decimal("0"))
+    if payments_total != expected_amount:
+        raise ValueError(error_message)
+
+    for payment in payments:
+        payment.deposited = True
+        payment.deposit_date = tx.date
+
+    await _store_transaction_payment_links(db, tx=tx, payments=payments)
+    await db.flush()
+    await db.commit()
+    await db.refresh(tx)
+    return tx
 
 
 async def _current_bank_balance(db: AsyncSession) -> Decimal:
@@ -73,6 +191,15 @@ async def create_bank_transaction_record(
         description=description,
         balance_after=Decimal("0"),
         source=source,
+        detected_category=(
+            BankTransactionCategory.UNCATEGORIZED
+            if source == BankTransactionSource.SYSTEM_OPENING
+            else detect_transaction_category(
+                amount=amount,
+                description=description,
+                reference=reference,
+            )
+        ),
     )
     db.add(tx)
     await db.flush()
@@ -119,6 +246,200 @@ async def update_transaction(
     await db.commit()
     await db.refresh(tx)
     return tx
+
+
+async def create_client_payment_from_transaction(
+    db: AsyncSession,
+    *,
+    tx_id: int,
+    invoice_id: int,
+) -> BankTransaction:
+    """Create a client virement from a positive bank transaction and reconcile it."""
+    tx = await get_transaction(db, tx_id)
+    if tx is None:
+        raise LookupError("Transaction not found")
+    _require_transaction_direction(tx, positive=True, purpose="create client payments")
+    _require_unreconciled_transaction(tx)
+
+    payment = await payment_service.create_bank_reconciled_client_payment(
+        db,
+        invoice_id=invoice_id,
+        amount=Decimal(str(tx.amount)),
+        payment_date=tx.date,
+        reference=tx.reference,
+        notes=tx.description or None,
+    )
+
+    await _store_transaction_payment_links(db, tx=tx, payments=[payment])
+    await db.flush()
+    await db.commit()
+    await db.refresh(tx)
+    return tx
+
+
+async def create_client_payments_from_transaction(
+    db: AsyncSession,
+    *,
+    tx_id: int,
+    payload: BankTransactionClientPaymentsCreate,
+) -> BankTransaction:
+    """Create multiple client virements from a single positive bank transaction."""
+    tx = await get_transaction(db, tx_id)
+    if tx is None:
+        raise LookupError("Transaction not found")
+    _require_transaction_direction(tx, positive=True, purpose="create client payments")
+    _require_unreconciled_transaction(tx)
+
+    expected_amount = Decimal(str(tx.amount))
+    allocated_amount = sum(
+        (Decimal(str(allocation.amount)) for allocation in payload.allocations),
+        start=Decimal("0"),
+    )
+    if allocated_amount != expected_amount:
+        raise ValueError("allocated amount must match bank transaction amount")
+
+    payments: list[Payment] = []
+    for allocation in payload.allocations:
+        payment = await payment_service.create_bank_reconciled_client_payment(
+            db,
+            invoice_id=allocation.invoice_id,
+            amount=Decimal(str(allocation.amount)),
+            payment_date=tx.date,
+            reference=tx.reference,
+            notes=tx.description or None,
+            commit=False,
+        )
+        payments.append(payment)
+
+    await _store_transaction_payment_links(db, tx=tx, payments=payments)
+    await db.flush()
+    await db.commit()
+    await db.refresh(tx)
+    return tx
+
+
+async def create_supplier_payment_from_transaction(
+    db: AsyncSession,
+    *,
+    tx_id: int,
+    invoice_id: int,
+) -> BankTransaction:
+    """Create a supplier virement from a negative bank transaction and reconcile it."""
+    tx = await get_transaction(db, tx_id)
+    if tx is None:
+        raise LookupError("Transaction not found")
+    _require_transaction_direction(tx, positive=False, purpose="create supplier payments")
+    _require_unreconciled_transaction(tx)
+
+    payment = await payment_service.create_bank_reconciled_supplier_payment(
+        db,
+        invoice_id=invoice_id,
+        amount=abs(Decimal(str(tx.amount))),
+        payment_date=tx.date,
+        reference=tx.reference,
+        notes=tx.description or None,
+    )
+
+    await _store_transaction_payment_links(db, tx=tx, payments=[payment])
+    await db.flush()
+    await db.commit()
+    await db.refresh(tx)
+    return tx
+
+
+async def link_client_payment_to_transaction(
+    db: AsyncSession,
+    *,
+    tx_id: int,
+    payment_id: int,
+) -> BankTransaction:
+    """Link a positive bank transaction to an existing client virement payment."""
+    tx = await get_transaction(db, tx_id)
+    if tx is None:
+        raise LookupError("Transaction not found")
+    _require_transaction_direction(
+        tx,
+        positive=True,
+        purpose="link existing client payments",
+    )
+    _require_unreconciled_transaction(tx)
+
+    payment = await _require_linkable_payment(
+        db,
+        payment_id=payment_id,
+        invoice_type=InvoiceType.CLIENT,
+    )
+    return await _finalize_payment_link(
+        db,
+        tx=tx,
+        payment=payment,
+        expected_amount=Decimal(str(tx.amount)),
+    )
+
+
+async def link_client_payments_to_transaction(
+    db: AsyncSession,
+    *,
+    tx_id: int,
+    payment_ids: list[int],
+) -> BankTransaction:
+    """Link a positive bank transaction to multiple existing client virement payments."""
+    tx = await get_transaction(db, tx_id)
+    if tx is None:
+        raise LookupError("Transaction not found")
+    _require_transaction_direction(
+        tx,
+        positive=True,
+        purpose="link existing client payments",
+    )
+    _require_unreconciled_transaction(tx)
+
+    payments: list[Payment] = []
+    for payment_id in payment_ids:
+        payment = await _require_linkable_payment(
+            db,
+            payment_id=payment_id,
+            invoice_type=InvoiceType.CLIENT,
+        )
+        payments.append(payment)
+
+    return await _finalize_payment_links(
+        db,
+        tx=tx,
+        payments=payments,
+        expected_amount=Decimal(str(tx.amount)),
+        error_message="linked payments total must match bank transaction amount",
+    )
+
+
+async def link_supplier_payment_to_transaction(
+    db: AsyncSession,
+    *,
+    tx_id: int,
+    payment_id: int,
+) -> BankTransaction:
+    """Link a negative bank transaction to an existing supplier virement payment."""
+    tx = await get_transaction(db, tx_id)
+    if tx is None:
+        raise LookupError("Transaction not found")
+    _require_transaction_direction(
+        tx,
+        positive=False,
+        purpose="link existing supplier payments",
+    )
+    _require_unreconciled_transaction(tx)
+
+    payment = await _require_linkable_payment(
+        db,
+        payment_id=payment_id,
+        invoice_type=InvoiceType.FOURNISSEUR,
+    )
+    return await _finalize_payment_link(
+        db,
+        tx=tx,
+        payment=payment,
+        expected_amount=abs(Decimal(str(tx.amount))),
+    )
 
 
 async def get_bank_balance(db: AsyncSession) -> Decimal:
@@ -195,6 +516,19 @@ async def create_deposit(db: AsyncSession, payload: DepositCreate) -> Deposit:
     await db.commit()
     await db.refresh(deposit)
     return deposit
+
+
+async def get_transaction_payment_ids(db: AsyncSession, tx_id: int) -> list[int]:
+    result = await db.execute(
+        select(bank_transaction_payments.c.payment_id)
+        .where(bank_transaction_payments.c.transaction_id == tx_id)
+        .order_by(bank_transaction_payments.c.payment_id.asc())
+    )
+    if payment_ids := list(result.scalars().all()):
+        return payment_ids
+
+    tx = await get_transaction(db, tx_id)
+    return [] if tx is None or tx.payment_id is None else [tx.payment_id]
 
 
 async def get_deposit(db: AsyncSession, deposit_id: int) -> Deposit | None:

--- a/backend/services/payment.py
+++ b/backend/services/payment.py
@@ -31,11 +31,103 @@ async def _attach_invoice_number(db: AsyncSession, payment: Payment) -> Payment:
 
 async def create_payment(db: AsyncSession, payload: PaymentCreate) -> Payment:
     """Record a payment and update the invoice paid_amount and status."""
+    return await _create_payment(db, payload)
+
+
+async def create_bank_reconciled_client_payment(
+    db: AsyncSession,
+    *,
+    invoice_id: int,
+    amount: Decimal,
+    payment_date: date,
+    reference: str | None = None,
+    notes: str | None = None,
+    commit: bool = True,
+) -> Payment:
+    """Create a client virement originating from a reconciled bank transaction."""
+    invoice = await _get_invoice(db, invoice_id)
+    if invoice is None:
+        raise InvoiceNotFoundError("Invoice not found")
+    if invoice.type != InvoiceType.CLIENT:
+        raise ValueError("bank reconciliation can only create client payments")
+
+    payload = PaymentCreate(
+        invoice_id=invoice.id,
+        contact_id=invoice.contact_id,
+        amount=amount,
+        date=payment_date,
+        method=PaymentMethod.VIREMENT,
+        reference=reference,
+        notes=notes,
+    )
+    return await _create_payment(
+        db,
+        payload,
+        allow_client_virement=True,
+        deposited=True,
+        deposit_date=payment_date,
+        commit=commit,
+    )
+
+
+async def create_bank_reconciled_supplier_payment(
+    db: AsyncSession,
+    *,
+    invoice_id: int,
+    amount: Decimal,
+    payment_date: date,
+    reference: str | None = None,
+    notes: str | None = None,
+    commit: bool = True,
+) -> Payment:
+    """Create a supplier virement originating from a reconciled bank transaction."""
+    invoice = await _get_invoice(db, invoice_id)
+    if invoice is None:
+        raise InvoiceNotFoundError("Invoice not found")
+    if invoice.type != InvoiceType.FOURNISSEUR:
+        raise ValueError("bank reconciliation can only create supplier payments")
+
+    payload = PaymentCreate(
+        invoice_id=invoice.id,
+        contact_id=invoice.contact_id,
+        amount=amount,
+        date=payment_date,
+        method=PaymentMethod.VIREMENT,
+        reference=reference,
+        notes=notes,
+    )
+    return await _create_payment(
+        db,
+        payload,
+        deposited=True,
+        deposit_date=payment_date,
+        commit=commit,
+    )
+
+
+async def _create_payment(
+    db: AsyncSession,
+    payload: PaymentCreate,
+    *,
+    allow_client_virement: bool = False,
+    deposited: bool | None = None,
+    deposit_date: date | None = None,
+    commit: bool = True,
+) -> Payment:
+    """Persist a payment and all its side effects."""
     invoice = await _get_invoice(db, payload.invoice_id)
     if invoice is None:
         raise InvoiceNotFoundError("Invoice not found")
-    _validate_manual_client_payment_method(invoice, payload.method)
+    _validate_manual_client_payment_method(
+        invoice,
+        payload.method,
+        allow_client_virement=allow_client_virement,
+    )
     payment = Payment(**payload.model_dump())
+    if deposited is not None:
+        payment.deposited = deposited
+    if deposit_date is not None:
+        payment.deposit_date = deposit_date
     db.add(payment)
     await db.flush()
     await _refresh_invoice_status(db, payload.invoice_id)
@@ -46,8 +138,9 @@ async def create_payment(db: AsyncSession, payload: PaymentCreate) -> Payment:
     )
 
     await generate_entries_for_payment(db, payment, invoice.type)
-    await db.commit()
-    await db.refresh(payment)
+    if commit:
+        await db.commit()
+        await db.refresh(payment)
     return await _attach_invoice_number(db, payment)
 
 
@@ -134,9 +227,12 @@ def _validate_manual_client_payment_method(
     method: PaymentMethod,
     *,
     current_method: PaymentMethod | None = None,
+    allow_client_virement: bool = False,
 ) -> None:
     """Reject manual client virements until bank reconciliation owns that workflow."""
     if invoice is None or invoice.type != InvoiceType.CLIENT:
+        return
+    if allow_client_virement:
         return
     if method != PaymentMethod.VIREMENT:
         return

--- a/doc/backlog.md
+++ b/doc/backlog.md
@@ -50,9 +50,9 @@ Tout sujet concret qui doit survivre au-delà de la séance en cours doit être 
 
 ## Priorités proposées pour la prochaine discussion
 
-1. **BL-031** — concevoir une vraie réconciliation bancaire bout en bout entre relevés importés, transactions détectées, catégorisation et création de paiements.
-2. **BL-021** — finaliser le manuel utilisateur illustré avec stabilisation éditoriale et enrichissement visuel.
-3. **BL-019** — refaire le README et la documentation technique d'installation, mise à jour, pile techno, configuration et exploitation Docker.
+1. **BL-030** — définir une politique explicite de modification des objets métier déjà créés ou validés.
+2. **BL-004** — afficher un historique d'import exploitable dans l'UI avec type, date, compteurs, diagnostics et traçabilité suffisante.
+3. **BL-021** — finaliser le manuel utilisateur illustré avec stabilisation éditoriale et enrichissement visuel.
 
 ## Récapitulatif des sujets ouverts
 
@@ -64,9 +64,7 @@ Tout sujet concret qui doit survivre au-delà de la séance en cours doit être 
 | BL-019 | 2026-04-13 | Documentation | Projet / Exploitation | P1 | Refaire le README et la documentation technique d'installation, mise à jour, pile techno, configuration et exploitation Docker |
 | BL-020 | 2026-04-13 | Documentation | Développement | P3 | Documenter clairement comment participer au projet : prérequis, environnement local, commandes utiles, qualité attendue et workflow PR |
 | BL-021 | 2026-04-13 | Documentation | Utilisateur / Parcours | P1 | Rédiger un manuel utilisateur illustré et pas à pas aligné sur les écrans réellement disponibles |
-| BL-024 | 2026-04-13 | Correction | Paiements / Banque | P1 | Clarifier le workflow cible de saisie des paiements et corriger l'automatisme qui remet en banque les paiements `espèces` et `virement` dès leur encodage |
 | BL-030 | 2026-04-16 | Décision | Métier / Edition des données | P1 | Définir une politique explicite de modification des objets métier déjà créés ou validés (factures, paiements, achats, etc.) avec règles de recalcul, traçabilité et limites selon le statut |
-| BL-031 | 2026-04-19 | Amélioration | Banque / Rapprochement | P1 | Concevoir puis implémenter une vraie réconciliation bancaire entre relevés importés, transactions détectées, catégorisation et création ou rapprochement des paiements |
 
 ## Détail des sujets
 
@@ -358,9 +356,18 @@ Tout sujet concret qui doit survivre au-delà de la séance en cours doit être 
 
 ### BL-031 — Construire une vraie réconciliation bancaire bout en bout
 
-- **Dates** : `created=2026-04-19`
+- **Dates** : `created=2026-04-19`, `started=2026-04-19`, `completed=2026-04-20`
 - **Pourquoi** : le produit sait aujourd'hui importer ou saisir des opérations bancaires et les marquer comme `rapprochées`, mais ce rapprochement reste superficiel : il n'existe ni vrai lien métier entre une transaction bancaire et un paiement, ni workflow robuste pour partir d'un relevé et en déduire ou rattacher les paiements clients attendus, en particulier pour les virements.
 - **Résultat attendu** : disposer d'une chaîne cohérente de réconciliation bancaire couvrant l'import des relevés, la détection des transactions utiles, leur catégorisation, la proposition de rapprochements, et la création ou le rattachement des paiements et autres mouvements métier appropriés.
+- **Résultat livré** : l'écran `Banque` supporte désormais l'import `CSV` / `OFX` / `QIF`, une catégorisation initiale des transactions, la création ou la confirmation de virements clients et fournisseurs depuis le relevé, la gestion d'un virement client unique ou ventilé sur plusieurs factures, la confirmation de plusieurs règlements clients existants quand leur total correspond exactement à la ligne bancaire, et une traçabilité explicite via les liens `transaction <-> payment(s)`.
+- **Premier lot visé au démarrage** : rendre les relevés `OFX` et `QIF` réellement exploitables dans l'interface `Banque`, puis enrichir chaque transaction importée d'une première catégorisation détectée automatiquement pour préparer le vrai workflow de rapprochement.
+- **Avancement actuel sur la branche** : en plus de ce premier lot, l'écran `Banque` permet maintenant de traiter les virements clients et fournisseurs directement depuis les lignes du relevé : création d'un règlement à partir d'une facture ouverte ou confirmation d'un règlement déjà saisi en liant la transaction bancaire au paiement existant, avec une meilleure suggestion automatique du candidat le plus plausible selon le montant, la date, la référence, le numéro de pièce et le tiers. Pour les virements clients, une même ligne bancaire positive peut désormais soit créer plusieurs règlements ventilés sur plusieurs factures, soit confirmer plusieurs règlements clients déjà saisis quand leur total correspond exactement au montant du virement.
+- **Signalement utilisateur au 2026-04-20** : quelques écarts ont été observés en recette, notamment sur le solde banque, sans diagnostic encore tranché entre import, génération d'écritures ou autre logique transverse.
+- **Décision de pilotage actée** : ne pas ouvrir maintenant une chasse aux écarts isolés tant que les fonctionnalités MVP restantes ne sont pas terminées ; faire ensuite une recette bout en bout de qualification MVP et utiliser cette passe finale pour attribuer proprement chaque anomalie résiduelle à l'import, aux écritures générées ou à un autre composant.
+- **Cas métier existants explicités pendant la discussion** :
+	- un même virement ou chèque peut correspondre à plusieurs factures clientes ;
+	- une même facture peut être réglée en plusieurs fois, par exemple avec plusieurs chèques ;
+	- une même facture peut aussi être réglée par plusieurs moyens de paiement, par exemple `20 EUR` en espèces et `50 EUR` par chèque, ou `30 EUR` par chèque et `40 EUR` par virement.
 - **Périmètre visé** :
 	- import des relevés via les formats utiles (`QIF`, `OFX`, et si pertinent les extractions Excel ou CSV réellement utilisées) ;
 	- détection des mouvements créditeurs et débiteurs significatifs ;
@@ -501,3 +508,4 @@ Tout sujet concret qui doit survivre au-delà de la séance en cours doit être 
 - **BL-025** — `created=2026-04-13`, `started=2026-04-13`, `completed=2026-04-13` — Le grand livre est maintenant borné à l'exercice choisi, sans option multi-exercices, avec un solde d'ouverture cohérent quand la période démarre en cours d'exercice.
 - **BL-026** — `created=2026-04-15`, `started=2026-04-15`, `completed=2026-04-16` — Le ticket a livré un cadrage de recette et un constat exploitable sur la reprise `2024`, puis a été clos une fois les écarts résiduels requalifiés en différences de modélisation assumées ou en suites dédiées (`BL-008`, `BL-029`).
 - **BL-029** — `created=2026-04-16`, `started=2026-04-16`, `completed=2026-04-19` — La saisie des factures clients par lignes typées, le calcul dérivé du total et de la ventilation comptable, et les adaptations d'import `Gestion` / `Comptabilité` sont maintenant intégrés dans `develop` et validés côté recette métier utilisateur.
+- **BL-031** — `created=2026-04-19`, `started=2026-04-19`, `completed=2026-04-20` — La branche `feature/bl-031-bank-reconciliation` livre maintenant une vraie chaîne de rapprochement bancaire exploitable pour le MVP : import `CSV` / `OFX` / `QIF`, catégorisation initiale, suggestions de rapprochement, création ou confirmation de virements clients et fournisseurs depuis l'écran `Banque`, support des virements clients ventilés sur plusieurs règlements, traçabilité `transaction <-> payment(s)` et validation automatisée ciblée passée. Les écarts de recette encore observés, comme certains soldes banque, sont explicitement renvoyés à la recette finale de qualification MVP plutôt qu'à une suite bloquante de BL-031.

--- a/frontend/src/api/bank.ts
+++ b/frontend/src/api/bank.ts
@@ -2,6 +2,21 @@ import apiClient from './client'
 
 export type DepositType = 'cheques' | 'especes'
 export type BankTransactionSource = 'manual' | 'import' | 'system_opening'
+export type BankTransactionCategory =
+  | 'uncategorized'
+  | 'customer_payment'
+  | 'cheque_deposit'
+  | 'cash_deposit'
+  | 'supplier_payment'
+  | 'salary'
+  | 'social_charge'
+  | 'bank_fee'
+  | 'internal_transfer'
+  | 'grant'
+  | 'sepa_debit'
+  | 'other_credit'
+  | 'other_debit'
+export type BankImportFormat = 'csv' | 'ofx' | 'qif'
 
 export interface BankTransaction {
   id: number
@@ -13,6 +28,22 @@ export interface BankTransaction {
   reconciled: boolean
   reconciled_with: string | null
   source: BankTransactionSource
+  detected_category: BankTransactionCategory
+  payment_id: number | null
+  payment_ids: number[]
+}
+
+export interface BankTransactionClientPaymentAllocation {
+  invoice_id: number
+  amount: string
+}
+
+export interface BankTransactionClientPaymentLink {
+  payment_id: number
+}
+
+export interface BankTransactionClientPaymentLinks {
+  payment_ids: number[]
 }
 
 export interface BankTransactionCreate {
@@ -82,6 +113,112 @@ export async function importCsv(content: string): Promise<BankTransaction[]> {
   const response = await apiClient.post<BankTransaction[]>('/api/bank/transactions/import-csv', {
     content,
   })
+  return response.data
+}
+
+export async function importOfx(content: string): Promise<BankTransaction[]> {
+  const response = await apiClient.post<BankTransaction[]>('/api/bank/transactions/import-ofx', {
+    content,
+  })
+  return response.data
+}
+
+export async function importQif(content: string): Promise<BankTransaction[]> {
+  const response = await apiClient.post<BankTransaction[]>('/api/bank/transactions/import-qif', {
+    content,
+  })
+  return response.data
+}
+
+export async function importBankStatement(
+  format: BankImportFormat,
+  content: string,
+): Promise<BankTransaction[]> {
+  if (format === 'ofx') {
+    return importOfx(content)
+  }
+  if (format === 'qif') {
+    return importQif(content)
+  }
+  return importCsv(content)
+}
+
+export async function createClientPaymentFromTransaction(
+  txId: number,
+  invoiceId: number,
+): Promise<BankTransaction> {
+  const response = await apiClient.post<BankTransaction>(
+    `/api/bank/transactions/${txId}/create-client-payment`,
+    {
+      invoice_id: invoiceId,
+    },
+  )
+  return response.data
+}
+
+export async function createClientPaymentsFromTransaction(
+  txId: number,
+  allocations: BankTransactionClientPaymentAllocation[],
+): Promise<BankTransaction> {
+  const response = await apiClient.post<BankTransaction>(
+    `/api/bank/transactions/${txId}/create-client-payments`,
+    {
+      allocations,
+    },
+  )
+  return response.data
+}
+
+export async function createSupplierPaymentFromTransaction(
+  txId: number,
+  invoiceId: number,
+): Promise<BankTransaction> {
+  const response = await apiClient.post<BankTransaction>(
+    `/api/bank/transactions/${txId}/create-supplier-payment`,
+    {
+      invoice_id: invoiceId,
+    },
+  )
+  return response.data
+}
+
+export async function linkClientPaymentToTransaction(
+  txId: number,
+  paymentId: number,
+): Promise<BankTransaction> {
+  const response = await apiClient.post<BankTransaction>(
+    `/api/bank/transactions/${txId}/link-client-payment`,
+    {
+      payment_id: paymentId,
+    },
+  )
+  return response.data
+}
+
+export async function linkClientPaymentsToTransaction(
+  txId: number,
+  paymentIds: number[],
+): Promise<BankTransaction> {
+  const payload: BankTransactionClientPaymentLinks = {
+    payment_ids: paymentIds,
+  }
+  const response = await apiClient.post<BankTransaction>(
+    `/api/bank/transactions/${txId}/link-client-payments`,
+    payload,
+  )
+  return response.data
+}
+
+export async function linkSupplierPaymentToTransaction(
+  txId: number,
+  paymentId: number,
+): Promise<BankTransaction> {
+  const response = await apiClient.post<BankTransaction>(
+    `/api/bank/transactions/${txId}/link-supplier-payment`,
+    {
+      payment_id: paymentId,
+    },
+  )
   return response.data
 }
 

--- a/frontend/src/i18n/fr.ts
+++ b/frontend/src/i18n/fr.ts
@@ -541,6 +541,7 @@ export default {
     create_client_payment_ready_to_save:
       'La ventilation couvre exactement le montant du virement. Vous pouvez enregistrer le rapprochement.',
     create_client_payment_tx_summary: 'Opération du {date} · {amount} · {description}',
+    remaining_amount: 'reste {amount}',
     create_client_payment_no_invoice:
       'Aucune facture client ouverte n’est disponible pour ce rattachement.',
     create_client_payment_success:

--- a/frontend/src/i18n/fr.ts
+++ b/frontend/src/i18n/fr.ts
@@ -500,11 +500,12 @@ export default {
     deposits_empty: 'Aucun bordereau ne correspond aux filtres actuels.',
     new_transaction: 'Nouvelle opération',
     new_deposit: 'Nouveau bordereau',
+    import_statement: 'Importer un relevé',
     import_csv: 'Importer CSV',
     transaction_intro:
       'Ajoutez une opération manuelle avec son solde après écriture pour garder un rapprochement lisible.',
     import_intro:
-      'Collez le relevé CSV exporté par la banque pour importer rapidement plusieurs opérations.',
+      'Chargez un relevé bancaire au format CSV, OFX ou QIF pour importer rapidement plusieurs opérations.',
     deposit_intro:
       'Constituez un bordereau propre en regroupant les paiements encore en attente de remise.',
     deposit_selection_title: 'Paiements à inclure',
@@ -517,6 +518,7 @@ export default {
     tx_description: 'Libellé',
     tx_reference: 'Référence',
     tx_balance: 'Solde après',
+    tx_category: 'Catégorie détectée',
     tx_reconciled: 'Rapproché',
     tx_source: 'Source',
     deposit_date: 'Date',
@@ -527,6 +529,68 @@ export default {
     deposit_payments: 'Paiements inclus',
     reconcile: 'Rapprocher',
     reconciled_with: 'Référence pointage',
+    create_client_payment: 'Créer un règlement client',
+    create_client_payment_title: 'Créer un règlement client depuis la banque',
+    create_client_payment_intro:
+      'Utilisez cette ligne créditrice pour créer un règlement client par virement et la rapprocher immédiatement.',
+    create_client_payment_invoice: 'Facture cliente à rattacher',
+    create_client_payment_allocations: 'Ventilation sur les factures clientes',
+    create_client_payment_allocated_amount: 'Montant affecté',
+    create_client_payment_remaining_to_allocate:
+      'Il reste {amount} à ventiler pour pouvoir enregistrer ce virement.',
+    create_client_payment_ready_to_save:
+      'La ventilation couvre exactement le montant du virement. Vous pouvez enregistrer le rapprochement.',
+    create_client_payment_tx_summary: 'Opération du {date} · {amount} · {description}',
+    create_client_payment_no_invoice:
+      'Aucune facture client ouverte n’est disponible pour ce rattachement.',
+    create_client_payment_success:
+      '{count} règlement(s) client créé(s) et ligne bancaire rapprochée.',
+    link_client_payment: 'Lier un règlement existant',
+    link_client_payment_title: 'Confirmer un règlement déjà saisi',
+    link_client_payment_intro:
+      'Sélectionnez un virement client déjà saisi pour confirmer cette ligne bancaire sans recréer un second règlement.',
+    link_client_payment_payments: 'Règlements clients à confirmer',
+    link_client_payment_no_payment:
+      'Aucun règlement client par virement avec le même montant n’est disponible pour cette ligne bancaire.',
+    link_client_payment_remaining_to_match:
+      'Écart restant : {amount} pour atteindre exactement le montant du virement.',
+    link_client_payment_ready_to_confirm:
+      'La sélection correspond exactement au montant du virement. Vous pouvez confirmer le rapprochement.',
+    link_client_payment_success:
+      '{count} règlement(s) existant(s) confirmé(s) et ligne bancaire rapprochée.',
+    create_supplier_payment: 'Créer un règlement fournisseur',
+    create_supplier_payment_title: 'Créer un règlement fournisseur depuis la banque',
+    create_supplier_payment_intro:
+      'Utilisez ce débit bancaire pour créer un règlement fournisseur par virement et le rapprocher immédiatement.',
+    create_supplier_payment_invoice: 'Facture fournisseur à rattacher',
+    create_supplier_payment_no_invoice:
+      'Aucune facture fournisseur ouverte n’est disponible pour ce rattachement.',
+    create_supplier_payment_success: 'Règlement fournisseur créé et ligne bancaire rapprochée.',
+    link_supplier_payment: 'Lier un règlement fournisseur existant',
+    link_supplier_payment_title: 'Confirmer un règlement fournisseur déjà saisi',
+    link_supplier_payment_intro:
+      'Sélectionnez un virement fournisseur déjà saisi pour confirmer ce débit bancaire sans recréer un second règlement.',
+    link_supplier_payment_payment: 'Règlement fournisseur à confirmer',
+    link_supplier_payment_no_payment:
+      'Aucun règlement fournisseur par virement avec le même montant n’est disponible pour cette ligne bancaire.',
+    link_supplier_payment_success:
+      'Règlement fournisseur existant confirmé et ligne bancaire rapprochée.',
+    suggested_candidate_hint: 'La meilleure suggestion a été présélectionnée automatiquement.',
+    categories: {
+      uncategorized: 'À catégoriser',
+      customer_payment: 'Règlement client',
+      cheque_deposit: 'Remise de chèques',
+      cash_deposit: 'Dépôt d’espèces',
+      supplier_payment: 'Paiement fournisseur',
+      salary: 'Salaire',
+      social_charge: 'Charge sociale',
+      bank_fee: 'Frais bancaires',
+      internal_transfer: 'Virement interne',
+      grant: 'Subvention / don',
+      sepa_debit: 'Prélèvement',
+      other_credit: 'Autre crédit',
+      other_debit: 'Autre débit',
+    },
     sources: {
       manual: 'Manuel',
       import: 'Import',
@@ -536,8 +600,11 @@ export default {
       cheques: 'Chèques',
       especes: 'Espèces',
     },
-    import_dialog_title: 'Importer un relevé Crédit Mutuel',
-    import_paste_label: 'Coller le contenu CSV',
+    import_dialog_title: 'Importer un relevé bancaire',
+    import_file_label: 'Fichier',
+    import_pick_file: 'Choisir un fichier',
+    import_no_file: 'Aucun fichier sélectionné',
+    import_file_required: 'Sélectionnez un fichier de relevé avant l’import.',
     import_success: '{n} opération(s) importée(s).',
     metrics: {
       current_balance_caption: 'Toutes périodes confondues',

--- a/frontend/src/tests/utils/bankReconciliation.spec.ts
+++ b/frontend/src/tests/utils/bankReconciliation.spec.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  normalizeReconciliationText,
+  scoreInvoiceSuggestion,
+  scorePaymentSuggestion,
+} from '../../utils/bankReconciliation'
+
+describe('bank reconciliation helpers', () => {
+  it('normalizes accents and separators for matching', () => {
+    expect(normalizeReconciliationText('VIR Fournisseur-ete')).toBe('VIR FOURNISSEUR ETE')
+  })
+
+  it('prioritizes invoice candidates that match amount and reference text', () => {
+    const strongMatch = scoreInvoiceSuggestion({
+      transactionAmount: 200,
+      transactionDate: '2024-03-15',
+      transactionDescription: 'VIR FAC-FOURN-001 FOURNISSEUR TEST',
+      transactionReference: 'FOURN-2024-001',
+      candidateNumber: 'A-2024-001',
+      candidateReference: 'FAC-FOURN-001',
+      candidateContactName: 'Fournisseur Test',
+      candidateDate: '2024-03-14',
+      candidateRemainingAmount: 200,
+    })
+    const weakMatch = scoreInvoiceSuggestion({
+      transactionAmount: 200,
+      transactionDate: '2024-03-15',
+      transactionDescription: 'VIR FAC-FOURN-001 FOURNISSEUR TEST',
+      transactionReference: 'FOURN-2024-001',
+      candidateNumber: 'A-2024-002',
+      candidateReference: 'AUTRE-REF',
+      candidateContactName: 'Autre tiers',
+      candidateDate: '2024-01-10',
+      candidateRemainingAmount: 195,
+    })
+
+    expect(strongMatch).toBeGreaterThan(weakMatch)
+  })
+
+  it('prioritizes payments that match invoice number or reference from the bank label', () => {
+    const strongMatch = scorePaymentSuggestion({
+      transactionAmount: 150,
+      transactionDate: '2024-03-15',
+      transactionDescription: 'VIR DUPONT F-2024-103',
+      transactionReference: 'LEGACY-VIR-001',
+      candidateInvoiceNumber: 'F-2024-103',
+      candidateReference: 'LEGACY-VIR-001',
+      candidateContactName: 'Dupont',
+      candidateDate: '2024-03-14',
+      candidateAmount: 150,
+    })
+    const weakMatch = scorePaymentSuggestion({
+      transactionAmount: 150,
+      transactionDate: '2024-03-15',
+      transactionDescription: 'VIR DUPONT F-2024-103',
+      transactionReference: 'LEGACY-VIR-001',
+      candidateInvoiceNumber: 'F-2024-999',
+      candidateReference: 'OTHER-REF',
+      candidateContactName: 'Martin',
+      candidateDate: '2024-02-01',
+      candidateAmount: 150,
+    })
+
+    expect(strongMatch).toBeGreaterThan(weakMatch)
+  })
+})

--- a/frontend/src/utils/bankReconciliation.ts
+++ b/frontend/src/utils/bankReconciliation.ts
@@ -1,0 +1,102 @@
+function normalizeReconciliationText(value: string | null | undefined): string {
+  return (value ?? '')
+    .normalize('NFD')
+    .replace(/\p{Diacritic}/gu, '')
+    .toUpperCase()
+    .replace(/[^A-Z0-9]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function scoreTextPresence(bankText: string, candidateText: string | null | undefined): number {
+  const normalizedCandidate = normalizeReconciliationText(candidateText)
+  if (!normalizedCandidate) {
+    return 0
+  }
+  if (bankText.includes(normalizedCandidate)) {
+    return normalizedCandidate.length >= 6 ? 80 : 30
+  }
+
+  const candidateTokens = normalizedCandidate.split(' ').filter((token) => token.length >= 4)
+  return candidateTokens.reduce((score, token) => {
+    return score + (bankText.includes(token) ? 18 : 0)
+  }, 0)
+}
+
+function scoreDateProximity(
+  transactionDate: string,
+  candidateDate: string | null | undefined,
+): number {
+  if (!candidateDate) {
+    return 0
+  }
+
+  const txDate = new Date(transactionDate)
+  const otherDate = new Date(candidateDate)
+  const dayDelta = Math.abs(otherDate.getTime() - txDate.getTime()) / (1000 * 60 * 60 * 24)
+
+  if (dayDelta <= 3) {
+    return 18
+  }
+  if (dayDelta <= 10) {
+    return 12
+  }
+  if (dayDelta <= 30) {
+    return 6
+  }
+  return 0
+}
+
+export interface InvoiceSuggestionInput {
+  transactionAmount: number
+  transactionDate: string
+  transactionDescription: string
+  transactionReference?: string | null
+  candidateNumber: string
+  candidateReference?: string | null
+  candidateContactName?: string | null
+  candidateDate: string
+  candidateRemainingAmount: number
+}
+
+export interface PaymentSuggestionInput {
+  transactionAmount: number
+  transactionDate: string
+  transactionDescription: string
+  transactionReference?: string | null
+  candidateInvoiceNumber?: string | null
+  candidateReference?: string | null
+  candidateContactName?: string | null
+  candidateDate: string
+  candidateAmount: number
+}
+
+export function scoreInvoiceSuggestion(input: InvoiceSuggestionInput): number {
+  const bankText = normalizeReconciliationText(
+    `${input.transactionDescription} ${input.transactionReference ?? ''}`,
+  )
+  const amountDelta = Math.abs(input.candidateRemainingAmount - input.transactionAmount)
+
+  let score = Math.max(0, 120 - Math.round(amountDelta * 100))
+  score += scoreTextPresence(bankText, input.candidateNumber)
+  score += scoreTextPresence(bankText, input.candidateReference)
+  score += scoreTextPresence(bankText, input.candidateContactName)
+  score += scoreDateProximity(input.transactionDate, input.candidateDate)
+  return score
+}
+
+export function scorePaymentSuggestion(input: PaymentSuggestionInput): number {
+  const bankText = normalizeReconciliationText(
+    `${input.transactionDescription} ${input.transactionReference ?? ''}`,
+  )
+  const amountDelta = Math.abs(input.candidateAmount - input.transactionAmount)
+
+  let score = Math.max(0, 140 - Math.round(amountDelta * 200))
+  score += scoreTextPresence(bankText, input.candidateInvoiceNumber)
+  score += scoreTextPresence(bankText, input.candidateReference)
+  score += scoreTextPresence(bankText, input.candidateContactName)
+  score += scoreDateProximity(input.transactionDate, input.candidateDate)
+  return score
+}
+
+export { normalizeReconciliationText }

--- a/frontend/src/views/BankView.vue
+++ b/frontend/src/views/BankView.vue
@@ -3,7 +3,7 @@
     <AppPageHeader :eyebrow="t('ui.page.collection_eyebrow')" :title="t('bank.title')">
       <template #actions>
         <Button
-          :label="t('bank.import_csv')"
+          :label="t('bank.import_statement')"
           icon="pi pi-upload"
           severity="secondary"
           @click="importDialogVisible = true"
@@ -100,6 +100,7 @@
                 'reference',
                 'balance_after',
                 'reconciled_label',
+                'detected_category_label',
                 'source_label',
               ]"
               data-key="id"
@@ -207,6 +208,32 @@
                 </template>
               </Column>
               <Column
+                field="detected_category_label"
+                :header="t('bank.tx_category')"
+                sortable
+                filter-field="detected_category"
+                :show-filter-match-modes="false"
+                :show-add-button="false"
+              >
+                <template #body="{ data }">
+                  <Tag
+                    :value="t(`bank.categories.${data.detected_category}`)"
+                    severity="contrast"
+                  />
+                </template>
+                <template #filter="{ filterModel }">
+                  <AppFilterMultiSelect
+                    v-model="filterModel.value"
+                    :options="categoryOptions"
+                    option-label="label"
+                    option-value="value"
+                    :placeholder="t('common.all')"
+                    display="chip"
+                    show-clear
+                  />
+                </template>
+              </Column>
+              <Column
                 field="source_label"
                 :header="t('bank.tx_source')"
                 class="bank-table__source"
@@ -233,8 +260,44 @@
                   />
                 </template>
               </Column>
-              <Column :header="t('common.actions')" style="width: 4.5rem">
+              <Column :header="t('common.actions')" style="width: 8.5rem">
                 <template #body="{ data }">
+                  <Button
+                    v-if="canLinkExistingSupplierPayment(data)"
+                    icon="pi pi-link"
+                    size="small"
+                    severity="secondary"
+                    text
+                    :title="t('bank.link_supplier_payment')"
+                    @click="openExistingSupplierPaymentDialog(data)"
+                  />
+                  <Button
+                    v-if="canCreateSupplierPayment(data)"
+                    icon="pi pi-arrow-up-right"
+                    size="small"
+                    severity="secondary"
+                    text
+                    :title="t('bank.create_supplier_payment')"
+                    @click="openSupplierPaymentDialog(data)"
+                  />
+                  <Button
+                    v-if="canLinkExistingClientPayment(data)"
+                    icon="pi pi-link"
+                    size="small"
+                    severity="secondary"
+                    text
+                    :title="t('bank.link_client_payment')"
+                    @click="openExistingClientPaymentDialog(data)"
+                  />
+                  <Button
+                    v-if="canCreateClientPayment(data)"
+                    icon="pi pi-wallet"
+                    size="small"
+                    severity="secondary"
+                    text
+                    :title="t('bank.create_client_payment')"
+                    @click="openClientPaymentDialog(data)"
+                  />
                   <Button
                     v-if="!data.reconciled"
                     icon="pi pi-check"
@@ -427,7 +490,7 @@
       </form>
     </Dialog>
 
-    <!-- CSV import dialog -->
+    <!-- Statement import dialog -->
     <Dialog
       v-model:visible="importDialogVisible"
       :header="t('bank.import_dialog_title')"
@@ -436,13 +499,33 @@
     >
       <div class="app-dialog-form bank-form">
         <section class="app-dialog-intro">
-          <p class="app-dialog-intro__eyebrow">{{ t('bank.import_csv') }}</p>
+          <p class="app-dialog-intro__eyebrow">{{ t('bank.import_statement') }}</p>
           <p class="app-dialog-intro__text">{{ t('bank.import_intro') }}</p>
         </section>
         <section class="app-dialog-section">
-          <div class="app-field">
-            <label class="app-field__label">{{ t('bank.import_paste_label') }}</label>
-            <Textarea v-model="csvContent" rows="8" class="font-mono text-sm" />
+          <div class="app-form-grid">
+            <div class="app-field app-field--span-2">
+              <label class="app-field__label">{{ t('bank.import_file_label') }}</label>
+              <div class="bank-import-file-row">
+                <Button
+                  :label="t('bank.import_pick_file')"
+                  icon="pi pi-paperclip"
+                  severity="secondary"
+                  outlined
+                  @click="openImportFilePicker"
+                />
+                <span class="bank-import-file-name">
+                  {{ importFileName || t('bank.import_no_file') }}
+                </span>
+              </div>
+              <input
+                ref="importFileInput"
+                type="file"
+                class="bank-import-file-input"
+                accept=".csv,.ofx,.qfx,.qif,text/csv,text/plain,application/xml,text/xml"
+                @change="onImportFileSelected"
+              />
+            </div>
           </div>
         </section>
         <div class="app-form-actions">
@@ -453,10 +536,341 @@
             @click="importDialogVisible = false"
           />
           <Button
-            :label="t('bank.import_csv')"
+            :label="t('bank.import_statement')"
             icon="pi pi-upload"
             :loading="saving"
             @click="submitImport"
+          />
+        </div>
+      </div>
+    </Dialog>
+
+    <Dialog
+      v-model:visible="clientPaymentDialogVisible"
+      :header="t('bank.create_client_payment_title')"
+      modal
+      class="app-dialog app-dialog--medium"
+    >
+      <div class="app-dialog-form bank-form">
+        <section class="app-dialog-intro">
+          <p class="app-dialog-intro__eyebrow">{{ t('bank.create_client_payment') }}</p>
+          <p class="app-dialog-intro__text">{{ t('bank.create_client_payment_intro') }}</p>
+        </section>
+        <section class="app-dialog-section">
+          <p v-if="clientPaymentTransaction" class="app-dialog-note">
+            {{
+              t('bank.create_client_payment_tx_summary', {
+                date: formatDisplayDate(clientPaymentTransaction.date),
+                amount: formatAmount(clientPaymentTransaction.amount),
+                description:
+                  clientPaymentTransaction.description || clientPaymentTransaction.reference || '-',
+              })
+            }}
+          </p>
+          <div class="app-field">
+            <label class="app-field__label">{{
+              t('bank.create_client_payment_allocations')
+            }}</label>
+            <div
+              v-if="!clientPaymentLoading && clientPaymentAllocations.length > 0"
+              class="app-dialog-list bank-allocation-list"
+            >
+              <div
+                v-for="allocation in clientPaymentAllocations"
+                :key="allocation.invoice_id"
+                class="app-dialog-list__item bank-allocation-item"
+              >
+                <div class="bank-allocation-item__summary">
+                  <Checkbox
+                    v-model="allocation.selected"
+                    binary
+                    @update:model-value="syncClientAllocationAmount(allocation)"
+                  />
+                  <span class="app-dialog-list__meta">
+                    <span class="app-dialog-list__title">{{ allocation.title }}</span>
+                    <span class="app-dialog-list__caption">{{ allocation.caption }}</span>
+                  </span>
+                </div>
+                <div class="bank-allocation-item__amount">
+                  <label class="app-field__label">{{
+                    t('bank.create_client_payment_allocated_amount')
+                  }}</label>
+                  <InputNumber
+                    v-model="allocation.allocated_amount"
+                    mode="currency"
+                    currency="EUR"
+                    locale="fr-FR"
+                    :min="0"
+                    :max="clientAllocationMaxAmount(allocation)"
+                    :disabled="!allocation.selected"
+                    fluid
+                    @update:model-value="syncClientAllocationAmount(allocation)"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+          <Message
+            v-if="!clientPaymentLoading && clientPaymentAllocations.length === 0"
+            severity="warn"
+          >
+            {{ t('bank.create_client_payment_no_invoice') }}
+          </Message>
+          <Message
+            v-else-if="!clientPaymentLoading"
+            :severity="Math.abs(clientPaymentRemainingToAllocate) < 0.005 ? 'info' : 'warn'"
+          >
+            {{
+              Math.abs(clientPaymentRemainingToAllocate) < 0.005
+                ? t('bank.create_client_payment_ready_to_save')
+                : t('bank.create_client_payment_remaining_to_allocate', {
+                    amount: formatAmount(clientPaymentRemainingToAllocate),
+                  })
+            }}
+          </Message>
+        </section>
+        <div class="app-form-actions">
+          <Button
+            :label="t('common.cancel')"
+            severity="secondary"
+            text
+            @click="clientPaymentDialogVisible = false"
+          />
+          <Button
+            :label="t('common.save')"
+            :loading="clientPaymentSaving"
+            :disabled="clientPaymentLoading || !canSubmitClientPayment"
+            @click="submitClientPayment"
+          />
+        </div>
+      </div>
+    </Dialog>
+
+    <Dialog
+      v-model:visible="existingClientPaymentDialogVisible"
+      :header="t('bank.link_client_payment_title')"
+      modal
+      class="app-dialog app-dialog--medium"
+    >
+      <div class="app-dialog-form bank-form">
+        <section class="app-dialog-intro">
+          <p class="app-dialog-intro__eyebrow">{{ t('bank.link_client_payment') }}</p>
+          <p class="app-dialog-intro__text">{{ t('bank.link_client_payment_intro') }}</p>
+        </section>
+        <section class="app-dialog-section">
+          <p v-if="existingClientPaymentTransaction" class="app-dialog-note">
+            {{
+              t('bank.create_client_payment_tx_summary', {
+                date: formatDisplayDate(existingClientPaymentTransaction.date),
+                amount: formatAmount(existingClientPaymentTransaction.amount),
+                description:
+                  existingClientPaymentTransaction.description ||
+                  existingClientPaymentTransaction.reference ||
+                  '-',
+              })
+            }}
+          </p>
+          <div class="app-field">
+            <label class="app-field__label">{{ t('bank.link_client_payment_payments') }}</label>
+            <div
+              v-if="!existingClientPaymentLoading && existingClientPaymentSelections.length > 0"
+              class="app-dialog-list bank-allocation-list"
+            >
+              <div
+                v-for="selection in existingClientPaymentSelections"
+                :key="selection.payment_id"
+                class="app-dialog-list__item bank-allocation-item"
+              >
+                <div class="bank-allocation-item__summary">
+                  <Checkbox v-model="selection.selected" binary />
+                  <span class="app-dialog-list__meta">
+                    <span class="app-dialog-list__title">{{ selection.title }}</span>
+                    <span class="app-dialog-list__caption">{{ selection.caption }}</span>
+                  </span>
+                </div>
+                <strong class="bank-allocation-item__fixed-amount">{{
+                  formatAmount(selection.amount)
+                }}</strong>
+              </div>
+            </div>
+          </div>
+          <Message
+            v-if="!existingClientPaymentLoading && existingClientPaymentSelections.length === 0"
+            severity="warn"
+          >
+            {{ t('bank.link_client_payment_no_payment') }}
+          </Message>
+          <Message
+            v-else-if="!existingClientPaymentLoading"
+            :severity="Math.abs(existingClientPaymentRemainingToMatch) < 0.005 ? 'info' : 'warn'"
+          >
+            {{
+              Math.abs(existingClientPaymentRemainingToMatch) < 0.005
+                ? t('bank.link_client_payment_ready_to_confirm')
+                : t('bank.link_client_payment_remaining_to_match', {
+                    amount: formatAmount(existingClientPaymentRemainingToMatch),
+                  })
+            }}
+          </Message>
+        </section>
+        <div class="app-form-actions">
+          <Button
+            :label="t('common.cancel')"
+            severity="secondary"
+            text
+            @click="existingClientPaymentDialogVisible = false"
+          />
+          <Button
+            :label="t('common.confirm')"
+            :loading="existingClientPaymentSaving"
+            :disabled="existingClientPaymentLoading || !canSubmitExistingClientPayment"
+            @click="submitExistingClientPayment"
+          />
+        </div>
+      </div>
+    </Dialog>
+
+    <Dialog
+      v-model:visible="supplierPaymentDialogVisible"
+      :header="t('bank.create_supplier_payment_title')"
+      modal
+      class="app-dialog app-dialog--medium"
+    >
+      <div class="app-dialog-form bank-form">
+        <section class="app-dialog-intro">
+          <p class="app-dialog-intro__eyebrow">{{ t('bank.create_supplier_payment') }}</p>
+          <p class="app-dialog-intro__text">{{ t('bank.create_supplier_payment_intro') }}</p>
+        </section>
+        <section class="app-dialog-section">
+          <p v-if="supplierPaymentTransaction" class="app-dialog-note">
+            {{
+              t('bank.create_client_payment_tx_summary', {
+                date: formatDisplayDate(supplierPaymentTransaction.date),
+                amount: formatAmount(supplierPaymentTransaction.amount),
+                description:
+                  supplierPaymentTransaction.description ||
+                  supplierPaymentTransaction.reference ||
+                  '-',
+              })
+            }}
+          </p>
+          <div class="app-field">
+            <label class="app-field__label">{{ t('bank.create_supplier_payment_invoice') }}</label>
+            <Select
+              v-model="supplierPaymentForm.invoice_id"
+              :options="supplierPaymentInvoiceOptions"
+              option-label="label"
+              option-value="value"
+              :loading="supplierPaymentLoading"
+              :placeholder="
+                supplierPaymentLoading
+                  ? t('common.loading')
+                  : t('bank.create_supplier_payment_invoice')
+              "
+              filter
+              show-clear
+            />
+          </div>
+          <Message
+            v-if="!supplierPaymentLoading && supplierPaymentInvoiceOptions.length === 0"
+            severity="warn"
+          >
+            {{ t('bank.create_supplier_payment_no_invoice') }}
+          </Message>
+          <Message
+            v-else-if="!supplierPaymentLoading && supplierPaymentForm.invoice_id !== null"
+            severity="info"
+          >
+            {{ t('bank.suggested_candidate_hint') }}
+          </Message>
+        </section>
+        <div class="app-form-actions">
+          <Button
+            :label="t('common.cancel')"
+            severity="secondary"
+            text
+            @click="supplierPaymentDialogVisible = false"
+          />
+          <Button
+            :label="t('common.save')"
+            :loading="supplierPaymentSaving"
+            :disabled="supplierPaymentForm.invoice_id === null || supplierPaymentLoading"
+            @click="submitSupplierPayment"
+          />
+        </div>
+      </div>
+    </Dialog>
+
+    <Dialog
+      v-model:visible="existingSupplierPaymentDialogVisible"
+      :header="t('bank.link_supplier_payment_title')"
+      modal
+      class="app-dialog app-dialog--medium"
+    >
+      <div class="app-dialog-form bank-form">
+        <section class="app-dialog-intro">
+          <p class="app-dialog-intro__eyebrow">{{ t('bank.link_supplier_payment') }}</p>
+          <p class="app-dialog-intro__text">{{ t('bank.link_supplier_payment_intro') }}</p>
+        </section>
+        <section class="app-dialog-section">
+          <p v-if="existingSupplierPaymentTransaction" class="app-dialog-note">
+            {{
+              t('bank.create_client_payment_tx_summary', {
+                date: formatDisplayDate(existingSupplierPaymentTransaction.date),
+                amount: formatAmount(existingSupplierPaymentTransaction.amount),
+                description:
+                  existingSupplierPaymentTransaction.description ||
+                  existingSupplierPaymentTransaction.reference ||
+                  '-',
+              })
+            }}
+          </p>
+          <div class="app-field">
+            <label class="app-field__label">{{ t('bank.link_supplier_payment_payment') }}</label>
+            <Select
+              v-model="existingSupplierPaymentForm.payment_id"
+              :options="existingSupplierPaymentOptions"
+              option-label="label"
+              option-value="value"
+              :loading="existingSupplierPaymentLoading"
+              :placeholder="
+                existingSupplierPaymentLoading
+                  ? t('common.loading')
+                  : t('bank.link_supplier_payment_payment')
+              "
+              filter
+              show-clear
+            />
+          </div>
+          <Message
+            v-if="!existingSupplierPaymentLoading && existingSupplierPaymentOptions.length === 0"
+            severity="warn"
+          >
+            {{ t('bank.link_supplier_payment_no_payment') }}
+          </Message>
+          <Message
+            v-else-if="
+              !existingSupplierPaymentLoading && existingSupplierPaymentForm.payment_id !== null
+            "
+            severity="info"
+          >
+            {{ t('bank.suggested_candidate_hint') }}
+          </Message>
+        </section>
+        <div class="app-form-actions">
+          <Button
+            :label="t('common.cancel')"
+            severity="secondary"
+            text
+            @click="existingSupplierPaymentDialogVisible = false"
+          />
+          <Button
+            :label="t('common.confirm')"
+            :loading="existingSupplierPaymentSaving"
+            :disabled="
+              existingSupplierPaymentForm.payment_id === null || existingSupplierPaymentLoading
+            "
+            @click="submitExistingSupplierPayment"
           />
         </div>
       </div>
@@ -560,11 +974,11 @@ import TabPanel from 'primevue/tabpanel'
 import TabPanels from 'primevue/tabpanels'
 import Tabs from 'primevue/tabs'
 import Tag from 'primevue/tag'
-import Textarea from 'primevue/textarea'
 import ToggleButton from 'primevue/togglebutton'
 import { useToast } from 'primevue/usetoast'
 import { computed, onMounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { listContactsApi, type Contact } from '@/api/contacts'
 import AppPage from '../components/ui/AppPage.vue'
 import AppDateRangeFilter from '../components/ui/AppDateRangeFilter.vue'
 import AppFilterMultiSelect from '../components/ui/AppFilterMultiSelect.vue'
@@ -574,17 +988,27 @@ import AppPanel from '../components/ui/AppPanel.vue'
 import AppStatCard from '../components/ui/AppStatCard.vue'
 import {
   addTransaction,
+  createClientPaymentsFromTransaction,
   createDeposit,
+  createSupplierPaymentFromTransaction,
   getBankBalance,
-  importCsv,
+  importBankStatement,
+  linkClientPaymentToTransaction,
+  linkClientPaymentsToTransaction,
+  linkSupplierPaymentToTransaction,
   listDeposits,
   listTransactions,
   updateTransaction,
+  type BankImportFormat,
+  type BankTransactionClientPaymentAllocation,
   type BankTransaction,
   type Deposit,
 } from '@/api/bank'
+import { listInvoicesApi, type Invoice } from '@/api/invoices'
 import { listPayments, type Payment } from '@/api/payments'
 import { useFiscalYearStore } from '@/stores/fiscalYear'
+import { scoreInvoiceSuggestion, scorePaymentSuggestion } from '@/utils/bankReconciliation'
+import { formatContactDisplayName } from '@/utils/contact'
 import { formatDisplayDate } from '@/utils/format'
 import {
   dateRangeFilter,
@@ -610,7 +1034,47 @@ const txDialogVisible = ref(false)
 const importDialogVisible = ref(false)
 const depositDialogVisible = ref(false)
 const saving = ref(false)
-const csvContent = ref('')
+const clientPaymentDialogVisible = ref(false)
+const clientPaymentSaving = ref(false)
+const clientPaymentLoading = ref(false)
+const existingClientPaymentDialogVisible = ref(false)
+const existingClientPaymentSaving = ref(false)
+const existingClientPaymentLoading = ref(false)
+const supplierPaymentDialogVisible = ref(false)
+const supplierPaymentSaving = ref(false)
+const supplierPaymentLoading = ref(false)
+const existingSupplierPaymentDialogVisible = ref(false)
+const existingSupplierPaymentSaving = ref(false)
+const existingSupplierPaymentLoading = ref(false)
+const importContent = ref('')
+const importFileName = ref('')
+const importFileInput = ref<HTMLInputElement | null>(null)
+const clientPaymentTransaction = ref<BankTransaction | null>(null)
+const existingClientPaymentTransaction = ref<BankTransaction | null>(null)
+const supplierPaymentTransaction = ref<BankTransaction | null>(null)
+const existingSupplierPaymentTransaction = ref<BankTransaction | null>(null)
+const clientInvoices = ref<Invoice[]>([])
+const supplierInvoices = ref<Invoice[]>([])
+const clientContacts = ref<Contact[]>([])
+const existingClientPayments = ref<Payment[]>([])
+const existingSupplierPayments = ref<Payment[]>([])
+
+interface ClientPaymentAllocationDraft {
+  invoice_id: number
+  title: string
+  caption: string
+  remaining_amount: number
+  allocated_amount: number
+  selected: boolean
+}
+
+interface ExistingClientPaymentSelectionDraft {
+  payment_id: number
+  title: string
+  caption: string
+  amount: number
+  selected: boolean
+}
 
 const depositTypeOptions = [
   { label: t('bank.deposit_types.cheques'), value: 'cheques' },
@@ -621,6 +1085,22 @@ const sourceOptions = [
   { label: t('bank.sources.manual'), value: 'manual' },
   { label: t('bank.sources.import'), value: 'import' },
   { label: t('bank.sources.system_opening'), value: 'system_opening' },
+]
+
+const categoryOptions = [
+  { label: t('bank.categories.customer_payment'), value: 'customer_payment' },
+  { label: t('bank.categories.cheque_deposit'), value: 'cheque_deposit' },
+  { label: t('bank.categories.cash_deposit'), value: 'cash_deposit' },
+  { label: t('bank.categories.supplier_payment'), value: 'supplier_payment' },
+  { label: t('bank.categories.salary'), value: 'salary' },
+  { label: t('bank.categories.social_charge'), value: 'social_charge' },
+  { label: t('bank.categories.bank_fee'), value: 'bank_fee' },
+  { label: t('bank.categories.internal_transfer'), value: 'internal_transfer' },
+  { label: t('bank.categories.grant'), value: 'grant' },
+  { label: t('bank.categories.sepa_debit'), value: 'sepa_debit' },
+  { label: t('bank.categories.other_credit'), value: 'other_credit' },
+  { label: t('bank.categories.other_debit'), value: 'other_debit' },
+  { label: t('bank.categories.uncategorized'), value: 'uncategorized' },
 ]
 
 const yesNoOptions = [
@@ -634,6 +1114,7 @@ const transactionRows = computed(() =>
     amount_value: parseFloat(transaction.amount),
     balance_after_value: parseFloat(transaction.balance_after),
     reconciled_label: transaction.reconciled ? t('common.yes') : t('common.no'),
+    detected_category_label: t(`bank.categories.${transaction.detected_category}`),
     source_label: t(`bank.sources.${transaction.source}`),
   })),
 )
@@ -685,6 +1166,7 @@ const {
   reference: textFilter(),
   balance_after_value: numericRangeFilter(),
   reconciled: inFilter(),
+  detected_category: inFilter(),
   source: inFilter(),
 })
 
@@ -780,6 +1262,18 @@ const depositForm = ref({
   bank_reference: '',
   payment_ids: [] as number[],
 })
+const clientPaymentForm = ref({
+  allocations: [] as ClientPaymentAllocationDraft[],
+})
+const existingClientPaymentForm = ref({
+  selections: [] as ExistingClientPaymentSelectionDraft[],
+})
+const supplierPaymentForm = ref({
+  invoice_id: null as number | null,
+})
+const existingSupplierPaymentForm = ref({
+  payment_id: null as number | null,
+})
 
 function formatAmount(value: string | number): string {
   return `${parseFloat(String(value)).toFixed(2)} €`
@@ -792,9 +1286,370 @@ function formatSignedAmount(value: number): string {
   return formatAmount(value)
 }
 
+function contactName(contactId: number): string {
+  const contact = clientContacts.value.find((candidate) => candidate.id === contactId)
+  if (!contact) {
+    return `#${contactId}`
+  }
+  return formatContactDisplayName(contact)
+}
+
+function invoiceRemainingAmount(invoice: Invoice): number {
+  return Math.max(0, parseFloat(invoice.total_amount) - parseFloat(invoice.paid_amount))
+}
+
+function resolveApiErrorMessage(error: unknown): string {
+  const detail = (
+    error as {
+      response?: {
+        data?: {
+          detail?: unknown
+        }
+      }
+    }
+  )?.response?.data?.detail
+  if (typeof detail === 'string' && detail.trim().length > 0) {
+    return detail
+  }
+  return t('common.error.unknown')
+}
+
+const sortedClientPaymentInvoices = computed(() => {
+  const transactionAmount = clientPaymentTransaction.value
+    ? parseFloat(clientPaymentTransaction.value.amount)
+    : 0
+
+  return clientInvoices.value
+    .filter(
+      (invoice) =>
+        ['sent', 'partial', 'overdue'].includes(invoice.status) &&
+        invoiceRemainingAmount(invoice) > 0,
+    )
+    .sort((left, right) => {
+      const leftScore = scoreInvoiceSuggestion({
+        transactionAmount,
+        transactionDate: clientPaymentTransaction.value?.date ?? '',
+        transactionDescription: clientPaymentTransaction.value?.description ?? '',
+        transactionReference: clientPaymentTransaction.value?.reference,
+        candidateNumber: left.number,
+        candidateReference: left.reference,
+        candidateContactName: contactName(left.contact_id),
+        candidateDate: left.date,
+        candidateRemainingAmount: invoiceRemainingAmount(left),
+      })
+      const rightScore = scoreInvoiceSuggestion({
+        transactionAmount,
+        transactionDate: clientPaymentTransaction.value?.date ?? '',
+        transactionDescription: clientPaymentTransaction.value?.description ?? '',
+        transactionReference: clientPaymentTransaction.value?.reference,
+        candidateNumber: right.number,
+        candidateReference: right.reference,
+        candidateContactName: contactName(right.contact_id),
+        candidateDate: right.date,
+        candidateRemainingAmount: invoiceRemainingAmount(right),
+      })
+      if (leftScore !== rightScore) {
+        return rightScore - leftScore
+      }
+      return right.date.localeCompare(left.date)
+    })
+})
+
+const clientPaymentAllocations = computed(() => clientPaymentForm.value.allocations)
+
+const clientPaymentTransactionAmount = computed(() =>
+  clientPaymentTransaction.value ? parseFloat(clientPaymentTransaction.value.amount) : 0,
+)
+
+const clientPaymentSelectedTotal = computed(() =>
+  clientPaymentForm.value.allocations.reduce(
+    (sum, allocation) => sum + (allocation.selected ? Number(allocation.allocated_amount || 0) : 0),
+    0,
+  ),
+)
+
+const clientPaymentRemainingToAllocate = computed(() =>
+  Number((clientPaymentTransactionAmount.value - clientPaymentSelectedTotal.value).toFixed(2)),
+)
+
+const canSubmitClientPayment = computed(
+  () =>
+    clientPaymentAllocations.value.some(
+      (allocation) => allocation.selected && allocation.allocated_amount > 0,
+    ) && Math.abs(clientPaymentRemainingToAllocate.value) < 0.005,
+)
+
+const supplierPaymentInvoiceOptions = computed(() => {
+  const transactionAmount = supplierPaymentTransaction.value
+    ? Math.abs(parseFloat(supplierPaymentTransaction.value.amount))
+    : 0
+
+  return supplierInvoices.value
+    .filter(
+      (invoice) =>
+        ['sent', 'partial', 'overdue'].includes(invoice.status) &&
+        invoiceRemainingAmount(invoice) > 0,
+    )
+    .sort((left, right) => {
+      const leftScore = scoreInvoiceSuggestion({
+        transactionAmount,
+        transactionDate: supplierPaymentTransaction.value?.date ?? '',
+        transactionDescription: supplierPaymentTransaction.value?.description ?? '',
+        transactionReference: supplierPaymentTransaction.value?.reference,
+        candidateNumber: left.number,
+        candidateReference: left.reference,
+        candidateContactName: contactName(left.contact_id),
+        candidateDate: left.date,
+        candidateRemainingAmount: invoiceRemainingAmount(left),
+      })
+      const rightScore = scoreInvoiceSuggestion({
+        transactionAmount,
+        transactionDate: supplierPaymentTransaction.value?.date ?? '',
+        transactionDescription: supplierPaymentTransaction.value?.description ?? '',
+        transactionReference: supplierPaymentTransaction.value?.reference,
+        candidateNumber: right.number,
+        candidateReference: right.reference,
+        candidateContactName: contactName(right.contact_id),
+        candidateDate: right.date,
+        candidateRemainingAmount: invoiceRemainingAmount(right),
+      })
+      if (leftScore !== rightScore) {
+        return rightScore - leftScore
+      }
+      return right.date.localeCompare(left.date)
+    })
+    .map((invoice) => ({
+      label: `${invoice.number} · ${contactName(invoice.contact_id)} · reste ${formatAmount(
+        invoiceRemainingAmount(invoice),
+      )}`,
+      value: invoice.id,
+    }))
+})
+
+const sortedExistingClientPayments = computed(() => {
+  const transactionAmount = existingClientPaymentTransaction.value
+    ? parseFloat(existingClientPaymentTransaction.value.amount)
+    : 0
+
+  return existingClientPayments.value
+    .filter(
+      (payment) =>
+        payment.method === 'virement' && parseFloat(payment.amount) <= transactionAmount + 0.0001,
+    )
+    .sort((left, right) => {
+      const leftScore = scorePaymentSuggestion({
+        transactionAmount,
+        transactionDate: existingClientPaymentTransaction.value?.date ?? '',
+        transactionDescription: existingClientPaymentTransaction.value?.description ?? '',
+        transactionReference: existingClientPaymentTransaction.value?.reference,
+        candidateInvoiceNumber: left.invoice_number,
+        candidateReference: left.reference,
+        candidateContactName: contactName(left.contact_id),
+        candidateDate: left.date,
+        candidateAmount: parseFloat(left.amount),
+      })
+      const rightScore = scorePaymentSuggestion({
+        transactionAmount,
+        transactionDate: existingClientPaymentTransaction.value?.date ?? '',
+        transactionDescription: existingClientPaymentTransaction.value?.description ?? '',
+        transactionReference: existingClientPaymentTransaction.value?.reference,
+        candidateInvoiceNumber: right.invoice_number,
+        candidateReference: right.reference,
+        candidateContactName: contactName(right.contact_id),
+        candidateDate: right.date,
+        candidateAmount: parseFloat(right.amount),
+      })
+      if (leftScore !== rightScore) {
+        return rightScore - leftScore
+      }
+      return right.date.localeCompare(left.date)
+    })
+})
+
+const existingClientPaymentSelections = computed(() => existingClientPaymentForm.value.selections)
+
+const existingClientPaymentTransactionAmount = computed(() =>
+  existingClientPaymentTransaction.value
+    ? parseFloat(existingClientPaymentTransaction.value.amount)
+    : 0,
+)
+
+const existingClientPaymentSelectedTotal = computed(() =>
+  existingClientPaymentForm.value.selections.reduce(
+    (sum, selection) => sum + (selection.selected ? selection.amount : 0),
+    0,
+  ),
+)
+
+const existingClientPaymentRemainingToMatch = computed(() =>
+  Number(
+    (
+      existingClientPaymentTransactionAmount.value - existingClientPaymentSelectedTotal.value
+    ).toFixed(2),
+  ),
+)
+
+const canSubmitExistingClientPayment = computed(
+  () =>
+    existingClientPaymentSelections.value.some((selection) => selection.selected) &&
+    Math.abs(existingClientPaymentRemainingToMatch.value) < 0.005,
+)
+
+const existingSupplierPaymentOptions = computed(() => {
+  const transactionAmount = existingSupplierPaymentTransaction.value
+    ? Math.abs(parseFloat(existingSupplierPaymentTransaction.value.amount))
+    : 0
+
+  return existingSupplierPayments.value
+    .filter(
+      (payment) =>
+        payment.method === 'virement' &&
+        Math.abs(parseFloat(payment.amount) - transactionAmount) < 0.0001,
+    )
+    .sort((left, right) => {
+      const leftScore = scorePaymentSuggestion({
+        transactionAmount,
+        transactionDate: existingSupplierPaymentTransaction.value?.date ?? '',
+        transactionDescription: existingSupplierPaymentTransaction.value?.description ?? '',
+        transactionReference: existingSupplierPaymentTransaction.value?.reference,
+        candidateInvoiceNumber: left.invoice_number,
+        candidateReference: left.reference,
+        candidateContactName: contactName(left.contact_id),
+        candidateDate: left.date,
+        candidateAmount: parseFloat(left.amount),
+      })
+      const rightScore = scorePaymentSuggestion({
+        transactionAmount,
+        transactionDate: existingSupplierPaymentTransaction.value?.date ?? '',
+        transactionDescription: existingSupplierPaymentTransaction.value?.description ?? '',
+        transactionReference: existingSupplierPaymentTransaction.value?.reference,
+        candidateInvoiceNumber: right.invoice_number,
+        candidateReference: right.reference,
+        candidateContactName: contactName(right.contact_id),
+        candidateDate: right.date,
+        candidateAmount: parseFloat(right.amount),
+      })
+      if (leftScore !== rightScore) {
+        return rightScore - leftScore
+      }
+      return right.date.localeCompare(left.date)
+    })
+    .map((payment) => {
+      const reference = payment.reference ? ` · ${payment.reference}` : ''
+      return {
+        label: `${payment.invoice_number || `#${payment.invoice_id}`} · ${contactName(
+          payment.contact_id,
+        )} · ${formatAmount(payment.amount)} · ${formatDisplayDate(payment.date)}${reference}`,
+        value: payment.id,
+      }
+    })
+})
+
 function toIsoDate(d: Date | string): string {
   if (typeof d === 'string') return d
   return d.toISOString().slice(0, 10)
+}
+
+function detectImportFormatFromFileName(fileName: string): BankImportFormat {
+  const lowerName = fileName.toLowerCase()
+  if (lowerName.endsWith('.ofx') || lowerName.endsWith('.qfx')) {
+    return 'ofx'
+  }
+  if (lowerName.endsWith('.qif')) {
+    return 'qif'
+  }
+  return 'csv'
+}
+
+function buildClientPaymentAllocationDrafts(): ClientPaymentAllocationDraft[] {
+  let remainingToAllocate = clientPaymentTransactionAmount.value
+
+  return sortedClientPaymentInvoices.value.map((invoice) => {
+    const remainingAmount = invoiceRemainingAmount(invoice)
+    const suggestedAmount = Math.min(remainingAmount, Math.max(remainingToAllocate, 0))
+    remainingToAllocate = Number((remainingToAllocate - suggestedAmount).toFixed(2))
+
+    return {
+      invoice_id: invoice.id,
+      title: `${invoice.number} · ${contactName(invoice.contact_id)}`,
+      caption: `${formatDisplayDate(invoice.date)} · reste ${formatAmount(remainingAmount)}`,
+      remaining_amount: remainingAmount,
+      allocated_amount: suggestedAmount,
+      selected: suggestedAmount > 0,
+    }
+  })
+}
+
+function buildExistingClientPaymentSelectionDrafts(): ExistingClientPaymentSelectionDraft[] {
+  let remainingToMatch = existingClientPaymentTransactionAmount.value
+
+  return sortedExistingClientPayments.value.map((payment) => {
+    const amount = parseFloat(payment.amount)
+    const reference = payment.reference ? ` · ${payment.reference}` : ''
+    const selected = amount <= remainingToMatch + 0.0001
+    if (selected) {
+      remainingToMatch = Number((remainingToMatch - amount).toFixed(2))
+    }
+
+    return {
+      payment_id: payment.id,
+      title: `${payment.invoice_number || `#${payment.invoice_id}`} · ${contactName(
+        payment.contact_id,
+      )}`,
+      caption: `${formatDisplayDate(payment.date)}${reference}`,
+      amount,
+      selected,
+    }
+  })
+}
+
+function clientAllocationSelectedSumExcluding(invoiceId: number): number {
+  return clientPaymentForm.value.allocations.reduce((sum, allocation) => {
+    if (!allocation.selected || allocation.invoice_id === invoiceId) {
+      return sum
+    }
+    return sum + Number(allocation.allocated_amount || 0)
+  }, 0)
+}
+
+function clientAllocationMaxAmount(allocation: ClientPaymentAllocationDraft): number {
+  const remainingTxAmount =
+    clientPaymentTransactionAmount.value -
+    clientAllocationSelectedSumExcluding(allocation.invoice_id)
+  return Math.max(0, Math.min(allocation.remaining_amount, remainingTxAmount))
+}
+
+function syncClientAllocationAmount(allocation: ClientPaymentAllocationDraft): void {
+  if (!allocation.selected) {
+    allocation.allocated_amount = 0
+    return
+  }
+
+  const maxAmount = clientAllocationMaxAmount(allocation)
+  const currentAmount = Number(allocation.allocated_amount || 0)
+
+  if (currentAmount <= 0) {
+    allocation.allocated_amount = maxAmount
+    return
+  }
+
+  allocation.allocated_amount = Math.min(currentAmount, maxAmount)
+}
+
+function openImportFilePicker() {
+  importFileInput.value?.click()
+}
+
+async function onImportFileSelected(event: Event) {
+  const input = event.target as HTMLInputElement
+  const file = input.files?.[0]
+  if (!file) {
+    return
+  }
+
+  importFileName.value = file.name
+  importContent.value = await file.text()
+  input.value = ''
 }
 
 async function loadTransactions() {
@@ -836,6 +1691,238 @@ async function reconcile(tx: BankTransaction) {
   await loadTransactions()
 }
 
+function canCreateClientPayment(tx: BankTransaction): boolean {
+  return (
+    !tx.reconciled &&
+    parseFloat(tx.amount) > 0 &&
+    ['customer_payment', 'other_credit'].includes(tx.detected_category)
+  )
+}
+
+function canLinkExistingClientPayment(tx: BankTransaction): boolean {
+  return canCreateClientPayment(tx)
+}
+
+function canCreateSupplierPayment(tx: BankTransaction): boolean {
+  return (
+    !tx.reconciled &&
+    parseFloat(tx.amount) < 0 &&
+    ['supplier_payment', 'other_debit'].includes(tx.detected_category)
+  )
+}
+
+function canLinkExistingSupplierPayment(tx: BankTransaction): boolean {
+  return canCreateSupplierPayment(tx)
+}
+
+async function openClientPaymentDialog(tx: BankTransaction) {
+  clientPaymentTransaction.value = tx
+  clientPaymentForm.value.allocations = []
+  clientPaymentDialogVisible.value = true
+  clientPaymentLoading.value = true
+  try {
+    const [invoices, contacts] = await Promise.all([
+      listInvoicesApi({ invoice_type: 'client' }),
+      listContactsApi({ active_only: true }),
+    ])
+    clientInvoices.value = invoices
+    clientContacts.value = contacts
+    clientPaymentForm.value.allocations = buildClientPaymentAllocationDrafts()
+  } catch {
+    toast.add({ severity: 'error', summary: t('common.error.unknown'), life: 3000 })
+  } finally {
+    clientPaymentLoading.value = false
+  }
+}
+
+async function openExistingClientPaymentDialog(tx: BankTransaction) {
+  existingClientPaymentTransaction.value = tx
+  existingClientPaymentForm.value.selections = []
+  existingClientPaymentDialogVisible.value = true
+  existingClientPaymentLoading.value = true
+  try {
+    const [payments, contacts] = await Promise.all([
+      listPayments({ invoice_type: 'client' }),
+      listContactsApi({ active_only: true }),
+    ])
+    existingClientPayments.value = payments
+    clientContacts.value = contacts
+    existingClientPaymentForm.value.selections = buildExistingClientPaymentSelectionDrafts()
+  } catch (error) {
+    toast.add({ severity: 'error', summary: resolveApiErrorMessage(error), life: 3000 })
+  } finally {
+    existingClientPaymentLoading.value = false
+  }
+}
+
+async function openSupplierPaymentDialog(tx: BankTransaction) {
+  supplierPaymentTransaction.value = tx
+  supplierPaymentForm.value.invoice_id = null
+  supplierPaymentDialogVisible.value = true
+  supplierPaymentLoading.value = true
+  try {
+    const [invoices, contacts] = await Promise.all([
+      listInvoicesApi({ invoice_type: 'fournisseur' }),
+      listContactsApi({ active_only: true }),
+    ])
+    supplierInvoices.value = invoices
+    clientContacts.value = contacts
+    supplierPaymentForm.value.invoice_id = supplierPaymentInvoiceOptions.value[0]?.value ?? null
+  } catch (error) {
+    toast.add({ severity: 'error', summary: resolveApiErrorMessage(error), life: 3000 })
+  } finally {
+    supplierPaymentLoading.value = false
+  }
+}
+
+async function openExistingSupplierPaymentDialog(tx: BankTransaction) {
+  existingSupplierPaymentTransaction.value = tx
+  existingSupplierPaymentForm.value.payment_id = null
+  existingSupplierPaymentDialogVisible.value = true
+  existingSupplierPaymentLoading.value = true
+  try {
+    const [payments, contacts] = await Promise.all([
+      listPayments({ invoice_type: 'fournisseur' }),
+      listContactsApi({ active_only: true }),
+    ])
+    existingSupplierPayments.value = payments
+    clientContacts.value = contacts
+    existingSupplierPaymentForm.value.payment_id =
+      existingSupplierPaymentOptions.value[0]?.value ?? null
+  } catch (error) {
+    toast.add({ severity: 'error', summary: resolveApiErrorMessage(error), life: 3000 })
+  } finally {
+    existingSupplierPaymentLoading.value = false
+  }
+}
+
+async function submitClientPayment() {
+  if (!clientPaymentTransaction.value || !canSubmitClientPayment.value) {
+    return
+  }
+
+  clientPaymentSaving.value = true
+  try {
+    const allocations: BankTransactionClientPaymentAllocation[] =
+      clientPaymentForm.value.allocations
+        .filter((allocation) => allocation.selected && allocation.allocated_amount > 0)
+        .map((allocation) => ({
+          invoice_id: allocation.invoice_id,
+          amount: allocation.allocated_amount.toFixed(2),
+        }))
+
+    await createClientPaymentsFromTransaction(clientPaymentTransaction.value.id, allocations)
+    clientPaymentDialogVisible.value = false
+    clientPaymentTransaction.value = null
+    const allocationCount = allocations.length
+    clientPaymentForm.value.allocations = []
+    toast.add({
+      severity: 'success',
+      summary: t('bank.create_client_payment_success', { count: allocationCount }),
+      life: 3000,
+    })
+    await loadTransactions()
+  } catch (error) {
+    toast.add({ severity: 'error', summary: resolveApiErrorMessage(error), life: 3000 })
+  } finally {
+    clientPaymentSaving.value = false
+  }
+}
+
+async function submitExistingClientPayment() {
+  if (!existingClientPaymentTransaction.value || !canSubmitExistingClientPayment.value) {
+    return
+  }
+
+  existingClientPaymentSaving.value = true
+  try {
+    const paymentIds = existingClientPaymentForm.value.selections
+      .filter((selection) => selection.selected)
+      .map((selection) => selection.payment_id)
+
+    const [singlePaymentId] = paymentIds
+    if (paymentIds.length === 1 && singlePaymentId !== undefined) {
+      await linkClientPaymentToTransaction(
+        existingClientPaymentTransaction.value.id,
+        singlePaymentId,
+      )
+    } else {
+      await linkClientPaymentsToTransaction(existingClientPaymentTransaction.value.id, paymentIds)
+    }
+
+    existingClientPaymentDialogVisible.value = false
+    existingClientPaymentTransaction.value = null
+    existingClientPaymentForm.value.selections = []
+    toast.add({
+      severity: 'success',
+      summary: t('bank.link_client_payment_success', { count: paymentIds.length }),
+      life: 3000,
+    })
+    await loadTransactions()
+  } catch (error) {
+    toast.add({ severity: 'error', summary: resolveApiErrorMessage(error), life: 3000 })
+  } finally {
+    existingClientPaymentSaving.value = false
+  }
+}
+
+async function submitSupplierPayment() {
+  if (!supplierPaymentTransaction.value || supplierPaymentForm.value.invoice_id === null) {
+    return
+  }
+
+  supplierPaymentSaving.value = true
+  try {
+    await createSupplierPaymentFromTransaction(
+      supplierPaymentTransaction.value.id,
+      supplierPaymentForm.value.invoice_id,
+    )
+    supplierPaymentDialogVisible.value = false
+    supplierPaymentTransaction.value = null
+    supplierPaymentForm.value.invoice_id = null
+    toast.add({
+      severity: 'success',
+      summary: t('bank.create_supplier_payment_success'),
+      life: 3000,
+    })
+    await loadTransactions()
+  } catch (error) {
+    toast.add({ severity: 'error', summary: resolveApiErrorMessage(error), life: 3000 })
+  } finally {
+    supplierPaymentSaving.value = false
+  }
+}
+
+async function submitExistingSupplierPayment() {
+  if (
+    !existingSupplierPaymentTransaction.value ||
+    existingSupplierPaymentForm.value.payment_id === null
+  ) {
+    return
+  }
+
+  existingSupplierPaymentSaving.value = true
+  try {
+    await linkSupplierPaymentToTransaction(
+      existingSupplierPaymentTransaction.value.id,
+      existingSupplierPaymentForm.value.payment_id,
+    )
+    existingSupplierPaymentDialogVisible.value = false
+    existingSupplierPaymentTransaction.value = null
+    existingSupplierPaymentForm.value.payment_id = null
+    toast.add({
+      severity: 'success',
+      summary: t('bank.link_supplier_payment_success'),
+      life: 3000,
+    })
+    await loadTransactions()
+  } catch (error) {
+    toast.add({ severity: 'error', summary: resolveApiErrorMessage(error), life: 3000 })
+  } finally {
+    existingSupplierPaymentSaving.value = false
+  }
+}
+
 async function submitTransaction() {
   saving.value = true
   try {
@@ -859,11 +1946,20 @@ async function submitTransaction() {
 }
 
 async function submitImport() {
+  if (!importFileName.value || !importContent.value.trim()) {
+    toast.add({ severity: 'warn', summary: t('bank.import_file_required'), life: 3000 })
+    return
+  }
+
   saving.value = true
   try {
-    const imported = await importCsv(csvContent.value)
+    const imported = await importBankStatement(
+      detectImportFormatFromFileName(importFileName.value),
+      importContent.value,
+    )
     importDialogVisible.value = false
-    csvContent.value = ''
+    importContent.value = ''
+    importFileName.value = ''
     toast.add({
       severity: 'success',
       summary: t('bank.import_success', { n: imported.length }),
@@ -948,6 +2044,21 @@ onMounted(async () => {
   width: 6.5rem;
 }
 
+.bank-import-file-row {
+  display: flex;
+  align-items: center;
+  gap: var(--app-space-3);
+}
+
+.bank-import-file-name {
+  color: var(--app-text-muted);
+  font-size: 0.95rem;
+}
+
+.bank-import-file-input {
+  display: none;
+}
+
 .bank-form {
   display: flex;
   flex-direction: column;
@@ -964,6 +2075,43 @@ onMounted(async () => {
 
 .bank-payment-option {
   cursor: pointer;
+}
+
+.bank-allocation-list {
+  gap: var(--app-space-3);
+}
+
+.bank-allocation-item {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--app-space-4);
+}
+
+.bank-allocation-item__summary {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--app-space-3);
+  min-width: 0;
+}
+
+.bank-allocation-item__amount {
+  min-width: 12rem;
+}
+
+.bank-allocation-item__fixed-amount {
+  white-space: nowrap;
+}
+
+@media (max-width: 768px) {
+  .bank-allocation-item {
+    flex-direction: column;
+  }
+
+  .bank-allocation-item__amount {
+    width: 100%;
+    min-width: 0;
+  }
 }
 
 .bank-payment-option :deep(.p-checkbox) {

--- a/frontend/src/views/BankView.vue
+++ b/frontend/src/views/BankView.vue
@@ -1419,9 +1419,9 @@ const supplierPaymentInvoiceOptions = computed(() => {
       return right.date.localeCompare(left.date)
     })
     .map((invoice) => ({
-      label: `${invoice.number} · ${contactName(invoice.contact_id)} · reste ${formatAmount(
-        invoiceRemainingAmount(invoice),
-      )}`,
+      label: `${invoice.number} · ${contactName(invoice.contact_id)} · ${t('bank.remaining_amount', {
+        amount: formatAmount(invoiceRemainingAmount(invoice)),
+      })}`,
       value: invoice.id,
     }))
 })
@@ -1572,7 +1572,9 @@ function buildClientPaymentAllocationDrafts(): ClientPaymentAllocationDraft[] {
     return {
       invoice_id: invoice.id,
       title: `${invoice.number} · ${contactName(invoice.contact_id)}`,
-      caption: `${formatDisplayDate(invoice.date)} · reste ${formatAmount(remainingAmount)}`,
+      caption: `${formatDisplayDate(invoice.date)} · ${t('bank.remaining_amount', {
+        amount: formatAmount(remainingAmount),
+      })}`,
       remaining_amount: remainingAmount,
       allocated_amount: suggestedAmount,
       selected: suggestedAmount > 0,

--- a/tests/integration/test_bank_api.py
+++ b/tests/integration/test_bank_api.py
@@ -45,6 +45,104 @@ async def _make_payment(db_session: AsyncSession) -> int:
     return p.id
 
 
+async def _make_client_invoice(
+    db_session: AsyncSession,
+    *,
+    number: str = "F-2024-101",
+    total_amount: Decimal = Decimal("150.00"),
+) -> Invoice:
+    contact = Contact(type=ContactType.CLIENT, nom="Virement Client")
+    db_session.add(contact)
+    await db_session.flush()
+
+    invoice = Invoice(
+        number=number,
+        type=InvoiceType.CLIENT,
+        contact_id=contact.id,
+        date=date(2024, 3, 1),
+        total_amount=total_amount,
+        paid_amount=Decimal("0"),
+        status=InvoiceStatus.SENT,
+    )
+    db_session.add(invoice)
+    await db_session.commit()
+    await db_session.refresh(invoice)
+    return invoice
+
+
+async def _make_client_virement_payment(
+    db_session: AsyncSession,
+    *,
+    number: str = "F-2024-103",
+    amount: Decimal = Decimal("150.00"),
+) -> Payment:
+    invoice = await _make_client_invoice(
+        db_session,
+        number=number,
+        total_amount=amount,
+    )
+    payment = Payment(
+        invoice_id=invoice.id,
+        contact_id=invoice.contact_id,
+        amount=amount,
+        date=date(2024, 3, 14),
+        method=PaymentMethod.VIREMENT,
+        reference="LEGACY-VIR-001",
+        deposited=False,
+    )
+    db_session.add(payment)
+    await db_session.commit()
+    await db_session.refresh(payment)
+    return payment
+
+
+async def _make_supplier_invoice(
+    db_session: AsyncSession,
+    *,
+    number: str = "A-2024-001",
+    total_amount: Decimal = Decimal("200.00"),
+) -> Invoice:
+    contact = Contact(type=ContactType.FOURNISSEUR, nom="Fournisseur Test")
+    db_session.add(contact)
+    await db_session.flush()
+
+    invoice = Invoice(
+        number=number,
+        type=InvoiceType.FOURNISSEUR,
+        contact_id=contact.id,
+        date=date(2024, 3, 1),
+        total_amount=total_amount,
+        paid_amount=Decimal("0"),
+        status=InvoiceStatus.SENT,
+        reference="FAC-FOURN-001",
+    )
+    db_session.add(invoice)
+    await db_session.commit()
+    await db_session.refresh(invoice)
+    return invoice
+
+
+async def _make_supplier_virement_payment(
+    db_session: AsyncSession,
+    *,
+    amount: Decimal = Decimal("200.00"),
+) -> Payment:
+    invoice = await _make_supplier_invoice(db_session, total_amount=amount)
+    payment = Payment(
+        invoice_id=invoice.id,
+        contact_id=invoice.contact_id,
+        amount=amount,
+        date=date(2024, 3, 14),
+        method=PaymentMethod.VIREMENT,
+        reference="FOURN-VIR-001",
+        deposited=False,
+    )
+    db_session.add(payment)
+    await db_session.commit()
+    await db_session.refresh(payment)
+    return payment
+
+
 @pytest.mark.asyncio
 async def test_get_balance_empty(client: AsyncClient, admin_user: User, auth_headers: dict) -> None:
     response = await client.get("/api/bank/balance", headers=auth_headers)
@@ -272,4 +370,418 @@ async def test_import_csv(client: AsyncClient, admin_user: User, auth_headers: d
     data = response.json()
     assert len(data) == 2
     assert data[0]["amount"] == "150.00"
+    assert data[0]["detected_category"] == "customer_payment"
     assert data[1]["amount"] == "-45.50"
+    assert data[1]["detected_category"] == "sepa_debit"
+
+
+@pytest.mark.asyncio
+async def test_create_client_payment_from_bank_transaction(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    admin_user: User,
+    auth_headers: dict,
+) -> None:
+    invoice = await _make_client_invoice(db_session)
+
+    create_tx_response = await client.post(
+        "/api/bank/transactions",
+        json={
+            "date": "2024-03-15",
+            "amount": "150.00",
+            "description": "VIR DUPONT",
+            "reference": "VIR-2024-001",
+            "source": "import",
+        },
+        headers=auth_headers,
+    )
+    assert create_tx_response.status_code == 201
+    tx_id = create_tx_response.json()["id"]
+
+    reconcile_response = await client.post(
+        f"/api/bank/transactions/{tx_id}/create-client-payment",
+        json={"invoice_id": invoice.id},
+        headers=auth_headers,
+    )
+
+    assert reconcile_response.status_code == 201
+    data = reconcile_response.json()
+    assert data["reconciled"] is True
+    assert data["reconciled_with"] == invoice.number
+    assert data["payment_id"] is not None
+
+    payment = await db_session.get(Payment, data["payment_id"])
+    assert payment is not None
+    assert payment.invoice_id == invoice.id
+    assert payment.contact_id == invoice.contact_id
+    assert payment.amount == Decimal("150.00")
+    assert payment.date == date(2024, 3, 15)
+    assert payment.method == PaymentMethod.VIREMENT
+    assert payment.reference == "VIR-2024-001"
+
+
+@pytest.mark.asyncio
+async def test_create_client_payments_from_bank_transaction(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    admin_user: User,
+    auth_headers: dict,
+) -> None:
+    contact = Contact(type=ContactType.CLIENT, nom="Virement Groupe")
+    db_session.add(contact)
+    await db_session.flush()
+
+    invoice_one = Invoice(
+        number="F-2024-301",
+        type=InvoiceType.CLIENT,
+        contact_id=contact.id,
+        date=date(2024, 3, 1),
+        total_amount=Decimal("70.00"),
+        paid_amount=Decimal("0"),
+        status=InvoiceStatus.SENT,
+    )
+    invoice_two = Invoice(
+        number="F-2024-302",
+        type=InvoiceType.CLIENT,
+        contact_id=contact.id,
+        date=date(2024, 3, 2),
+        total_amount=Decimal("50.00"),
+        paid_amount=Decimal("0"),
+        status=InvoiceStatus.SENT,
+    )
+    db_session.add_all([invoice_one, invoice_two])
+    await db_session.commit()
+    await db_session.refresh(invoice_one)
+    await db_session.refresh(invoice_two)
+
+    create_tx_response = await client.post(
+        "/api/bank/transactions",
+        json={
+            "date": "2024-03-15",
+            "amount": "120.00",
+            "description": "VIR CLIENT GROUPE",
+            "reference": "VIR-2024-002",
+            "source": "import",
+        },
+        headers=auth_headers,
+    )
+    assert create_tx_response.status_code == 201
+    tx_id = create_tx_response.json()["id"]
+
+    reconcile_response = await client.post(
+        f"/api/bank/transactions/{tx_id}/create-client-payments",
+        json={
+            "allocations": [
+                {"invoice_id": invoice_one.id, "amount": "70.00"},
+                {"invoice_id": invoice_two.id, "amount": "50.00"},
+            ]
+        },
+        headers=auth_headers,
+    )
+
+    assert reconcile_response.status_code == 201
+    data = reconcile_response.json()
+    assert data["reconciled"] is True
+    assert data["payment_id"] is None
+    assert len(data["payment_ids"]) == 2
+
+    payments = list(
+        (
+            await db_session.execute(
+                select(Payment)
+                .where(Payment.id.in_(data["payment_ids"]))
+                .order_by(Payment.id.asc())
+            )
+        ).scalars()
+    )
+    assert [payment.invoice_id for payment in payments] == [invoice_one.id, invoice_two.id]
+    assert all(payment.method == PaymentMethod.VIREMENT for payment in payments)
+    assert all(payment.deposited is True for payment in payments)
+    assert all(payment.deposit_date == date(2024, 3, 15) for payment in payments)
+
+    await db_session.refresh(invoice_one)
+    await db_session.refresh(invoice_two)
+    assert invoice_one.status == InvoiceStatus.PAID
+    assert invoice_two.status == InvoiceStatus.PAID
+
+
+@pytest.mark.asyncio
+async def test_create_client_payment_from_debit_transaction_is_rejected(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    admin_user: User,
+    auth_headers: dict,
+) -> None:
+    invoice = await _make_client_invoice(
+        db_session,
+        number="F-2024-102",
+        total_amount=Decimal("45.50"),
+    )
+
+    create_tx_response = await client.post(
+        "/api/bank/transactions",
+        json={
+            "date": "2024-03-15",
+            "amount": "-45.50",
+            "description": "PRLV EDF",
+            "source": "import",
+        },
+        headers=auth_headers,
+    )
+    assert create_tx_response.status_code == 201
+    tx_id = create_tx_response.json()["id"]
+
+    reconcile_response = await client.post(
+        f"/api/bank/transactions/{tx_id}/create-client-payment",
+        json={"invoice_id": invoice.id},
+        headers=auth_headers,
+    )
+
+    assert reconcile_response.status_code == 422
+    assert (
+        reconcile_response.json()["detail"]
+        == "only positive bank transactions can create client payments"
+    )
+
+
+@pytest.mark.asyncio
+async def test_link_existing_client_payment_to_bank_transaction(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    admin_user: User,
+    auth_headers: dict,
+) -> None:
+    payment = await _make_client_virement_payment(db_session)
+
+    create_tx_response = await client.post(
+        "/api/bank/transactions",
+        json={
+            "date": "2024-03-15",
+            "amount": "150.00",
+            "description": "VIR DUPONT",
+            "reference": "VIR-2024-001",
+            "source": "import",
+        },
+        headers=auth_headers,
+    )
+    assert create_tx_response.status_code == 201
+    tx_id = create_tx_response.json()["id"]
+
+    link_response = await client.post(
+        f"/api/bank/transactions/{tx_id}/link-client-payment",
+        json={"payment_id": payment.id},
+        headers=auth_headers,
+    )
+
+    assert link_response.status_code == 200
+    data = link_response.json()
+    assert data["reconciled"] is True
+    assert data["payment_id"] == payment.id
+
+    await db_session.refresh(payment)
+    assert payment.deposited is True
+    assert payment.deposit_date == date(2024, 3, 15)
+
+
+@pytest.mark.asyncio
+async def test_link_existing_client_payments_to_bank_transaction(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    admin_user: User,
+    auth_headers: dict,
+) -> None:
+    payment_one = await _make_client_virement_payment(
+        db_session,
+        number="F-2024-104",
+        amount=Decimal("70.00"),
+    )
+    payment_two = await _make_client_virement_payment(
+        db_session,
+        number="F-2024-105",
+        amount=Decimal("50.00"),
+    )
+
+    create_tx_response = await client.post(
+        "/api/bank/transactions",
+        json={
+            "date": "2024-03-15",
+            "amount": "120.00",
+            "description": "VIR DUPONT GROUPE",
+            "reference": "VIR-2024-003",
+            "source": "import",
+        },
+        headers=auth_headers,
+    )
+    assert create_tx_response.status_code == 201
+    tx_id = create_tx_response.json()["id"]
+
+    link_response = await client.post(
+        f"/api/bank/transactions/{tx_id}/link-client-payments",
+        json={"payment_ids": [payment_one.id, payment_two.id]},
+        headers=auth_headers,
+    )
+
+    assert link_response.status_code == 200
+    data = link_response.json()
+    assert data["reconciled"] is True
+    assert data["payment_id"] is None
+    assert data["payment_ids"] == [payment_one.id, payment_two.id]
+
+    await db_session.refresh(payment_one)
+    await db_session.refresh(payment_two)
+    assert payment_one.deposited is True
+    assert payment_two.deposited is True
+    assert payment_one.deposit_date == date(2024, 3, 15)
+    assert payment_two.deposit_date == date(2024, 3, 15)
+
+
+@pytest.mark.asyncio
+async def test_link_existing_client_payments_rejects_amount_mismatch(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    admin_user: User,
+    auth_headers: dict,
+) -> None:
+    payment = await _make_client_virement_payment(db_session, amount=Decimal("100.00"))
+
+    create_tx_response = await client.post(
+        "/api/bank/transactions",
+        json={
+            "date": "2024-03-15",
+            "amount": "120.00",
+            "description": "VIR DUPONT GROUPE",
+            "source": "import",
+        },
+        headers=auth_headers,
+    )
+    assert create_tx_response.status_code == 201
+    tx_id = create_tx_response.json()["id"]
+
+    link_response = await client.post(
+        f"/api/bank/transactions/{tx_id}/link-client-payments",
+        json={"payment_ids": [payment.id]},
+        headers=auth_headers,
+    )
+
+    assert link_response.status_code == 422
+    assert (
+        link_response.json()["detail"] == "linked payments total must match bank transaction amount"
+    )
+
+
+@pytest.mark.asyncio
+async def test_link_existing_client_payment_rejects_amount_mismatch(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    admin_user: User,
+    auth_headers: dict,
+) -> None:
+    payment = await _make_client_virement_payment(db_session, amount=Decimal("120.00"))
+
+    create_tx_response = await client.post(
+        "/api/bank/transactions",
+        json={
+            "date": "2024-03-15",
+            "amount": "150.00",
+            "description": "VIR DUPONT",
+            "source": "import",
+        },
+        headers=auth_headers,
+    )
+    assert create_tx_response.status_code == 201
+    tx_id = create_tx_response.json()["id"]
+
+    link_response = await client.post(
+        f"/api/bank/transactions/{tx_id}/link-client-payment",
+        json={"payment_id": payment.id},
+        headers=auth_headers,
+    )
+
+    assert link_response.status_code == 422
+    assert link_response.json()["detail"] == "bank transaction amount must match payment amount"
+
+
+@pytest.mark.asyncio
+async def test_create_supplier_payment_from_bank_transaction(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    admin_user: User,
+    auth_headers: dict,
+) -> None:
+    invoice = await _make_supplier_invoice(db_session)
+
+    create_tx_response = await client.post(
+        "/api/bank/transactions",
+        json={
+            "date": "2024-03-15",
+            "amount": "-200.00",
+            "description": "VIR FOURNISSEUR TEST",
+            "reference": "FOURN-2024-001",
+            "source": "import",
+        },
+        headers=auth_headers,
+    )
+    assert create_tx_response.status_code == 201
+    tx_id = create_tx_response.json()["id"]
+
+    reconcile_response = await client.post(
+        f"/api/bank/transactions/{tx_id}/create-supplier-payment",
+        json={"invoice_id": invoice.id},
+        headers=auth_headers,
+    )
+
+    assert reconcile_response.status_code == 201
+    data = reconcile_response.json()
+    assert data["reconciled"] is True
+    assert data["reconciled_with"] == invoice.number
+    assert data["payment_id"] is not None
+
+    payment = await db_session.get(Payment, data["payment_id"])
+    assert payment is not None
+    assert payment.invoice_id == invoice.id
+    assert payment.contact_id == invoice.contact_id
+    assert payment.amount == Decimal("200.00")
+    assert payment.date == date(2024, 3, 15)
+    assert payment.method == PaymentMethod.VIREMENT
+    assert payment.reference == "FOURN-2024-001"
+    assert payment.deposited is True
+    assert payment.deposit_date == date(2024, 3, 15)
+
+
+@pytest.mark.asyncio
+async def test_link_existing_supplier_payment_to_bank_transaction(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    admin_user: User,
+    auth_headers: dict,
+) -> None:
+    payment = await _make_supplier_virement_payment(db_session)
+
+    create_tx_response = await client.post(
+        "/api/bank/transactions",
+        json={
+            "date": "2024-03-15",
+            "amount": "-200.00",
+            "description": "VIR FOURNISSEUR TEST",
+            "reference": "FOURN-2024-001",
+            "source": "import",
+        },
+        headers=auth_headers,
+    )
+    assert create_tx_response.status_code == 201
+    tx_id = create_tx_response.json()["id"]
+
+    link_response = await client.post(
+        f"/api/bank/transactions/{tx_id}/link-supplier-payment",
+        json={"payment_id": payment.id},
+        headers=auth_headers,
+    )
+
+    assert link_response.status_code == 200
+    data = link_response.json()
+    assert data["reconciled"] is True
+    assert data["payment_id"] == payment.id
+
+    await db_session.refresh(payment)
+    assert payment.deposited is True
+    assert payment.deposit_date == date(2024, 3, 15)

--- a/tests/integration/test_bank_ofx_qif_api.py
+++ b/tests/integration/test_bank_ofx_qif_api.py
@@ -44,6 +44,7 @@ async def test_import_ofx_success(client: AsyncClient, auth_headers: dict) -> No
     assert len(data) == 1
     assert data[0]["amount"] == "-100.00"
     assert data[0]["description"] == "TEST OFX"
+    assert data[0]["detected_category"] == "other_debit"
 
 
 @pytest.mark.asyncio
@@ -68,6 +69,7 @@ async def test_import_qif_success(client: AsyncClient, auth_headers: dict) -> No
     assert len(data) == 1
     assert data[0]["amount"] == "-100.00"
     assert data[0]["description"] == "TEST QIF"
+    assert data[0]["detected_category"] == "other_debit"
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_payments_api.py
+++ b/tests/integration/test_payments_api.py
@@ -269,7 +269,9 @@ async def test_update_cash_payment_rejects_amount_change(
     )
 
     assert update_resp.status_code == 400
-    assert update_resp.json()["detail"] == "cash client payments cannot change amount after creation"
+    assert (
+        update_resp.json()["detail"] == "cash client payments cannot change amount after creation"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_bank_import.py
+++ b/tests/unit/test_bank_import.py
@@ -7,8 +7,10 @@ from decimal import Decimal
 
 import pytest
 
+from backend.models.bank import BankTransactionCategory
 from backend.services.bank_import import (
     BankImportError,
+    detect_transaction_category,
     parse_credit_mutuel_csv,
     parse_ofx,
     parse_qif,
@@ -145,6 +147,46 @@ def test_ofx_xml_reference() -> None:
 def test_ofx_empty_raises() -> None:
     with pytest.raises(BankImportError):
         parse_ofx("<OFX></OFX>")
+
+
+def test_detect_customer_payment_category() -> None:
+    category = detect_transaction_category(
+        amount=Decimal("52.00"),
+        description="VIR INST ANNE WENTZO VIREMENT DE",
+    )
+    assert category == BankTransactionCategory.CUSTOMER_PAYMENT
+
+
+def test_detect_cheque_deposit_category() -> None:
+    category = detect_transaction_category(
+        amount=Decimal("388.00"),
+        description="REM CHQ REF05001A05",
+    )
+    assert category == BankTransactionCategory.CHEQUE_DEPOSIT
+
+
+def test_detect_cash_deposit_category() -> None:
+    category = detect_transaction_category(
+        amount=Decimal("700.00"),
+        description="VRST REF05001A05",
+    )
+    assert category == BankTransactionCategory.CASH_DEPOSIT
+
+
+def test_detect_salary_category() -> None:
+    category = detect_transaction_category(
+        amount=Decimal("-1249.64"),
+        description="VIR INST SALAIRE LAY 2026.02 VG6",
+    )
+    assert category == BankTransactionCategory.SALARY
+
+
+def test_detect_social_charge_category() -> None:
+    category = detect_transaction_category(
+        amount=Decimal("-800.00"),
+        description="PRLV SEPA URSSAF DE LORRAINE TT4",
+    )
+    assert category == BankTransactionCategory.SOCIAL_CHARGE
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_bank_service.py
+++ b/tests/unit/test_bank_service.py
@@ -13,6 +13,8 @@ from backend.models.contact import Contact, ContactType
 from backend.models.invoice import Invoice, InvoiceStatus, InvoiceType
 from backend.models.payment import Payment, PaymentMethod
 from backend.schemas.bank import (
+    BankTransactionClientPaymentAllocation,
+    BankTransactionClientPaymentsCreate,
     BankTransactionCreate,
     BankTransactionUpdate,
     DepositCreate,
@@ -146,6 +148,464 @@ async def test_update_transaction_reconcile(db_session: AsyncSession) -> None:
     )
     assert updated.reconciled is True
     assert updated.reconciled_with == "REF123"
+
+
+@pytest.mark.asyncio
+async def test_create_client_payment_from_transaction(db_session: AsyncSession) -> None:
+    contact = Contact(type=ContactType.CLIENT, nom="Durand")
+    db_session.add(contact)
+    await db_session.flush()
+
+    invoice = Invoice(
+        number="F-2024-200",
+        type=InvoiceType.CLIENT,
+        contact_id=contact.id,
+        date=date(2024, 3, 1),
+        total_amount=Decimal("120.00"),
+        paid_amount=Decimal("0"),
+        status=InvoiceStatus.SENT,
+    )
+    db_session.add(invoice)
+    await db_session.flush()
+
+    tx = await bank_service.add_transaction(
+        db_session,
+        BankTransactionCreate(
+            date=date(2024, 3, 10),
+            amount=Decimal("120.00"),
+            description="VIR DURAND",
+            reference="BANK-REF-001",
+            source=BankTransactionSource.IMPORT,
+        ),
+    )
+
+    updated_tx = await bank_service.create_client_payment_from_transaction(
+        db_session,
+        tx_id=tx.id,
+        invoice_id=invoice.id,
+    )
+
+    assert updated_tx.reconciled is True
+    assert updated_tx.reconciled_with == invoice.number
+    assert updated_tx.payment_id is not None
+
+    payment = await db_session.get(Payment, updated_tx.payment_id)
+    assert payment is not None
+    assert payment.method == PaymentMethod.VIREMENT
+    assert payment.reference == "BANK-REF-001"
+    assert payment.deposited is True
+    assert payment.deposit_date == date(2024, 3, 10)
+
+
+@pytest.mark.asyncio
+async def test_create_client_payments_from_transaction(db_session: AsyncSession) -> None:
+    contact = Contact(type=ContactType.CLIENT, nom="Durand")
+    db_session.add(contact)
+    await db_session.flush()
+
+    invoice_one = Invoice(
+        number="F-2024-210",
+        type=InvoiceType.CLIENT,
+        contact_id=contact.id,
+        date=date(2024, 3, 1),
+        total_amount=Decimal("70.00"),
+        paid_amount=Decimal("0"),
+        status=InvoiceStatus.SENT,
+    )
+    invoice_two = Invoice(
+        number="F-2024-211",
+        type=InvoiceType.CLIENT,
+        contact_id=contact.id,
+        date=date(2024, 3, 2),
+        total_amount=Decimal("50.00"),
+        paid_amount=Decimal("0"),
+        status=InvoiceStatus.SENT,
+    )
+    db_session.add_all([invoice_one, invoice_two])
+    await db_session.flush()
+
+    tx = await bank_service.add_transaction(
+        db_session,
+        BankTransactionCreate(
+            date=date(2024, 3, 10),
+            amount=Decimal("120.00"),
+            description="VIR DURAND GROUPE",
+            reference="BANK-REF-002",
+            source=BankTransactionSource.IMPORT,
+        ),
+    )
+
+    updated_tx = await bank_service.create_client_payments_from_transaction(
+        db_session,
+        tx_id=tx.id,
+        payload=BankTransactionClientPaymentsCreate(
+            allocations=[
+                BankTransactionClientPaymentAllocation(
+                    invoice_id=invoice_one.id,
+                    amount=Decimal("70.00"),
+                ),
+                BankTransactionClientPaymentAllocation(
+                    invoice_id=invoice_two.id,
+                    amount=Decimal("50.00"),
+                ),
+            ]
+        ),
+    )
+
+    assert updated_tx.reconciled is True
+    assert updated_tx.payment_id is None
+
+    payment_ids = await bank_service.get_transaction_payment_ids(db_session, updated_tx.id)
+    assert len(payment_ids) == 2
+
+    created_payments = [await db_session.get(Payment, payment_id) for payment_id in payment_ids]
+    assert [payment.invoice_id for payment in created_payments if payment is not None] == [
+        invoice_one.id,
+        invoice_two.id,
+    ]
+    assert all(
+        payment is not None and payment.method == PaymentMethod.VIREMENT
+        for payment in created_payments
+    )
+
+    await db_session.refresh(invoice_one)
+    await db_session.refresh(invoice_two)
+    assert invoice_one.status == InvoiceStatus.PAID
+    assert invoice_two.status == InvoiceStatus.PAID
+
+
+@pytest.mark.asyncio
+async def test_create_client_payments_from_transaction_rejects_amount_mismatch(
+    db_session: AsyncSession,
+) -> None:
+    contact = Contact(type=ContactType.CLIENT, nom="Durand")
+    db_session.add(contact)
+    await db_session.flush()
+
+    invoice = Invoice(
+        number="F-2024-212",
+        type=InvoiceType.CLIENT,
+        contact_id=contact.id,
+        date=date(2024, 3, 1),
+        total_amount=Decimal("120.00"),
+        paid_amount=Decimal("0"),
+        status=InvoiceStatus.SENT,
+    )
+    db_session.add(invoice)
+    await db_session.flush()
+
+    tx = await bank_service.add_transaction(
+        db_session,
+        BankTransactionCreate(
+            date=date(2024, 3, 10),
+            amount=Decimal("120.00"),
+            description="VIR DURAND GROUPE",
+            source=BankTransactionSource.IMPORT,
+        ),
+    )
+
+    with pytest.raises(ValueError, match="allocated amount must match bank transaction amount"):
+        await bank_service.create_client_payments_from_transaction(
+            db_session,
+            tx_id=tx.id,
+            payload=BankTransactionClientPaymentsCreate(
+                allocations=[
+                    BankTransactionClientPaymentAllocation(
+                        invoice_id=invoice.id,
+                        amount=Decimal("100.00"),
+                    )
+                ]
+            ),
+        )
+
+
+@pytest.mark.asyncio
+async def test_link_existing_client_payment_to_transaction(db_session: AsyncSession) -> None:
+    contact = Contact(type=ContactType.CLIENT, nom="Durand")
+    db_session.add(contact)
+    await db_session.flush()
+
+    invoice = Invoice(
+        number="F-2024-201",
+        type=InvoiceType.CLIENT,
+        contact_id=contact.id,
+        date=date(2024, 3, 1),
+        total_amount=Decimal("120.00"),
+        paid_amount=Decimal("0"),
+        status=InvoiceStatus.SENT,
+    )
+    db_session.add(invoice)
+    await db_session.flush()
+
+    payment = Payment(
+        invoice_id=invoice.id,
+        contact_id=contact.id,
+        amount=Decimal("120.00"),
+        date=date(2024, 3, 9),
+        method=PaymentMethod.VIREMENT,
+        deposited=False,
+    )
+    db_session.add(payment)
+    await db_session.commit()
+    await db_session.refresh(payment)
+
+    tx = await bank_service.add_transaction(
+        db_session,
+        BankTransactionCreate(
+            date=date(2024, 3, 10),
+            amount=Decimal("120.00"),
+            description="VIR DURAND",
+            source=BankTransactionSource.IMPORT,
+        ),
+    )
+
+    updated_tx = await bank_service.link_client_payment_to_transaction(
+        db_session,
+        tx_id=tx.id,
+        payment_id=payment.id,
+    )
+
+    assert updated_tx.reconciled is True
+    assert updated_tx.payment_id == payment.id
+
+    await db_session.refresh(payment)
+    assert payment.deposited is True
+    assert payment.deposit_date == date(2024, 3, 10)
+
+
+@pytest.mark.asyncio
+async def test_link_existing_client_payments_to_transaction(db_session: AsyncSession) -> None:
+    contact = Contact(type=ContactType.CLIENT, nom="Durand")
+    db_session.add(contact)
+    await db_session.flush()
+
+    invoice_one = Invoice(
+        number="F-2024-213",
+        type=InvoiceType.CLIENT,
+        contact_id=contact.id,
+        date=date(2024, 3, 1),
+        total_amount=Decimal("70.00"),
+        paid_amount=Decimal("70.00"),
+        status=InvoiceStatus.PAID,
+    )
+    invoice_two = Invoice(
+        number="F-2024-214",
+        type=InvoiceType.CLIENT,
+        contact_id=contact.id,
+        date=date(2024, 3, 2),
+        total_amount=Decimal("50.00"),
+        paid_amount=Decimal("50.00"),
+        status=InvoiceStatus.PAID,
+    )
+    db_session.add_all([invoice_one, invoice_two])
+    await db_session.flush()
+
+    payment_one = Payment(
+        invoice_id=invoice_one.id,
+        contact_id=contact.id,
+        amount=Decimal("70.00"),
+        date=date(2024, 3, 8),
+        method=PaymentMethod.VIREMENT,
+        reference="LEGACY-VIR-070",
+        deposited=False,
+    )
+    payment_two = Payment(
+        invoice_id=invoice_two.id,
+        contact_id=contact.id,
+        amount=Decimal("50.00"),
+        date=date(2024, 3, 9),
+        method=PaymentMethod.VIREMENT,
+        reference="LEGACY-VIR-050",
+        deposited=False,
+    )
+    db_session.add_all([payment_one, payment_two])
+    await db_session.commit()
+    await db_session.refresh(payment_one)
+    await db_session.refresh(payment_two)
+
+    tx = await bank_service.add_transaction(
+        db_session,
+        BankTransactionCreate(
+            date=date(2024, 3, 10),
+            amount=Decimal("120.00"),
+            description="VIR DURAND GROUPE",
+            source=BankTransactionSource.IMPORT,
+        ),
+    )
+
+    updated_tx = await bank_service.link_client_payments_to_transaction(
+        db_session,
+        tx_id=tx.id,
+        payment_ids=[payment_one.id, payment_two.id],
+    )
+
+    assert updated_tx.reconciled is True
+    assert updated_tx.payment_id is None
+
+    payment_ids = await bank_service.get_transaction_payment_ids(db_session, updated_tx.id)
+    assert payment_ids == [payment_one.id, payment_two.id]
+
+    await db_session.refresh(payment_one)
+    await db_session.refresh(payment_two)
+    assert payment_one.deposited is True
+    assert payment_two.deposited is True
+    assert payment_one.deposit_date == date(2024, 3, 10)
+    assert payment_two.deposit_date == date(2024, 3, 10)
+
+
+@pytest.mark.asyncio
+async def test_link_existing_client_payments_rejects_amount_mismatch(
+    db_session: AsyncSession,
+) -> None:
+    contact = Contact(type=ContactType.CLIENT, nom="Durand")
+    db_session.add(contact)
+    await db_session.flush()
+
+    invoice = Invoice(
+        number="F-2024-215",
+        type=InvoiceType.CLIENT,
+        contact_id=contact.id,
+        date=date(2024, 3, 1),
+        total_amount=Decimal("120.00"),
+        paid_amount=Decimal("120.00"),
+        status=InvoiceStatus.PAID,
+    )
+    db_session.add(invoice)
+    await db_session.flush()
+
+    payment = Payment(
+        invoice_id=invoice.id,
+        contact_id=contact.id,
+        amount=Decimal("100.00"),
+        date=date(2024, 3, 8),
+        method=PaymentMethod.VIREMENT,
+        deposited=False,
+    )
+    db_session.add(payment)
+    await db_session.commit()
+    await db_session.refresh(payment)
+
+    tx = await bank_service.add_transaction(
+        db_session,
+        BankTransactionCreate(
+            date=date(2024, 3, 10),
+            amount=Decimal("120.00"),
+            description="VIR DURAND GROUPE",
+            source=BankTransactionSource.IMPORT,
+        ),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="linked payments total must match bank transaction amount",
+    ):
+        await bank_service.link_client_payments_to_transaction(
+            db_session,
+            tx_id=tx.id,
+            payment_ids=[payment.id],
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_supplier_payment_from_transaction(db_session: AsyncSession) -> None:
+    contact = Contact(type=ContactType.FOURNISSEUR, nom="Fournisseur")
+    db_session.add(contact)
+    await db_session.flush()
+
+    invoice = Invoice(
+        number="A-2024-200",
+        type=InvoiceType.FOURNISSEUR,
+        contact_id=contact.id,
+        date=date(2024, 3, 1),
+        total_amount=Decimal("220.00"),
+        paid_amount=Decimal("0"),
+        status=InvoiceStatus.SENT,
+        reference="SUP-001",
+    )
+    db_session.add(invoice)
+    await db_session.flush()
+
+    tx = await bank_service.add_transaction(
+        db_session,
+        BankTransactionCreate(
+            date=date(2024, 3, 10),
+            amount=Decimal("-220.00"),
+            description="VIR FOURNISSEUR",
+            reference="SUP-001",
+            source=BankTransactionSource.IMPORT,
+        ),
+    )
+
+    updated_tx = await bank_service.create_supplier_payment_from_transaction(
+        db_session,
+        tx_id=tx.id,
+        invoice_id=invoice.id,
+    )
+
+    assert updated_tx.reconciled is True
+    assert updated_tx.reconciled_with == invoice.number
+    assert updated_tx.payment_id is not None
+
+    payment = await db_session.get(Payment, updated_tx.payment_id)
+    assert payment is not None
+    assert payment.amount == Decimal("220.00")
+    assert payment.method == PaymentMethod.VIREMENT
+    assert payment.deposited is True
+    assert payment.deposit_date == date(2024, 3, 10)
+
+
+@pytest.mark.asyncio
+async def test_link_existing_supplier_payment_to_transaction(db_session: AsyncSession) -> None:
+    contact = Contact(type=ContactType.FOURNISSEUR, nom="Fournisseur")
+    db_session.add(contact)
+    await db_session.flush()
+
+    invoice = Invoice(
+        number="A-2024-201",
+        type=InvoiceType.FOURNISSEUR,
+        contact_id=contact.id,
+        date=date(2024, 3, 1),
+        total_amount=Decimal("220.00"),
+        paid_amount=Decimal("0"),
+        status=InvoiceStatus.SENT,
+    )
+    db_session.add(invoice)
+    await db_session.flush()
+
+    payment = Payment(
+        invoice_id=invoice.id,
+        contact_id=contact.id,
+        amount=Decimal("220.00"),
+        date=date(2024, 3, 9),
+        method=PaymentMethod.VIREMENT,
+        deposited=False,
+    )
+    db_session.add(payment)
+    await db_session.commit()
+    await db_session.refresh(payment)
+
+    tx = await bank_service.add_transaction(
+        db_session,
+        BankTransactionCreate(
+            date=date(2024, 3, 10),
+            amount=Decimal("-220.00"),
+            description="VIR FOURNISSEUR",
+            source=BankTransactionSource.IMPORT,
+        ),
+    )
+
+    updated_tx = await bank_service.link_supplier_payment_to_transaction(
+        db_session,
+        tx_id=tx.id,
+        payment_id=payment.id,
+    )
+
+    assert updated_tx.reconciled is True
+    assert updated_tx.payment_id == payment.id
+
+    await db_session.refresh(payment)
+    assert payment.deposited is True
+    assert payment.deposit_date == date(2024, 3, 10)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_bank_service.py
+++ b/tests/unit/test_bank_service.py
@@ -6,9 +6,10 @@ from datetime import date
 from decimal import Decimal
 
 import pytest
+from sqlalchemy import insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from backend.models.bank import BankTransactionSource, DepositType
+from backend.models.bank import BankTransactionSource, DepositType, bank_transaction_payments
 from backend.models.contact import Contact, ContactType
 from backend.models.invoice import Invoice, InvoiceStatus, InvoiceType
 from backend.models.payment import Payment, PaymentMethod
@@ -320,6 +321,72 @@ async def test_create_client_payments_from_transaction_rejects_amount_mismatch(
 
 
 @pytest.mark.asyncio
+async def test_create_client_payment_rejects_transaction_with_existing_association_link(
+    db_session: AsyncSession,
+) -> None:
+    contact = Contact(type=ContactType.CLIENT, nom="Durand")
+    db_session.add(contact)
+    await db_session.flush()
+
+    invoice = Invoice(
+        number="F-2024-216",
+        type=InvoiceType.CLIENT,
+        contact_id=contact.id,
+        date=date(2024, 3, 1),
+        total_amount=Decimal("120.00"),
+        paid_amount=Decimal("0"),
+        status=InvoiceStatus.SENT,
+    )
+    linked_invoice = Invoice(
+        number="F-2024-217",
+        type=InvoiceType.CLIENT,
+        contact_id=contact.id,
+        date=date(2024, 3, 2),
+        total_amount=Decimal("120.00"),
+        paid_amount=Decimal("120.00"),
+        status=InvoiceStatus.PAID,
+    )
+    db_session.add_all([invoice, linked_invoice])
+    await db_session.flush()
+
+    linked_payment = Payment(
+        invoice_id=linked_invoice.id,
+        contact_id=contact.id,
+        amount=Decimal("120.00"),
+        date=date(2024, 3, 9),
+        method=PaymentMethod.VIREMENT,
+        deposited=False,
+    )
+    db_session.add(linked_payment)
+    await db_session.flush()
+
+    tx = await bank_service.add_transaction(
+        db_session,
+        BankTransactionCreate(
+            date=date(2024, 3, 10),
+            amount=Decimal("120.00"),
+            description="VIR DURAND",
+            source=BankTransactionSource.IMPORT,
+        ),
+    )
+    tx.reconciled = False
+    tx.payment_id = None
+    await db_session.flush()
+    await db_session.execute(
+        insert(bank_transaction_payments),
+        [{"transaction_id": tx.id, "payment_id": linked_payment.id}],
+    )
+    await db_session.commit()
+
+    with pytest.raises(ValueError, match="bank transaction is already reconciled"):
+        await bank_service.create_client_payment_from_transaction(
+            db_session,
+            tx_id=tx.id,
+            invoice_id=invoice.id,
+        )
+
+
+@pytest.mark.asyncio
 async def test_link_existing_client_payment_to_transaction(db_session: AsyncSession) -> None:
     contact = Contact(type=ContactType.CLIENT, nom="Durand")
     db_session.add(contact)
@@ -451,6 +518,48 @@ async def test_link_existing_client_payments_to_transaction(db_session: AsyncSes
     assert payment_two.deposited is True
     assert payment_one.deposit_date == date(2024, 3, 10)
     assert payment_two.deposit_date == date(2024, 3, 10)
+
+
+@pytest.mark.asyncio
+async def test_get_transaction_payment_ids_map_supports_association_and_legacy_link(
+    db_session: AsyncSession,
+) -> None:
+    payment = await _make_payment(db_session)
+    second_payment = Payment(
+        invoice_id=payment.invoice_id,
+        contact_id=payment.contact_id,
+        amount=Decimal("40.00"),
+        date=date(2024, 2, 2),
+        method=PaymentMethod.CHEQUE,
+        deposited=False,
+    )
+    db_session.add(second_payment)
+    await db_session.flush()
+
+    legacy_tx = await bank_service.add_transaction(
+        db_session,
+        BankTransactionCreate(date=date(2024, 3, 10), amount=Decimal("100.00")),
+    )
+    legacy_tx.payment_id = payment.id
+    associated_tx = await bank_service.add_transaction(
+        db_session,
+        BankTransactionCreate(date=date(2024, 3, 11), amount=Decimal("40.00")),
+    )
+    await db_session.execute(
+        insert(bank_transaction_payments),
+        [{"transaction_id": associated_tx.id, "payment_id": second_payment.id}],
+    )
+    await db_session.commit()
+
+    payment_ids_by_tx_id = await bank_service.get_transaction_payment_ids_map(
+        db_session,
+        [legacy_tx.id, associated_tx.id],
+    )
+
+    assert payment_ids_by_tx_id == {
+        legacy_tx.id: [payment.id],
+        associated_tx.id: [second_payment.id],
+    }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
This PR delivers BL-031 by turning bank statement import into a usable bank reconciliation workflow for the MVP.

## What changed
- add bank transaction categorization and persistent transaction-to-payment links, including grouped client payment support
- expose backend routes and schemas to create or link client and supplier virement payments from bank transactions
- update the Bank view to import statements from files, infer the format from the file extension, show detected categories, and support grouped client reconciliation flows
- add backend and frontend test coverage for categorization, reconciliation helpers, and the new API/UI flows
- close BL-031 in the backlog and record that remaining bank balance discrepancies are deferred to the final MVP qualification pass

## Validation
- `d:/dev/_misc/solde/.venv/Scripts/python.exe -m ruff check .`
- `d:/dev/_misc/solde/.venv/Scripts/python.exe -m ruff format --check .`
- `d:/dev/_misc/solde/.venv/Scripts/python.exe -m mypy .`
- `d:/dev/_misc/solde/.venv/Scripts/python.exe -m pytest tests/`
- `cd frontend && npx vue-tsc --noEmit -p tsconfig.app.json`
- `cd frontend && npx vue-tsc --noEmit`
- `cd frontend && npx eslint src/`
- `cd frontend && npx vitest run`
