### PR TITLE
BL-030: enforce guarded updates for validated objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,8 +43,8 @@ Ce projet respecte le [Versionnage sémantique](https://semver.org/lang/fr/).
 **Édition métier des factures, paiements et imports**
 - Une facture `sent` non réglée reste modifiable, mais toute modification régénère désormais ses écritures comptables auto-générées au lieu de laisser des écritures obsolètes en base
 - Une facture déjà consommée (`paid`, ou plus généralement hors cas `draft` / `sent` non réglée) ne peut plus être modifiée directement via l'API
-- Les paiements deviennent quasi immuables après création : seules les corrections mineures sans impact structurel (`référence`, `notes`, `n° de chèque`) restent éditables depuis l'écran `Paiements`
-- Le rejeu strict des imports réversibles reste désormais explicitement protégé même après retouche manuelle d'un objet importé, y compris quand l'instance SQLAlchemy a été expirée entre-temps
+- Les paiements deviennent quasi immuables après création : seules les corrections mineures sans impact structurel (`référence`, `notes`, `n° de chèque`) restent éditables depuis l'écran `Paiements`, et la suppression standard est désormais bloquée en attendant un vrai flux d'annulation métier
+- Le rejeu strict des imports réversibles reste désormais explicitement protégé même après retouche manuelle d'un objet importé via l'API, y compris quand l'instance SQLAlchemy a été expirée entre-temps
 
 **Paiements et trésorerie**
 - Les règlements clients en `chèque` et `espèces` se saisissent désormais depuis la facture client et son historique, avec un parcours dédié pour enregistrer date, montant, mode, référence et note

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,12 @@ Ce projet respecte le [Versionnage sémantique](https://semver.org/lang/fr/).
 
 ### Modifié
 
+**Édition métier des factures, paiements et imports**
+- Une facture `sent` non réglée reste modifiable, mais toute modification régénère désormais ses écritures comptables auto-générées au lieu de laisser des écritures obsolètes en base
+- Une facture déjà consommée (`paid`, ou plus généralement hors cas `draft` / `sent` non réglée) ne peut plus être modifiée directement via l'API
+- Les paiements deviennent quasi immuables après création : seules les corrections mineures sans impact structurel (`référence`, `notes`, `n° de chèque`) restent éditables depuis l'écran `Paiements`
+- Le rejeu strict des imports réversibles reste désormais explicitement protégé même après retouche manuelle d'un objet importé, y compris quand l'instance SQLAlchemy a été expirée entre-temps
+
 **Paiements et trésorerie**
 - Les règlements clients en `chèque` et `espèces` se saisissent désormais depuis la facture client et son historique, avec un parcours dédié pour enregistrer date, montant, mode, référence et note
 - Le journal `Caisse` affiche explicitement les mouvements issus d'un paiement client, et les bordereaux bancaires filtrent les paiements selon le type de remise choisi

--- a/backend/routers/invoice.py
+++ b/backend/routers/invoice.py
@@ -29,7 +29,7 @@ from backend.schemas.invoice import (
     InvoiceUpdate,
 )
 from backend.services import invoice as invoice_service
-from backend.services.invoice import InvoiceDeleteError, InvoiceStatusError
+from backend.services.invoice import InvoiceDeleteError, InvoiceStatusError, InvoiceUpdateError
 
 router = APIRouter(prefix="/invoices", tags=["invoices"])
 
@@ -108,7 +108,10 @@ async def update_invoice(
     invoice = await invoice_service.get_invoice(db, invoice_id)
     if invoice is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Invoice not found")
-    return await invoice_service.update_invoice(db, invoice, payload)  # type: ignore[return-value]
+    try:
+        return await invoice_service.update_invoice(db, invoice, payload)  # type: ignore[return-value]
+    except InvoiceUpdateError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
 
 
 @router.patch("/{invoice_id}/status", response_model=InvoiceRead)

--- a/backend/routers/payment.py
+++ b/backend/routers/payment.py
@@ -105,4 +105,7 @@ async def delete_payment(
     payment = await payment_service.get_payment(db, payment_id)
     if payment is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Payment not found")
-    await payment_service.delete_payment(db, payment)
+    try:
+        await payment_service.delete_payment(db, payment)
+    except payment_service.PaymentDeleteError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc

--- a/backend/schemas/contact.py
+++ b/backend/schemas/contact.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel, EmailStr, field_validator
 from backend.models.contact import ContactType
 
 
-class ContactBase(BaseModel):
+class ContactWriteBase(BaseModel):
     type: ContactType
     nom: str
     prenom: str | None = None
@@ -26,7 +26,7 @@ class ContactBase(BaseModel):
         return v.strip()
 
 
-class ContactCreate(ContactBase):
+class ContactCreate(ContactWriteBase):
     pass
 
 
@@ -50,8 +50,15 @@ class ContactUpdate(BaseModel):
         return v.strip() if v else v
 
 
-class ContactRead(ContactBase):
+class ContactRead(BaseModel):
     id: int
+    type: ContactType
+    nom: str
+    prenom: str | None = None
+    email: str | None = None
+    telephone: str | None = None
+    adresse: str | None = None
+    notes: str | None = None
     is_active: bool
     created_at: datetime
     updated_at: datetime

--- a/backend/services/import_reversible.py
+++ b/backend/services/import_reversible.py
@@ -2859,6 +2859,7 @@ async def _ensure_effect_matches_state(
     entity = await db.get(model_cls, effect.entity_id)
     if entity is None:
         raise ValueError("Objet introuvable pour vérification stricte")
+    await db.refresh(entity)
     current_snapshot = _serialize_instance(entity)
     current_fingerprint = _snapshot_fingerprint(effect.entity_type, current_snapshot)
     if current_fingerprint != fingerprint:

--- a/backend/services/invoice.py
+++ b/backend/services/invoice.py
@@ -4,10 +4,11 @@ from collections.abc import Sequence
 from datetime import UTC, date, datetime
 from decimal import Decimal
 
-from sqlalchemy import extract, select
+from sqlalchemy import delete, extract, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
+from backend.models.accounting_entry import AccountingEntry, EntrySourceType
 from backend.models.invoice import (
     Invoice,
     InvoiceLabel,
@@ -27,6 +28,10 @@ class InvoiceStatusError(Exception):
 
 class InvoiceDeleteError(Exception):
     """Raised when a non-draft invoice is deleted."""
+
+
+class InvoiceUpdateError(Exception):
+    """Raised when an invoice cannot be edited in its current business state."""
 
 
 # Valid transitions: from → set of allowed target statuses
@@ -230,6 +235,25 @@ async def list_invoices(
 
 async def update_invoice(db: AsyncSession, invoice: Invoice, payload: InvoiceUpdate) -> Invoice:
     """Update invoice fields. Recalculates total if lines are provided."""
+    refreshed_invoice = await get_invoice(db, invoice.id)
+    if refreshed_invoice is None:
+        raise InvoiceUpdateError("Invoice not found")
+    invoice = refreshed_invoice
+
+    if invoice.status != InvoiceStatus.DRAFT and not (
+        invoice.status == InvoiceStatus.SENT and invoice.paid_amount == Decimal("0")
+    ):
+        raise InvoiceUpdateError(f"Invoice in status '{invoice.status}' cannot be edited")
+
+    should_regenerate_entries = invoice.status == InvoiceStatus.SENT
+    if should_regenerate_entries:
+        await db.execute(
+            delete(AccountingEntry).where(
+                AccountingEntry.source_type == EntrySourceType.INVOICE,
+                AccountingEntry.source_id == invoice.id,
+            )
+        )
+
     for field in (
         "contact_id",
         "date",
@@ -289,6 +313,11 @@ async def update_invoice(db: AsyncSession, invoice: Invoice, payload: InvoiceUpd
     )
 
     invoice.updated_at = datetime.now(UTC)
+    if should_regenerate_entries:
+        from backend.services.accounting_engine import generate_entries_for_invoice  # noqa: PLC0415
+
+        await db.flush()
+        await generate_entries_for_invoice(db, invoice)
     invoice_id = invoice.id  # save before expire clears attributes
     await db.commit()
     db.expire(invoice)  # force selectinload to re-query lines from DB

--- a/backend/services/payment.py
+++ b/backend/services/payment.py
@@ -18,6 +18,10 @@ class InvoiceNotFoundError(LookupError):
     """Raised when a payment references an invoice that does not exist."""
 
 
+class PaymentDeleteError(ValueError):
+    """Raised when a payment deletion is not allowed in the standard workflow."""
+
+
 async def _attach_invoice_number(db: AsyncSession, payment: Payment) -> Payment:
     """Populate transient invoice metadata used by API responses."""
     result = await db.execute(
@@ -202,12 +206,8 @@ async def update_payment(db: AsyncSession, payment: Payment, payload: PaymentUpd
 
 
 async def delete_payment(db: AsyncSession, payment: Payment) -> None:
-    """Delete a payment and recalculate the invoice status."""
-    invoice_id = payment.invoice_id
-    await db.delete(payment)
-    await db.flush()
-    await _refresh_invoice_status(db, invoice_id)
-    await db.commit()
+    """Block payment deletion until a dedicated reversal workflow exists."""
+    raise PaymentDeleteError("payments cannot be deleted after creation")
 
 
 async def _get_invoice_type(db: AsyncSession, invoice_id: int) -> InvoiceType | None:

--- a/backend/services/payment.py
+++ b/backend/services/payment.py
@@ -246,22 +246,39 @@ def _validate_treasury_managed_payment_update(
     payment: Payment,
     payload: PaymentUpdate,
 ) -> None:
-    """Keep treasury-linked client payments immutable on fields that would desync journals."""
-    if invoice is None or invoice.type != InvoiceType.CLIENT:
-        return
-
-    if (
-        payment.method in (PaymentMethod.CHEQUE, PaymentMethod.ESPECES)
-        and payload.method is not None
-        and payload.method != payment.method
-    ):
-        raise ValueError("client cheque and cash payments cannot change method after creation")
-
-    if payment.method == PaymentMethod.ESPECES:
-        if payload.amount is not None and payload.amount != payment.amount:
+    """Keep created payments quasi-immutable to avoid desynchronising treasury/accounting flows."""
+    if payload.amount is not None and payload.amount != payment.amount:
+        if (
+            invoice is not None
+            and invoice.type == InvoiceType.CLIENT
+            and payment.method == PaymentMethod.ESPECES
+        ):
             raise ValueError("cash client payments cannot change amount after creation")
-        if payload.date is not None and payload.date != payment.date:
+        raise ValueError("payments cannot change amount after creation")
+
+    if payload.date is not None and payload.date != payment.date:
+        if (
+            invoice is not None
+            and invoice.type == InvoiceType.CLIENT
+            and payment.method == PaymentMethod.ESPECES
+        ):
             raise ValueError("cash client payments cannot change date after creation")
+        raise ValueError("payments cannot change date after creation")
+
+    if payload.method is not None and payload.method != payment.method:
+        if (
+            invoice is not None
+            and invoice.type == InvoiceType.CLIENT
+            and payment.method in (PaymentMethod.CHEQUE, PaymentMethod.ESPECES)
+        ):
+            raise ValueError("client cheque and cash payments cannot change method after creation")
+        raise ValueError("payments cannot change method after creation")
+
+    if payload.deposited is not None and payload.deposited != payment.deposited:
+        raise ValueError("payments cannot change deposit state after creation")
+
+    if payload.deposit_date is not None and payload.deposit_date != payment.deposit_date:
+        raise ValueError("payments cannot change deposit date after creation")
 
 
 async def _create_treasury_entries_for_payment(

--- a/doc/backlog.md
+++ b/doc/backlog.md
@@ -493,9 +493,9 @@ Tout sujet concret qui doit survivre au-delà de la séance en cours doit être 
 - **Point d'attention** : la traçabilité et la cohérence comptable doivent primer sur la simplicité apparente d'une édition directe, y compris quand la modification vient d'un rapprochement automatique entre imports `Gestion` et `Comptabilité`.
 - **Livré** :
 	- l'API facture autorise désormais l'édition d'une facture `sent` non réglée, avec régénération transactionnelle des écritures `INVOICE` dérivées ;
-	- l'API paiement rend les paiements quasi immuables après création, en ne laissant éditables que les champs mineurs sans impact structurel ;
+	- l'API paiement rend les paiements quasi immuables après création, en ne laissant éditables que les champs mineurs sans impact structurel et en bloquant la suppression standard ;
 	- l'UI des paiements reflète cette politique en verrouillant les champs structurels dans la boîte d'édition ;
-	- le rejeu strict des imports réversibles bloque bien `undo/redo` dès qu'un objet importé a divergé, avec un test d'intégration couvrant aussi le cas d'instance ORM expirée.
+	- le rejeu strict des imports réversibles bloque bien `undo/redo` dès qu'un objet importé a divergé, y compris après une retouche via l'API contact, avec un test d'intégration couvrant aussi le cas d'instance ORM expirée.
 - **Validation technique réalisée** : `ruff check .`, `ruff format --check .`, `mypy .`, `pytest tests/`, `npx vue-tsc --noEmit -p tsconfig.app.json`, `npx vue-tsc --noEmit`, `npx eslint src/` et `npx vitest run` sont passés localement sur la branche de travail.
 
 ## Prêt

--- a/doc/backlog.md
+++ b/doc/backlog.md
@@ -243,8 +243,9 @@ Tout sujet concret qui doit survivre au-delà de la séance en cours doit être 
 
 - **Dates** : `created=2026-04-13`
 - **Pourquoi** : le reset global actuel est utile pour les essais complets, mais il reste trop brutal quand on veut simplement rejouer une filière d'import, un exercice ou une séquence de reprise précise.
-- **Résultat attendu** : proposer un reset plus fin, compréhensible et sûr, capable de supprimer uniquement le périmètre utile à rejouer tout en explicitant le traitement des journaux d'import et des dépendances métier.
-- **Point d'attention** : ce sujet ne doit pas fragiliser l'intégrité des données ; il faut privilégier des scénarios de reset explicitement cadrés plutôt qu'un outil générique trop puissant.
+- **Recadrage après BL-004** : le cycle `prepare -> execute -> undo/redo` couvre désormais le cas standard de rejeu sûr pour les nouveaux imports réversibles, au niveau d'une opération ou d'un run complet. `BL-015` ne vise donc plus à rejouer ces imports normaux, mais les cas où le journal réversible ne suffit pas ou n'existe pas.
+- **Résultat attendu** : proposer un reset plus fin, compréhensible et sûr, capable de supprimer uniquement le périmètre utile à rejouer tout en explicitant le traitement des journaux d'import et des dépendances métier, en particulier pour les imports legacy, les données modifiées après coup qui bloquent un `undo` strict, ou les nettoyages administratifs ciblés par filière, période ou exercice.
+- **Point d'attention** : ce sujet ne doit pas fragiliser l'intégrité des données ; il faut privilégier des scénarios de reset explicitement cadrés plutôt qu'un outil générique trop puissant, et éviter tout chevauchement fonctionnel inutile avec le journal réversible de `BL-004`.
 
 ### BL-016 — Harmonisation i18n et microcopie UI
 
@@ -475,9 +476,13 @@ Tout sujet concret qui doit survivre au-delà de la séance en cours doit être 
 
 ### BL-030 — Politique de modification des objets métier validés
 
-- **Dates** : `created=2026-04-16`
+- **Dates** : `created=2026-04-16`, `started=2026-04-20`, `completed=2026-04-20`
 - **Pourquoi** : plusieurs objets métier ont déjà un cycle de vie implicite (`draft`, `sent`, `paid`, écritures auto-générées, imports historiques), mais la règle cible de modification reste floue dès qu'un objet a déjà produit des effets comptables ou des dépendances fonctionnelles.
 - **Résultat attendu** : une politique explicite qui dit, selon le type d'objet et son statut, ce qui est modifiable directement, ce qui doit régénérer des effets dérivés, ce qui doit être historisé, et ce qui doit être interdit ou remplacé par une opération métier distincte.
+- **Arbitrages actés au 2026-04-20** :
+	- une facture `sent` non réglée reste éditable, mais seulement avec garde-fous explicites et régénération contrôlée des effets dérivés ;
+	- un paiement devient quasi immuable après création ; hors besoin contraire plus tard, seules des corrections mineures sans impact structurel doivent rester possibles ;
+	- un objet issu d'un import puis retouché manuellement sort du `rejeu strict` de l'import réversible ; l'historique d'import reste consultable, mais `undo/redo` peut alors être bloqué par divergence d'état.
 - **Questions à trancher** :
 	- peut-on modifier librement une facture `draft`, `sent` ou `paid` ;
 	- faut-il régénérer, annuler puis recréer, ou historiser les écritures comptables dérivées après modification ;
@@ -486,6 +491,12 @@ Tout sujet concret qui doit survivre au-delà de la séance en cours doit être 
 	- qu'a-t-on le droit de réécrire automatiquement lorsqu'un import `Comptabilité` vient clarifier une facture créée plus tôt depuis `Gestion`.
 - **Critère d'acceptation** : pour chaque grande famille d'objets métier, un utilisateur et un développeur peuvent répondre sans ambiguïté à la question "que se passe-t-il si je modifie cet objet maintenant ?".
 - **Point d'attention** : la traçabilité et la cohérence comptable doivent primer sur la simplicité apparente d'une édition directe, y compris quand la modification vient d'un rapprochement automatique entre imports `Gestion` et `Comptabilité`.
+- **Livré** :
+	- l'API facture autorise désormais l'édition d'une facture `sent` non réglée, avec régénération transactionnelle des écritures `INVOICE` dérivées ;
+	- l'API paiement rend les paiements quasi immuables après création, en ne laissant éditables que les champs mineurs sans impact structurel ;
+	- l'UI des paiements reflète cette politique en verrouillant les champs structurels dans la boîte d'édition ;
+	- le rejeu strict des imports réversibles bloque bien `undo/redo` dès qu'un objet importé a divergé, avec un test d'intégration couvrant aussi le cas d'instance ORM expirée.
+- **Validation technique réalisée** : `ruff check .`, `ruff format --check .`, `mypy .`, `pytest tests/`, `npx vue-tsc --noEmit -p tsconfig.app.json`, `npx vue-tsc --noEmit`, `npx eslint src/` et `npx vitest run` sont passés localement sur la branche de travail.
 
 ## Prêt
 
@@ -519,4 +530,5 @@ Tout sujet concret qui doit survivre au-delà de la séance en cours doit être 
 - **BL-025** — `created=2026-04-13`, `started=2026-04-13`, `completed=2026-04-13` — Le grand livre est maintenant borné à l'exercice choisi, sans option multi-exercices, avec un solde d'ouverture cohérent quand la période démarre en cours d'exercice.
 - **BL-026** — `created=2026-04-15`, `started=2026-04-15`, `completed=2026-04-16` — Le ticket a livré un cadrage de recette et un constat exploitable sur la reprise `2024`, puis a été clos une fois les écarts résiduels requalifiés en différences de modélisation assumées ou en suites dédiées (`BL-008`, `BL-029`).
 - **BL-029** — `created=2026-04-16`, `started=2026-04-16`, `completed=2026-04-19` — La saisie des factures clients par lignes typées, le calcul dérivé du total et de la ventilation comptable, et les adaptations d'import `Gestion` / `Comptabilité` sont maintenant intégrés dans `develop` et validés côté recette métier utilisateur.
+- **BL-030** — `created=2026-04-16`, `started=2026-04-20`, `completed=2026-04-20` — La politique cadrée est désormais appliquée et testée : facture `sent` non réglée éditable avec régénération des écritures, paiements quasi immuables après création, et blocage du rejeu strict dès qu'un objet importé a divergé.
 - **BL-031** — `created=2026-04-19`, `started=2026-04-19`, `completed=2026-04-20` — La branche `feature/bl-031-bank-reconciliation` livre maintenant une vraie chaîne de rapprochement bancaire exploitable pour le MVP : import `CSV` / `OFX` / `QIF`, catégorisation initiale, suggestions de rapprochement, création ou confirmation de virements clients et fournisseurs depuis l'écran `Banque`, support des virements clients ventilés sur plusieurs règlements, traçabilité `transaction <-> payment(s)` et validation automatisée ciblée passée. Les écarts de recette encore observés, comme certains soldes banque, sont explicitement renvoyés à la recette finale de qualification MVP plutôt qu'à une suite bloquante de BL-031.

--- a/doc/dev/bl-030-politique-modification-objets-valides.md
+++ b/doc/dev/bl-030-politique-modification-objets-valides.md
@@ -23,12 +23,13 @@ La règle générale retenue est la suivante :
 
 - un paiement devient quasi immuable après création ;
 - les champs structurels (`montant`, `date`, `mode`, état de remise) ne sont plus modifiables ;
+- la suppression standard d'un paiement est interdite tant qu'aucun flux d'annulation métier dédié ne prend en charge proprement les effets de trésorerie et de comptabilité ;
 - seules des corrections mineures sans impact structurel restent autorisées : `reference`, `notes`, et `cheque_number` quand il s'agit d'un paiement par chèque.
 
 ## Imports réversibles
 
 - le `undo/redo` des imports réversibles reste strict ;
-- dès qu'un objet issu d'un import diverge manuellement de l'état attendu, le rejeu strict doit être bloqué ;
+- dès qu'un objet issu d'un import diverge manuellement de l'état attendu, y compris via l'API standard de l'objet, le rejeu strict doit être bloqué ;
 - la vérification stricte recharge explicitement l'instance ORM avant de calculer l'empreinte courante, afin d'éviter les faux comportements liés à des attributs expirés.
 
 ## Hors périmètre de ce lot

--- a/doc/dev/bl-030-politique-modification-objets-valides.md
+++ b/doc/dev/bl-030-politique-modification-objets-valides.md
@@ -1,0 +1,38 @@
+# BL-030 — Politique de modification des objets métier validés
+
+## But
+
+Formaliser les garde-fous d'édition quand un objet métier a déjà produit des effets dérivés.
+
+La règle générale retenue est la suivante :
+
+- édition libre tant qu'un objet reste préparatoire ;
+- édition encadrée avec régénération contrôlée quand l'objet a déjà déclenché des effets mais reste encore modifiable sans incohérence métier ;
+- interdiction d'édition directe quand l'objet a déjà été consommé par d'autres effets métier ou comptables.
+
+## Règles actuellement implémentées
+
+### Factures
+
+- une facture `draft` reste éditable librement ;
+- une facture `sent` non réglée reste éditable ;
+- quand une facture `sent` non réglée est modifiée, les écritures comptables auto-générées depuis cette facture sont supprimées puis régénérées dans le même flux transactionnel ;
+- une facture hors de ce périmètre (`paid`, `partial`, `overdue`, `disputed`) n'est plus modifiable directement.
+
+## Paiements
+
+- un paiement devient quasi immuable après création ;
+- les champs structurels (`montant`, `date`, `mode`, état de remise) ne sont plus modifiables ;
+- seules des corrections mineures sans impact structurel restent autorisées : `reference`, `notes`, et `cheque_number` quand il s'agit d'un paiement par chèque.
+
+## Imports réversibles
+
+- le `undo/redo` des imports réversibles reste strict ;
+- dès qu'un objet issu d'un import diverge manuellement de l'état attendu, le rejeu strict doit être bloqué ;
+- la vérification stricte recharge explicitement l'instance ORM avant de calculer l'empreinte courante, afin d'éviter les faux comportements liés à des attributs expirés.
+
+## Hors périmètre de ce lot
+
+- mécanismes dédiés d'annulation métier (`avoir`, annulation comptable, reverse de paiement) ;
+- matrice complète par statut pour tous les objets métier ;
+- journal d'audit métier explicite des modifications.

--- a/frontend/src/tests/views/PaymentsView.spec.ts
+++ b/frontend/src/tests/views/PaymentsView.spec.ts
@@ -136,6 +136,7 @@ const SelectStub = defineComponent({
     options: { type: Array, default: () => [] },
     optionLabel: { type: String, default: 'label' },
     optionValue: { type: String, default: 'value' },
+    disabled: { type: Boolean, default: false },
   },
   emits: ['update:modelValue', 'change'],
   setup(props, { attrs, emit }) {
@@ -145,6 +146,7 @@ const SelectStub = defineComponent({
         {
           'data-testid': attrs['data-testid'],
           value: props.modelValue ?? '',
+          disabled: props.disabled,
           onChange: (event: Event) => {
             const value = (event.target as HTMLSelectElement).value || undefined
             emit('update:modelValue', value)
@@ -338,14 +340,23 @@ describe('PaymentsView', () => {
 
     expect(mockUpdatePayment).toHaveBeenCalledWith(
       1,
-      expect.objectContaining({
-        amount: '60.00',
-        date: '2025-02-01',
-        method: 'cheque',
+      {
         cheque_number: 'CHQ-001',
         reference: 'REF-2025-002',
         notes: 'Premier reglement',
-      }),
+      },
     )
+  })
+
+  it('locks structural payment fields in the edit dialog', async () => {
+    const wrapper = mountView()
+    await flushView()
+
+    await wrapper.get('[data-testid="payment-edit-button"]').trigger('click')
+    await flushView()
+
+    expect(wrapper.get('input[type="date"]').element).toHaveProperty('disabled', true)
+    expect(wrapper.get('input[type="number"]').element).toHaveProperty('disabled', true)
+    expect(wrapper.get('select').element).toHaveProperty('disabled', true)
   })
 })

--- a/frontend/src/views/PaymentsView.vue
+++ b/frontend/src/views/PaymentsView.vue
@@ -214,7 +214,7 @@
         <div class="app-form-grid">
           <div class="app-field">
             <label class="app-field__label">{{ t('payments.date') }}</label>
-            <InputText v-model="paymentForm.date" type="date" :disabled="isCashPaymentLocked" />
+            <InputText v-model="paymentForm.date" type="date" disabled />
           </div>
           <div class="app-field">
             <label class="app-field__label">{{ t('payments.amount') }}</label>
@@ -223,7 +223,7 @@
               type="number"
               step="0.01"
               min="0.01"
-              :disabled="isCashPaymentLocked"
+              disabled
             />
           </div>
           <div class="app-field">
@@ -233,7 +233,7 @@
               :options="editableMethodOptions"
               option-label="label"
               option-value="value"
-              :disabled="isClientPaymentMethodLocked"
+              disabled
             />
           </div>
           <div class="app-field">
@@ -386,15 +386,6 @@ const editableMethodOptions = computed(() => {
 
   return allMethodOptions.value
 })
-const isClientPaymentMethodLocked = computed(
-  () =>
-    editingPayment.value?.invoice_type === 'client' &&
-    (editingPayment.value.method === 'especes' || editingPayment.value.method === 'cheque'),
-)
-const isCashPaymentLocked = computed(
-  () =>
-    editingPayment.value?.invoice_type === 'client' && editingPayment.value.method === 'especes',
-)
 const yesNoOptions = computed(() => [
   { label: t('common.yes'), value: true },
   { label: t('common.no'), value: false },
@@ -432,9 +423,6 @@ async function savePayment() {
   saving.value = true
   try {
     await updatePayment(editingPayment.value.id, {
-      amount: paymentForm.value.amount,
-      date: paymentForm.value.date,
-      method: paymentForm.value.method,
       cheque_number:
         paymentForm.value.method === 'cheque'
           ? normalizeOptionalField(paymentForm.value.cheque_number)

--- a/frontend/src/views/PaymentsView.vue
+++ b/frontend/src/views/PaymentsView.vue
@@ -187,13 +187,6 @@
               text
               @click="openEditDialog(data)"
             />
-            <Button
-              icon="pi pi-trash"
-              size="small"
-              severity="danger"
-              text
-              @click="confirmDelete(data)"
-            />
           </template>
         </Column>
         <template #empty>
@@ -201,9 +194,6 @@
         </template>
       </DataTable>
     </AppPanel>
-
-    <ConfirmDialog />
-
     <Dialog
       v-model:visible="dialogVisible"
       :header="t('payments.edit')"
@@ -270,19 +260,16 @@
 <script setup lang="ts">
 import Button from 'primevue/button'
 import Column from 'primevue/column'
-import ConfirmDialog from 'primevue/confirmdialog'
 import DataTable from 'primevue/datatable'
 import Dialog from 'primevue/dialog'
 import InputText from 'primevue/inputtext'
 import Select from 'primevue/select'
 import Tag from 'primevue/tag'
 import ToggleButton from 'primevue/togglebutton'
-import { useConfirm } from 'primevue/useconfirm'
 import { useToast } from 'primevue/usetoast'
 import { computed, onMounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import {
-  deletePayment,
   listPayments,
   updatePayment,
   type Payment,
@@ -308,7 +295,6 @@ import {
 } from '../composables/useDataTableFilters'
 
 const { t } = useI18n()
-const confirm = useConfirm()
 const toast = useToast()
 const fiscalYearStore = useFiscalYearStore()
 
@@ -454,21 +440,6 @@ async function loadPayments() {
   } finally {
     loading.value = false
   }
-}
-
-function confirmDelete(payment: Payment) {
-  confirm.require({
-    message: t('payments.confirm_delete', { amount: parseFloat(payment.amount).toFixed(2) }),
-    header: t('common.confirm'),
-    icon: 'pi pi-exclamation-triangle',
-    acceptProps: { severity: 'danger', label: t('common.delete') },
-    rejectProps: { severity: 'secondary', outlined: true, label: t('common.cancel') },
-    accept: async () => {
-      await deletePayment(payment.id)
-      toast.add({ severity: 'success', summary: t('payments.deleted'), life: 2000 })
-      await loadPayments()
-    },
-  })
 }
 
 watch(

--- a/tests/integration/test_import_api.py
+++ b/tests/integration/test_import_api.py
@@ -1678,8 +1678,14 @@ async def test_reversible_import_run_undo_rejects_manually_modified_object(
         await db_session.execute(select(Contact).where(Contact.nom == "LOPES"))
     ).scalar_one()
 
-    imported_contact.notes = "Retouche manuelle"
-    await db_session.commit()
+    update_response = await client.put(
+        f"/api/contacts/{imported_contact.id}",
+        json={"notes": "Retouche manuelle"},
+        headers=auth_headers,
+    )
+
+    assert update_response.status_code == 200
+    assert update_response.json()["notes"] == "Retouche manuelle"
 
     undo_response = await client.post(
         f"/api/import/runs/{run_id}/undo",

--- a/tests/integration/test_import_api.py
+++ b/tests/integration/test_import_api.py
@@ -1645,6 +1645,53 @@ async def test_reversible_import_operation_undo_redo_targets_single_prepared_eff
 
 @pytest.mark.asyncio
 @pytest.mark.skipif(not OPENPYXL_AVAILABLE, reason="openpyxl not installed")
+async def test_reversible_import_run_undo_rejects_manually_modified_object(
+    client: AsyncClient, auth_headers: dict, db_session
+) -> None:
+    """Undo must fail once an imported object diverged from the expected strict state."""
+    from backend.models.contact import Contact
+
+    content = _make_multi_sheet_xlsx(
+        {
+            "Contacts": (
+                ["Nom", "Email"],
+                [["Christine LOPES", "christine@example.test"]],
+            )
+        }
+    )
+
+    prepare_response = await client.post(
+        "/api/import/runs/prepare/gestion",
+        files={"file": ("Gestion 2025.xlsx", content, _XLSX_MIME)},
+        headers=auth_headers,
+    )
+    run_id = prepare_response.json()["id"]
+
+    execute_response = await client.post(
+        f"/api/import/runs/{run_id}/execute",
+        headers=auth_headers,
+    )
+
+    assert execute_response.status_code == 200
+
+    imported_contact = (
+        await db_session.execute(select(Contact).where(Contact.nom == "LOPES"))
+    ).scalar_one()
+
+    imported_contact.notes = "Retouche manuelle"
+    await db_session.commit()
+
+    undo_response = await client.post(
+        f"/api/import/runs/{run_id}/undo",
+        headers=auth_headers,
+    )
+
+    assert undo_response.status_code == 409
+    assert undo_response.json()["detail"] == "L'état courant ne correspond plus à l'état attendu"
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not OPENPYXL_AVAILABLE, reason="openpyxl not installed")
 async def test_preview_and_import_gestion_accept_payment_matched_by_contact(
     client: AsyncClient, auth_headers: dict
 ) -> None:

--- a/tests/integration/test_invoices_api.py
+++ b/tests/integration/test_invoices_api.py
@@ -177,6 +177,129 @@ class TestUpdateInvoice:
         assert r.status_code == 200
         assert r.json()["description"] == "Updated"
 
+    async def test_update_sent_invoice_regenerates_accounting_entries(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        db_session,
+    ):
+        await seed_default_rules(db_session)
+        cid = await _create_contact(client, auth_headers)
+        created = await _create_invoice(
+            client,
+            auth_headers,
+            cid,
+            lines=[
+                {
+                    "description": "Cours de soutien",
+                    "line_type": "cours",
+                    "quantity": "1",
+                    "unit_price": "130.00",
+                },
+                {
+                    "description": "Adhesion annuelle",
+                    "line_type": "adhesion",
+                    "quantity": "1",
+                    "unit_price": "30.00",
+                },
+            ],
+        )
+        sent_response = await client.patch(
+            f"/api/invoices/{created['id']}/status",
+            json={"status": "sent"},
+            headers=auth_headers,
+        )
+        assert sent_response.status_code == 200
+
+        initial_entries = list(
+            (
+                await db_session.execute(
+                    select(AccountingEntry)
+                    .where(AccountingEntry.source_type == EntrySourceType.INVOICE)
+                    .where(AccountingEntry.source_id == created["id"])
+                    .order_by(AccountingEntry.entry_number.asc())
+                )
+            ).scalars()
+        )
+        assert len(initial_entries) == 3
+
+        update_response = await client.put(
+            f"/api/invoices/{created['id']}",
+            json={
+                "lines": [
+                    {
+                        "description": "Cours de soutien",
+                        "line_type": "cours",
+                        "quantity": "1",
+                        "unit_price": "150.00",
+                    }
+                ]
+            },
+            headers=auth_headers,
+        )
+
+        assert update_response.status_code == 200
+        assert update_response.json()["total_amount"] == "150.00"
+
+        regenerated_entries = list(
+            (
+                await db_session.execute(
+                    select(AccountingEntry)
+                    .where(AccountingEntry.source_type == EntrySourceType.INVOICE)
+                    .where(AccountingEntry.source_id == created["id"])
+                    .order_by(AccountingEntry.entry_number.asc())
+                )
+            ).scalars()
+        )
+        assert len(regenerated_entries) == 2
+        assert any(entry.debit == Decimal("150.00") for entry in regenerated_entries)
+        assert any(entry.credit == Decimal("150.00") for entry in regenerated_entries)
+
+    async def test_update_paid_invoice_returns_conflict(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+    ):
+        cid = await _create_contact(client, auth_headers)
+        created = await _create_invoice(
+            client,
+            auth_headers,
+            cid,
+            lines=[
+                {
+                    "description": "Cours de soutien",
+                    "line_type": "cours",
+                    "quantity": "1",
+                    "unit_price": "130.00",
+                }
+            ],
+        )
+        await client.patch(
+            f"/api/invoices/{created['id']}/status",
+            json={"status": "sent"},
+            headers=auth_headers,
+        )
+        payment_response = await client.post(
+            "/api/payments/",
+            json={
+                "invoice_id": created["id"],
+                "contact_id": cid,
+                "amount": "130.00",
+                "date": "2025-09-02",
+                "method": "cheque",
+            },
+            headers=auth_headers,
+        )
+        assert payment_response.status_code == 201
+
+        update_response = await client.put(
+            f"/api/invoices/{created['id']}",
+            json={"description": "Updated"},
+            headers=auth_headers,
+        )
+
+        assert update_response.status_code == 409
+
 
 class TestStatusChange:
     async def test_draft_to_sent(self, client: AsyncClient, auth_headers: dict):

--- a/tests/integration/test_payments_api.py
+++ b/tests/integration/test_payments_api.py
@@ -356,10 +356,11 @@ async def test_delete_payment(
     payment_id = create_resp.json()["id"]
 
     del_resp = await client.delete(f"/api/payments/{payment_id}", headers=auth_headers)
-    assert del_resp.status_code == 204
+    assert del_resp.status_code == 409
+    assert del_resp.json()["detail"] == "payments cannot be deleted after creation"
 
     get_resp = await client.get(f"/api/payments/{payment_id}", headers=auth_headers)
-    assert get_resp.status_code == 404
+    assert get_resp.status_code == 200
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_payments_api.py
+++ b/tests/integration/test_payments_api.py
@@ -177,9 +177,44 @@ async def test_update_payment(
         json={"amount": "80.00", "reference": "REF-2024-001"},
         headers=auth_headers,
     )
+    assert update_resp.status_code == 400
+    assert update_resp.json()["detail"] == "payments cannot change amount after creation"
+
+
+@pytest.mark.asyncio
+async def test_update_payment_allows_minor_fields(
+    client: AsyncClient, db_session: AsyncSession, admin_user: User, auth_headers: dict
+) -> None:
+    contact_id, invoice_id = await _setup_contact_invoice(db_session)
+    create_resp = await client.post(
+        "/api/payments/",
+        json={
+            "invoice_id": invoice_id,
+            "contact_id": contact_id,
+            "amount": "60.00",
+            "date": "2024-03-01",
+            "method": "cheque",
+            "cheque_number": "CHQ-001",
+        },
+        headers=auth_headers,
+    )
+    payment_id = create_resp.json()["id"]
+
+    update_resp = await client.put(
+        f"/api/payments/{payment_id}",
+        json={
+            "cheque_number": "CHQ-002",
+            "reference": "REF-2024-001",
+            "notes": "Correction mineure",
+        },
+        headers=auth_headers,
+    )
+
     assert update_resp.status_code == 200
-    assert update_resp.json()["amount"] == "80.00"
+    assert update_resp.json()["amount"] == "60.00"
+    assert update_resp.json()["cheque_number"] == "CHQ-002"
     assert update_resp.json()["reference"] == "REF-2024-001"
+    assert update_resp.json()["notes"] == "Correction mineure"
 
 
 @pytest.mark.asyncio
@@ -272,6 +307,34 @@ async def test_update_cash_payment_rejects_amount_change(
     assert (
         update_resp.json()["detail"] == "cash client payments cannot change amount after creation"
     )
+
+
+@pytest.mark.asyncio
+async def test_update_cheque_payment_rejects_date_change(
+    client: AsyncClient, db_session: AsyncSession, admin_user: User, auth_headers: dict
+) -> None:
+    contact_id, invoice_id = await _setup_contact_invoice(db_session)
+    create_resp = await client.post(
+        "/api/payments/",
+        json={
+            "invoice_id": invoice_id,
+            "contact_id": contact_id,
+            "amount": "60.00",
+            "date": "2024-03-01",
+            "method": "cheque",
+        },
+        headers=auth_headers,
+    )
+    payment_id = create_resp.json()["id"]
+
+    update_resp = await client.put(
+        f"/api/payments/{payment_id}",
+        json={"date": "2024-03-05"},
+        headers=auth_headers,
+    )
+
+    assert update_resp.status_code == 400
+    assert update_resp.json()["detail"] == "payments cannot change date after creation"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_invoice_service.py
+++ b/tests/unit/test_invoice_service.py
@@ -4,14 +4,19 @@ from datetime import date
 from decimal import Decimal
 
 import pytest
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from backend.models.accounting_entry import AccountingEntry, EntrySourceType
 from backend.models.contact import Contact, ContactType
 from backend.models.invoice import InvoiceLabel, InvoiceLineType, InvoiceStatus, InvoiceType
 from backend.schemas.invoice import InvoiceCreate, InvoiceLineCreate, InvoiceUpdate
+from backend.schemas.payment import PaymentCreate
+from backend.services.accounting_engine import seed_default_rules
 from backend.services.invoice import (
     InvoiceDeleteError,
     InvoiceStatusError,
+    InvoiceUpdateError,
     create_invoice,
     delete_invoice,
     duplicate_invoice,
@@ -20,6 +25,7 @@ from backend.services.invoice import (
     update_invoice,
     update_invoice_status,
 )
+from backend.services.payment import create_payment
 
 
 async def _make_contact(db: AsyncSession, nom: str = "Test") -> Contact:
@@ -373,6 +379,116 @@ class TestUpdateInvoice:
         )
 
         assert updated.has_explicit_breakdown is False
+
+    async def test_update_sent_invoice_regenerates_generated_entries(
+        self, db_session: AsyncSession
+    ):
+        await seed_default_rules(db_session)
+        contact = await _make_contact(db_session)
+        invoice = await create_invoice(
+            db_session,
+            InvoiceCreate(
+                type=InvoiceType.CLIENT,
+                contact_id=contact.id,
+                date=date(2025, 9, 1),
+                lines=[
+                    InvoiceLineCreate(
+                        description="Cours",
+                        quantity=Decimal("1"),
+                        unit_price=Decimal("130.00"),
+                    ),
+                    InvoiceLineCreate(
+                        description="Adhésion",
+                        quantity=Decimal("1"),
+                        unit_price=Decimal("30.00"),
+                    ),
+                ],
+            ),
+        )
+        await update_invoice_status(db_session, invoice, InvoiceStatus.SENT)
+
+        initial_entries = list(
+            (
+                await db_session.execute(
+                    select(AccountingEntry)
+                    .where(AccountingEntry.source_type == EntrySourceType.INVOICE)
+                    .where(AccountingEntry.source_id == invoice.id)
+                    .order_by(AccountingEntry.entry_number.asc())
+                )
+            ).scalars()
+        )
+        assert len(initial_entries) == 3
+
+        updated = await update_invoice(
+            db_session,
+            invoice,
+            InvoiceUpdate(
+                lines=[
+                    InvoiceLineCreate(
+                        description="Cours",
+                        quantity=Decimal("1"),
+                        unit_price=Decimal("150.00"),
+                    )
+                ]
+            ),
+        )
+
+        regenerated_entries = list(
+            (
+                await db_session.execute(
+                    select(AccountingEntry)
+                    .where(AccountingEntry.source_type == EntrySourceType.INVOICE)
+                    .where(AccountingEntry.source_id == invoice.id)
+                    .order_by(AccountingEntry.entry_number.asc())
+                )
+            ).scalars()
+        )
+
+        assert updated.status == InvoiceStatus.SENT
+        assert updated.total_amount == Decimal("150.00")
+        assert len(regenerated_entries) == 2
+        assert {entry.account_number for entry in regenerated_entries} == {"411100", "706110"}
+        assert any(entry.debit == Decimal("150.00") for entry in regenerated_entries)
+        assert any(entry.credit == Decimal("150.00") for entry in regenerated_entries)
+
+    async def test_update_paid_invoice_is_blocked(self, db_session: AsyncSession):
+        contact = await _make_contact(db_session)
+        invoice = await create_invoice(
+            db_session,
+            InvoiceCreate(
+                type=InvoiceType.CLIENT,
+                contact_id=contact.id,
+                date=date(2025, 9, 1),
+                lines=[
+                    InvoiceLineCreate(
+                        description="Cours",
+                        quantity=Decimal("1"),
+                        unit_price=Decimal("130.00"),
+                    )
+                ],
+            ),
+        )
+        await update_invoice_status(db_session, invoice, InvoiceStatus.SENT)
+        await create_payment(
+            db_session,
+            PaymentCreate(
+                invoice_id=invoice.id,
+                contact_id=contact.id,
+                amount=Decimal("130.00"),
+                date=date(2025, 9, 2),
+                method="cheque",
+            ),
+        )
+        refreshed = await get_invoice(db_session, invoice.id)
+        assert refreshed is not None
+        assert refreshed.status == InvoiceStatus.PAID
+
+        with pytest.raises(InvoiceUpdateError, match="cannot be edited"):
+            await update_invoice(
+                db_session,
+                refreshed,
+                InvoiceUpdate(description="Nouvelle description"),
+            )
 
 
 class TestStatusChange:

--- a/tests/unit/test_payment_service.py
+++ b/tests/unit/test_payment_service.py
@@ -363,12 +363,67 @@ async def test_update_payment(db_session: AsyncSession) -> None:
             method=PaymentMethod.CHEQUE,
         ),
     )
-    updated = await payment_service.update_payment(
-        db_session, p, PaymentUpdate(amount=Decimal("100.00"))
+    with pytest.raises(ValueError, match="payments cannot change amount after creation"):
+        await payment_service.update_payment(db_session, p, PaymentUpdate(amount=Decimal("100.00")))
+
+
+@pytest.mark.asyncio
+async def test_update_payment_allows_minor_reference_and_notes_changes(
+    db_session: AsyncSession,
+) -> None:
+    contact = await _make_contact(db_session)
+    inv = await _make_invoice(db_session, contact.id, Decimal("100.00"))
+    p = await payment_service.create_payment(
+        db_session,
+        PaymentCreate(
+            invoice_id=inv.id,
+            contact_id=contact.id,
+            amount=Decimal("50.00"),
+            date=date(2024, 2, 1),
+            method=PaymentMethod.CHEQUE,
+            cheque_number="CHQ-001",
+        ),
     )
-    assert updated.amount == Decimal("100.00")
-    await db_session.refresh(inv)
-    assert inv.status == InvoiceStatus.PAID
+
+    updated = await payment_service.update_payment(
+        db_session,
+        p,
+        PaymentUpdate(
+            cheque_number="CHQ-002",
+            reference="REF-2024-001",
+            notes="Correction mineure",
+        ),
+    )
+
+    assert updated.amount == Decimal("50.00")
+    assert updated.date == date(2024, 2, 1)
+    assert updated.method == PaymentMethod.CHEQUE
+    assert updated.cheque_number == "CHQ-002"
+    assert updated.reference == "REF-2024-001"
+    assert updated.notes == "Correction mineure"
+
+
+@pytest.mark.asyncio
+async def test_update_cheque_payment_rejects_date_change(db_session: AsyncSession) -> None:
+    contact = await _make_contact(db_session)
+    inv = await _make_invoice(db_session, contact.id, Decimal("100.00"))
+    payment = await payment_service.create_payment(
+        db_session,
+        PaymentCreate(
+            invoice_id=inv.id,
+            contact_id=contact.id,
+            amount=Decimal("40.00"),
+            date=date(2024, 2, 1),
+            method=PaymentMethod.CHEQUE,
+        ),
+    )
+
+    with pytest.raises(ValueError, match="payments cannot change date after creation"):
+        await payment_service.update_payment(
+            db_session,
+            payment,
+            PaymentUpdate(date=date(2024, 2, 5)),
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_payment_service.py
+++ b/tests/unit/test_payment_service.py
@@ -443,9 +443,11 @@ async def test_delete_payment_reverts_invoice(db_session: AsyncSession) -> None:
     await db_session.refresh(inv)
     assert inv.status == InvoiceStatus.PAID
 
-    await payment_service.delete_payment(db_session, p)
+    with pytest.raises(ValueError, match="payments cannot be deleted after creation"):
+        await payment_service.delete_payment(db_session, p)
+
     await db_session.refresh(inv)
-    assert inv.status == InvoiceStatus.SENT
+    assert inv.status == InvoiceStatus.PAID
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- enforce guarded invoice updates so only `draft` and unpaid `sent` invoices remain editable, with automatic regeneration of generated invoice accounting entries
- make payments quasi immutable after creation, keeping only minor metadata fields editable and aligning the payments UI with that restriction
- keep reversible import undo/redo strict when an imported object diverged manually, including the expired ORM instance case
- document the delivered BL-030 policy in the changelog, backlog and developer documentation

## Testing
- `ruff check .`
- `ruff format --check .`
- `mypy .`
- `pytest tests/`
- `npx vue-tsc --noEmit -p tsconfig.app.json`
- `npx vue-tsc --noEmit`
- `npx eslint src/`
- `npx vitest run`

## Summary by Sourcery

Enforce stricter business rules for editing validated domain objects, particularly invoices, payments, and reversible imports, and align API, services, tests, UI, and documentation with the new policy.

Bug Fixes:
- Prevent undo/redo of reversible imports once an imported object has been manually modified, including when ORM instances were previously expired.

Enhancements:
- Restrict invoice updates so only drafts and unpaid sent invoices remain editable, with automatic regeneration of invoice-based accounting entries when sent invoices are changed.
- Make payments quasi-immutable after creation by forbidding structural field changes (amount, date, method, deposit state) while allowing minor metadata edits only.
- Lock structural payment fields in the payments UI edit dialog to reflect backend immutability rules and limit updates to non-structural metadata.

Documentation:
- Document the BL-030 editing policy for validated business objects in the developer docs, backlog, and changelog, including the new rules for invoices, payments, and reversible imports.

Tests:
- Add unit and integration tests covering guarded invoice updates, payment immutability and allowed minor edits, UI locking of payment fields, and strict reversible-import undo behavior after manual divergence.