### PR TITLE
Add selective import reset and harden reversible runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ Ce projet respecte le [Versionnage sémantique](https://semver.org/lang/fr/).
 - Espace `Mon profil` permettant à chaque utilisateur authentifié de consulter son compte, de mettre à jour son e-mail et de changer son mot de passe
 - Procédure de réinitialisation d'accès par l'administrateur avec mot de passe temporaire pour le contexte auto-hébergé
 
+**Administration des reprises d'import**
+- Reset sélectif de reprise dans `Paramètres` avec prévisualisation puis suppression confirmée d'un périmètre `Gestion` ou `Comptabilite` borné à un exercice
+- Plan de suppression construit à partir des traces d'import (`import_logs` legacy et `import_runs` réversibles) et enrichi, côté `Gestion`, par les dépendances métier dérivées créées ensuite dans Solde
+- Documentation utilisateur consolidée pour expliquer la place respective de l'historique réversible, du reset sélectif et de la réinitialisation complète
+
 **Frontend — filtre générique**
 - Composable `useTableFilter` + `applyFilter` (`composables/useTableFilter.ts`) : filtre client-side fuzzy sur tous les champs d'un tableau
 - Champ de recherche générique ajouté dans les 11 écrans avec DataTable : Paiements, Exercices, Règles comptables, Plan comptable, Journal, Balance, Salaires, Factures clients, Factures fournisseurs, Banque (transactions + remises), Caisse (journal + comptages)

--- a/backend/routers/excel_import.py
+++ b/backend/routers/excel_import.py
@@ -135,6 +135,9 @@ def _get_test_import_shortcut_by_alias(alias: str) -> _TestImportShortcut:
 async def _run_test_import_shortcut(
     shortcut: _TestImportShortcut,
     db: AsyncSession,
+    *,
+    comparison_start_date: date | None = None,
+    comparison_end_date: date | None = None,
 ) -> dict[str, object]:
     if shortcut.file_path is None:
         raise HTTPException(
@@ -145,11 +148,22 @@ async def _run_test_import_shortcut(
     path = Path(shortcut.file_path)
     _check_excel_extension(path.name)
     content = _read_path_limited(path)
-    if shortcut.import_type == "gestion":
-        result = await excel_import.import_gestion_file(db, content, path.name)
-    else:
-        result = await excel_import.import_comptabilite_file(db, content, path.name)
-    return result.to_dict()
+    try:
+        run = await import_reversible.prepare_import_run(
+            db,
+            import_type=shortcut.import_type,
+            file_bytes=content,
+            file_name=path.name,
+            comparison_start_date=comparison_start_date,
+            comparison_end_date=comparison_end_date,
+        )
+        serialized_run = import_reversible.serialize_run(run)
+        if serialized_run["can_execute"]:
+            run = await import_reversible.execute_import_run(db, run.id)
+            serialized_run = import_reversible.serialize_run(run)
+    except Exception as exc:  # pragma: no cover - delegated mapping below
+        _raise_import_run_error(exc)
+    return serialized_run
 
 
 def _raise_import_run_error(exc: Exception) -> NoReturn:
@@ -427,8 +441,24 @@ async def run_test_import_shortcut(
     alias: str,
     db: Annotated[AsyncSession, Depends(get_db)],
     _: _WriteAccess,
+    comparison_start_date: date | None = None,
+    comparison_end_date: date | None = None,
 ) -> dict[str, object]:
     """Run a temporary dev-only import shortcut without preview confirmation."""
     _require_test_import_shortcuts_enabled()
+    if (
+        comparison_start_date is not None
+        and comparison_end_date is not None
+        and comparison_start_date > comparison_end_date
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail="La date de début doit être inférieure ou égale à la date de fin",
+        )
     shortcut = _get_test_import_shortcut_by_alias(alias)
-    return await _run_test_import_shortcut(shortcut, db)
+    return await _run_test_import_shortcut(
+        shortcut,
+        db,
+        comparison_start_date=comparison_start_date,
+        comparison_end_date=comparison_end_date,
+    )

--- a/backend/routers/settings.py
+++ b/backend/routers/settings.py
@@ -11,6 +11,8 @@ from backend.routers.auth import require_role
 from backend.schemas.settings import (
     AppSettingsRead,
     AppSettingsUpdate,
+    SelectiveResetPreviewRead,
+    SelectiveResetRequest,
     TreasurySystemOpeningRead,
     TreasurySystemOpeningUpdate,
 )
@@ -69,6 +71,26 @@ async def reset_db(
     Intended for demos and user-acceptance testing.
     """
     return await settings_service.reset_data(db)
+
+
+@router.post("/selective-reset/preview", response_model=SelectiveResetPreviewRead)
+async def preview_selective_reset(
+    payload: SelectiveResetRequest,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    _current_user: _AdminRequired,
+) -> SelectiveResetPreviewRead:
+    """Preview the objects that would be deleted by a selective import reset."""
+    return await settings_service.preview_selective_reset(db, payload)
+
+
+@router.post("/selective-reset/apply", response_model=SelectiveResetPreviewRead)
+async def apply_selective_reset(
+    payload: SelectiveResetRequest,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    _current_user: _AdminRequired,
+) -> SelectiveResetPreviewRead:
+    """Apply a selective import reset for one import type and one fiscal year."""
+    return await settings_service.apply_selective_reset(db, payload)
 
 
 @router.post("/bootstrap-accounting", response_model=dict[str, int])

--- a/backend/routers/settings.py
+++ b/backend/routers/settings.py
@@ -1,8 +1,8 @@
 """Settings API router — GET/PUT /api/settings (admin only)."""
 
-from typing import Annotated
+from typing import Annotated, NoReturn
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.database import get_db
@@ -21,6 +21,17 @@ from backend.services import settings as settings_service
 router = APIRouter(prefix="/settings", tags=["settings"])
 
 _AdminRequired = Annotated[User, Depends(require_role(UserRole.ADMIN))]
+
+
+def _raise_selective_reset_error(exc: Exception) -> NoReturn:
+    if isinstance(exc, LookupError):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    if isinstance(exc, ValueError):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=str(exc),
+        ) from exc
+    raise exc
 
 
 @router.get("/", response_model=AppSettingsRead)
@@ -80,7 +91,10 @@ async def preview_selective_reset(
     _current_user: _AdminRequired,
 ) -> SelectiveResetPreviewRead:
     """Preview the objects that would be deleted by a selective import reset."""
-    return await settings_service.preview_selective_reset(db, payload)
+    try:
+        return await settings_service.preview_selective_reset(db, payload)
+    except Exception as exc:  # pragma: no cover - delegated mapping below
+        _raise_selective_reset_error(exc)
 
 
 @router.post("/selective-reset/apply", response_model=SelectiveResetPreviewRead)
@@ -90,7 +104,10 @@ async def apply_selective_reset(
     _current_user: _AdminRequired,
 ) -> SelectiveResetPreviewRead:
     """Apply a selective import reset for one import type and one fiscal year."""
-    return await settings_service.apply_selective_reset(db, payload)
+    try:
+        return await settings_service.apply_selective_reset(db, payload)
+    except Exception as exc:  # pragma: no cover - delegated mapping below
+        _raise_selective_reset_error(exc)
 
 
 @router.post("/bootstrap-accounting", response_model=dict[str, int])

--- a/backend/schemas/settings.py
+++ b/backend/schemas/settings.py
@@ -7,6 +7,8 @@ from decimal import Decimal as _Decimal
 
 from pydantic import BaseModel, field_validator
 
+from backend.models.import_log import ImportLogType
+
 
 class AppSettingsRead(BaseModel):
     """Settings returned by GET /api/settings.
@@ -88,3 +90,21 @@ class SystemOpeningUpdate(BaseModel):
 class TreasurySystemOpeningUpdate(BaseModel):
     bank: SystemOpeningUpdate
     cash: SystemOpeningUpdate
+
+
+class SelectiveResetRequest(BaseModel):
+    import_type: ImportLogType
+    fiscal_year_id: int
+
+
+class SelectiveResetPreviewRead(BaseModel):
+    import_type: ImportLogType
+    fiscal_year_id: int
+    fiscal_year_name: str
+    fiscal_year_start_date: _Date
+    fiscal_year_end_date: _Date
+    matched_import_logs: int
+    matched_import_runs: int
+    root_objects: dict[str, int]
+    derived_objects: dict[str, int]
+    delete_plan: dict[str, int]

--- a/backend/services/excel_import.py
+++ b/backend/services/excel_import.py
@@ -4873,22 +4873,26 @@ async def _add_gestion_existing_rows_preview(
             parsed_sheet, salary_rows, _ = _parse_salary_sheet(ws)
             if parsed_sheet is None or parsed_sheet.missing_columns:
                 continue
-            ignored_issues = [
-                RowIgnoredIssue(
-                    source_row_number=salary_row.source_row_number,
-                    message=EXISTING_SALARY_MESSAGE,
-                )
-                for salary_row in salary_rows
-                if (salary_row.month, _salary_employee_key(salary_row.employee_name))
-                in existing_salary_keys
-            ]
-            for ignored_issue in ignored_issues:
+            salary_ignored_issues: list[RowIgnoredIssue] = []
+            seen_salary_keys = set(existing_salary_keys)
+            for salary_row in salary_rows:
+                salary_key = (salary_row.month, _salary_employee_key(salary_row.employee_name))
+                if salary_key in seen_salary_keys:
+                    salary_ignored_issues.append(
+                        RowIgnoredIssue(
+                            source_row_number=salary_row.source_row_number,
+                            message=EXISTING_SALARY_MESSAGE,
+                        )
+                    )
+                    continue
+                seen_salary_keys.add(salary_key)
+            for ignored_issue in salary_ignored_issues:
                 _append_preview_ignored_issue(
                     preview,
                     sheet_preview,
                     ignored_issue,
                 )
-            if ignored_count := len(ignored_issues):
+            if ignored_count := len(salary_ignored_issues):
                 sheet_preview["rows"] = max(0, sheet_preview["rows"] - ignored_count)
                 preview.estimated_salaries = max(0, preview.estimated_salaries - ignored_count)
 

--- a/backend/services/import_reversible.py
+++ b/backend/services/import_reversible.py
@@ -67,6 +67,7 @@ from backend.services.excel_import_policy import (
     ENTRY_COVERED_BY_SOLDE_MESSAGE,
     ENTRY_EXISTING_MESSAGE,
     ENTRY_NEAR_EXISTING_MANUAL_MESSAGE,
+    EXISTING_GESTION_ROW_MESSAGE,
     EXISTING_SALARY_MESSAGE,
     filter_duplicate_contact_rows,
     filter_duplicate_invoice_rows,
@@ -139,6 +140,10 @@ _IGNORED_FINGERPRINT_COLUMNS: dict[str, set[str]] = {
     "accounting_entry": {"created_at"},
 }
 
+_DUPLICATE_WORKBOOK_PAYMENT_MESSAGE = (
+    "paiement deja couvert par une autre ligne du fichier, ligne ignoree"
+)
+
 
 _ENTITY_MODELS: dict[str, type[Any]] = {
     "contact": Contact,
@@ -170,6 +175,47 @@ def _jsonable(value: Any) -> Any:
     if hasattr(value, "value") and value.__class__.__module__.startswith("backend.models"):
         return value.value
     return value
+
+
+def _canonical_decimal_string(value: Any) -> str:
+    text = format(Decimal(str(value)), "f")
+    if "." in text:
+        text = text.rstrip("0").rstrip(".")
+    if text in {"", "-0"}:
+        return "0"
+    return text
+
+
+def _normalize_snapshot_for_fingerprint(
+    entity_type: str,
+    snapshot: dict[str, Any],
+) -> dict[str, Any]:
+    model_cls = _ENTITY_MODELS.get(entity_type)
+    if model_cls is None:
+        return snapshot
+
+    normalized = dict(snapshot)
+    for column in sa_inspect(model_cls).columns:
+        if column.key not in normalized:
+            continue
+        value = normalized[column.key]
+        if value is None:
+            continue
+        if isinstance(column.type, Numeric):
+            normalized[column.key] = _canonical_decimal_string(value)
+    return normalized
+
+
+def _filtered_snapshot_for_fingerprint(
+    entity_type: str,
+    snapshot: dict[str, Any],
+) -> dict[str, Any]:
+    normalized_snapshot = _normalize_snapshot_for_fingerprint(entity_type, snapshot)
+    return {
+        key: value
+        for key, value in normalized_snapshot.items()
+        if key not in _IGNORED_FINGERPRINT_COLUMNS.get(entity_type, set())
+    }
 
 
 def _deserialize_column_value(column: Any, value: Any) -> Any:
@@ -205,11 +251,7 @@ def _serialize_instance(instance: Any) -> dict[str, Any]:
 def _snapshot_fingerprint(entity_type: str, snapshot: dict[str, Any] | None) -> str | None:
     if snapshot is None:
         return None
-    filtered = {
-        key: value
-        for key, value in snapshot.items()
-        if key not in _IGNORED_FINGERPRINT_COLUMNS.get(entity_type, set())
-    }
+    filtered = _filtered_snapshot_for_fingerprint(entity_type, snapshot)
     return sha256(_json_dumps(filtered).encode("utf-8")).hexdigest()
 
 
@@ -574,6 +616,19 @@ def _build_run_summary(run: ImportRun) -> dict[str, Any]:
                 sheet["errors"].extend(diagnostics)
             continue
 
+        if operation.status == ImportOperationStatus.FAILED:
+            failure_messages = [message for message in diagnostics if message]
+            if operation.error_message:
+                failure_messages.append(operation.error_message)
+            formatted_messages = [
+                f"{operation.title} — {message}" if operation.title else message
+                for message in dict.fromkeys(failure_messages)
+            ]
+            summary["errors"].extend(formatted_messages)
+            if sheet is not None:
+                sheet["errors"].extend(formatted_messages)
+            continue
+
         if operation.status != ImportOperationStatus.APPLIED:
             continue
 
@@ -817,6 +872,8 @@ async def _prepare_gestion_specs(
     existing_salary_keys = await legacy_excel_import._load_existing_salary_keys(db)
     planned_invoice_candidates: list[PaymentMatchCandidate] = []
     deferred_payment_sheets: list[tuple[str, list[NormalizedPaymentRow]]] = []
+    planned_payment_signatures: set[tuple[str, str, str, str]] = set()
+    existing_payment_signatures = await legacy_excel_import._load_existing_payment_signatures(db)
 
     for sheet_name in workbook.sheetnames:
         ws = workbook[sheet_name]
@@ -1019,6 +1076,7 @@ async def _prepare_gestion_specs(
                         payload={"reason": issue.message, "row": _row_to_payload(salary_row)},
                     )
                     continue
+                existing_salary_keys.add(salary_key)
                 rows_by_month.setdefault(salary_row.month, []).append(salary_row)
             for month, month_rows in sorted(rows_by_month.items()):
                 _append_spec(
@@ -1085,6 +1143,70 @@ async def _prepare_gestion_specs(
                     },
                 )
             for bank_row in bank_rows:
+                if bank_row.amount > 0:
+                    supplier_candidate = (
+                        legacy_excel_import._supplier_invoice_candidate_from_bank_row(bank_row)
+                    )
+                    if supplier_candidate is None:
+                        invoice_reference = legacy_excel_import._single_client_invoice_reference(
+                            bank_row.reference,
+                            bank_row.description,
+                        )
+                        if invoice_reference is not None:
+                            resolution = await resolve_payment_match_with_database(
+                                db,
+                                legacy_excel_import._payment_row_from_bank_row(
+                                    bank_row,
+                                    invoice_reference=invoice_reference,
+                                ),
+                                planned_invoice_candidates,
+                            )
+                            if (
+                                resolution.status == "matched"
+                                and resolution.candidate is not None
+                                and resolution.candidate.invoice_id is not None
+                            ):
+                                payment_signature = legacy_excel_import._payment_signature(
+                                    invoice_id=resolution.candidate.invoice_id,
+                                    payment_date=bank_row.entry_date,
+                                    amount=bank_row.amount,
+                                    method=PaymentMethod.VIREMENT.value,
+                                )
+                                if payment_signature in existing_payment_signatures:
+                                    issue = RowIgnoredIssue(
+                                        source_row_number=bank_row.source_row_number,
+                                        message=EXISTING_GESTION_ROW_MESSAGE,
+                                    )
+                                    _append_spec(
+                                        specs,
+                                        operation_type="ignored_by_policy",
+                                        title=bank_row.reference or bank_row.description,
+                                        description="Ligne bancaire déjà présente dans Solde.",
+                                        source_sheet=sheet_name,
+                                        source_row_numbers=[bank_row.source_row_number],
+                                        decision=ImportOperationDecision.IGNORE,
+                                        diagnostics=[format_row_issue(issue)],
+                                        payload={
+                                            "reason": issue.message,
+                                            "row": _row_to_payload(bank_row),
+                                        },
+                                    )
+                                    continue
+                            if resolution.status == "matched" and resolution.candidate is not None:
+                                planned_payment_signatures.add(
+                                    legacy_excel_import._gestion_payment_comparison_signature(
+                                        reference=(
+                                            resolution.candidate.invoice_number or invoice_reference
+                                        ),
+                                        payment_date=bank_row.entry_date,
+                                        amount=bank_row.amount,
+                                        settlement_account=(
+                                            legacy_excel_import._client_settlement_account_from_method(
+                                                PaymentMethod.VIREMENT.value
+                                            )
+                                        ),
+                                    )
+                                )
                 _append_spec(
                     specs,
                     operation_type="bank_row_import",
@@ -1124,6 +1246,58 @@ async def _prepare_gestion_specs(
                     payload={"row": _row_to_payload(payment_row)},
                 )
                 continue
+            assert resolution.candidate is not None
+            workbook_payment_signature = legacy_excel_import._gestion_payment_comparison_signature(
+                reference=resolution.candidate.invoice_number or payment_row.invoice_ref,
+                payment_date=payment_row.payment_date,
+                amount=payment_row.amount,
+                settlement_account=legacy_excel_import._client_settlement_account_from_method(
+                    payment_row.method
+                ),
+            )
+            if workbook_payment_signature in planned_payment_signatures:
+                issue = RowIgnoredIssue(
+                    source_row_number=payment_row.source_row_number,
+                    message=_DUPLICATE_WORKBOOK_PAYMENT_MESSAGE,
+                )
+                _append_spec(
+                    specs,
+                    operation_type="ignored_by_policy",
+                    title=f"Paiement ligne {payment_row.source_row_number}",
+                    description="Paiement client déjà couvert par une autre ligne du fichier.",
+                    source_sheet=sheet_name,
+                    source_row_numbers=[payment_row.source_row_number],
+                    decision=ImportOperationDecision.IGNORE,
+                    diagnostics=[format_row_issue(issue)],
+                    payload={"reason": issue.message, "row": _row_to_payload(payment_row)},
+                )
+                continue
+            planned_payment_signatures.add(workbook_payment_signature)
+            if resolution.candidate.invoice_id is not None:
+                payment_signature = legacy_excel_import._payment_signature(
+                    invoice_id=resolution.candidate.invoice_id,
+                    payment_date=payment_row.payment_date,
+                    amount=payment_row.amount,
+                    method=payment_row.method,
+                )
+                if payment_signature in existing_payment_signatures:
+                    issue = RowIgnoredIssue(
+                        source_row_number=payment_row.source_row_number,
+                        message=EXISTING_GESTION_ROW_MESSAGE,
+                    )
+                    _append_spec(
+                        specs,
+                        operation_type="ignored_by_policy",
+                        title=f"Paiement ligne {payment_row.source_row_number}",
+                        description="Paiement client déjà présent dans Solde.",
+                        source_sheet=sheet_name,
+                        source_row_numbers=[payment_row.source_row_number],
+                        decision=ImportOperationDecision.IGNORE,
+                        diagnostics=[format_row_issue(issue)],
+                        payload={"reason": issue.message, "row": _row_to_payload(payment_row)},
+                    )
+                    continue
+                existing_payment_signatures.add(payment_signature)
             _append_spec(
                 specs,
                 operation_type="client_payment_row_import",
@@ -2315,6 +2489,9 @@ async def _execute_cash_row_import(db: AsyncSession, operation: ImportOperation)
                 await _query_generated_payment_entries(db, supplier_result.payment.id)
             )
 
+    if refreshed_invoice is not None:
+        await db.refresh(refreshed_invoice)
+
     if (
         supplier_result is not None
         and supplier_result.created_contact
@@ -2509,6 +2686,10 @@ async def _execute_bank_row_import(db: AsyncSession, operation: ImportOperation)
         )
     )
     await db.flush()
+
+    if refreshed_invoice is not None:
+        await db.refresh(refreshed_invoice)
+
     created_entries = await _query_generated_bank_entries(db, bank_entry.id) + [
         entry
         for entry in created_entries
@@ -2821,9 +3002,10 @@ async def execute_import_run(db: AsyncSession, run_id: int) -> ImportRun:
         if operation.status != ImportOperationStatus.PREPARED:
             continue
         try:
-            await _execute_operation(db, operation)
-            operation.status = ImportOperationStatus.APPLIED
-            operation.error_message = None
+            async with db.begin_nested():
+                await _execute_operation(db, operation)
+                operation.status = ImportOperationStatus.APPLIED
+                operation.error_message = None
         except Exception as exc:
             operation.status = ImportOperationStatus.FAILED
             operation.error_message = str(exc)
@@ -2863,7 +3045,10 @@ async def _ensure_effect_matches_state(
     current_snapshot = _serialize_instance(entity)
     current_fingerprint = _snapshot_fingerprint(effect.entity_type, current_snapshot)
     if current_fingerprint != fingerprint:
-        raise ValueError("L'état courant ne correspond plus à l'état attendu")
+        expected_filtered = _filtered_snapshot_for_fingerprint(effect.entity_type, snapshot)
+        current_filtered = _filtered_snapshot_for_fingerprint(effect.entity_type, current_snapshot)
+        if current_filtered != expected_filtered:
+            raise ValueError("L'état courant ne correspond plus à l'état attendu")
     return snapshot
 
 

--- a/backend/services/settings.py
+++ b/backend/services/settings.py
@@ -9,7 +9,7 @@ from datetime import date
 from decimal import Decimal
 from typing import Any, cast
 
-from sqlalchemy import delete, func, select
+from sqlalchemy import delete, select
 from sqlalchemy.engine import CursorResult
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -136,7 +136,7 @@ def _file_matches_fiscal_year(file_name: str | None, fiscal_year: FiscalYear) ->
 async def _get_fiscal_year_or_raise(db: AsyncSession, fiscal_year_id: int) -> FiscalYear:
     fiscal_year = await db.get(FiscalYear, fiscal_year_id)
     if fiscal_year is None:
-        raise ValueError("Fiscal year not found")
+        raise LookupError("Fiscal year not found")
     return fiscal_year
 
 
@@ -327,29 +327,28 @@ async def _find_deletable_contact_ids(
 ) -> set[int]:
     if not candidate_contact_ids:
         return set()
-    deletable_ids: set[int] = set()
-    for contact_id in candidate_contact_ids:
-        invoice_count = await db.scalar(
-            select(func.count(Invoice.id)).where(
-                Invoice.contact_id == contact_id,
-                Invoice.id.not_in(delete_object_ids["invoice"] or {-1}),
-            )
+    referenced_contact_ids: set[int] = set()
+    source_queries = (
+        select(Invoice.contact_id).where(
+            Invoice.contact_id.in_(candidate_contact_ids),
+            Invoice.id.not_in(delete_object_ids["invoice"] or {-1}),
+        ),
+        select(Payment.contact_id).where(
+            Payment.contact_id.in_(candidate_contact_ids),
+            Payment.id.not_in(delete_object_ids["payment"] or {-1}),
+        ),
+        select(CashRegister.contact_id).where(
+            CashRegister.contact_id.in_(candidate_contact_ids),
+            CashRegister.id.not_in(delete_object_ids["cash_register"] or {-1}),
+        ),
+    )
+    for query in source_queries:
+        result = await db.execute(query.distinct())
+        referenced_contact_ids.update(
+            contact_id for contact_id in result.scalars().all() if contact_id is not None
         )
-        payment_count = await db.scalar(
-            select(func.count(Payment.id)).where(
-                Payment.contact_id == contact_id,
-                Payment.id.not_in(delete_object_ids["payment"] or {-1}),
-            )
-        )
-        cash_count = await db.scalar(
-            select(func.count(CashRegister.id)).where(
-                CashRegister.contact_id == contact_id,
-                CashRegister.id.not_in(delete_object_ids["cash_register"] or {-1}),
-            )
-        )
-        if (invoice_count or 0) == 0 and (payment_count or 0) == 0 and (cash_count or 0) == 0:
-            deletable_ids.add(contact_id)
-    return deletable_ids
+
+    return candidate_contact_ids - referenced_contact_ids
 
 
 async def _enrich_gestion_plan(db: AsyncSession, plan: _SelectiveResetPlan) -> None:

--- a/backend/services/settings.py
+++ b/backend/services/settings.py
@@ -1,26 +1,45 @@
 """Application settings service — read and update the single settings row."""
 
+import json
 import logging
+import re
+from collections import defaultdict
+from dataclasses import dataclass, field
 from datetime import date
 from decimal import Decimal
 from typing import Any, cast
 
-from sqlalchemy import delete, select
+from sqlalchemy import delete, func, select
 from sqlalchemy.engine import CursorResult
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.database import Base
+from backend.models.accounting_entry import AccountingEntry, EntrySourceType
 from backend.models.app_settings import AppSettings
-from backend.models.bank import BankTransaction, BankTransactionSource
+from backend.models.bank import (
+    BankTransaction,
+    BankTransactionSource,
+    Deposit,
+    bank_transaction_payments,
+    deposit_payments,
+)
 from backend.models.cash import (
     CASH_SYSTEM_OPENING_DESCRIPTION,
     CashEntrySource,
     CashMovementType,
     CashRegister,
 )
+from backend.models.contact import Contact
 from backend.models.fiscal_year import FiscalYear, FiscalYearStatus
+from backend.models.import_log import ImportLog, ImportLogStatus, ImportLogType
+from backend.models.import_run import ImportRun
+from backend.models.invoice import Invoice
+from backend.models.payment import Payment
+from backend.models.salary import Salary
 from backend.schemas.settings import (
     AppSettingsUpdate,
+    SelectiveResetPreviewRead,
+    SelectiveResetRequest,
     SystemOpeningRead,
     TreasurySystemOpeningRead,
     TreasurySystemOpeningUpdate,
@@ -30,6 +49,519 @@ logger = logging.getLogger(__name__)
 
 _SETTINGS_ID = 1
 _PRESERVED_TABLES = {"users"}
+_IMPORT_FILE_YEAR_RE = re.compile(r"(?<!\d)(20\d{2})(?!\d)")
+_SELECTIVE_RESET_OBJECT_TYPES = (
+    "contact",
+    "invoice",
+    "payment",
+    "salary",
+    "cash_register",
+    "bank_transaction",
+    "accounting_entry",
+    "deposit",
+)
+_ROOT_OBJECT_TYPES = tuple(
+    object_type for object_type in _SELECTIVE_RESET_OBJECT_TYPES if object_type != "deposit"
+)
+
+
+@dataclass
+class _SelectiveResetPlan:
+    import_type: ImportLogType
+    fiscal_year: FiscalYear
+    import_log_ids: set[int] = field(default_factory=set)
+    import_run_ids: set[int] = field(default_factory=set)
+    root_object_ids: dict[str, set[int]] = field(
+        default_factory=lambda: {object_type: set() for object_type in _ROOT_OBJECT_TYPES}
+    )
+    derived_object_ids: dict[str, set[int]] = field(
+        default_factory=lambda: {
+            object_type: set() for object_type in _SELECTIVE_RESET_OBJECT_TYPES
+        }
+    )
+    delete_object_ids: dict[str, set[int]] = field(
+        default_factory=lambda: {
+            object_type: set() for object_type in _SELECTIVE_RESET_OBJECT_TYPES
+        }
+    )
+    unlink_bank_transaction_ids: set[int] = field(default_factory=set)
+
+    def to_preview(self) -> SelectiveResetPreviewRead:
+        return SelectiveResetPreviewRead(
+            import_type=self.import_type,
+            fiscal_year_id=self.fiscal_year.id,
+            fiscal_year_name=self.fiscal_year.name,
+            fiscal_year_start_date=self.fiscal_year.start_date,
+            fiscal_year_end_date=self.fiscal_year.end_date,
+            matched_import_logs=len(self.import_log_ids),
+            matched_import_runs=len(self.import_run_ids),
+            root_objects={
+                object_type: len(self.root_object_ids[object_type])
+                for object_type in _ROOT_OBJECT_TYPES
+                if self.root_object_ids[object_type]
+            },
+            derived_objects={
+                object_type: len(self.derived_object_ids[object_type])
+                for object_type in _SELECTIVE_RESET_OBJECT_TYPES
+                if self.derived_object_ids[object_type]
+            },
+            delete_plan={
+                **{
+                    object_type: len(self.delete_object_ids[object_type])
+                    for object_type in _SELECTIVE_RESET_OBJECT_TYPES
+                    if self.delete_object_ids[object_type]
+                },
+                **({"import_logs": len(self.import_log_ids)} if self.import_log_ids else {}),
+                **({"import_runs": len(self.import_run_ids)} if self.import_run_ids else {}),
+            },
+        )
+
+
+def _deserialize_json(value: str | None) -> dict[str, Any]:
+    if not value:
+        return {}
+    try:
+        loaded = json.loads(value)
+    except json.JSONDecodeError:
+        return {}
+    return loaded if isinstance(loaded, dict) else {}
+
+
+def _file_matches_fiscal_year(file_name: str | None, fiscal_year: FiscalYear) -> bool:
+    if not file_name:
+        return False
+    return _IMPORT_FILE_YEAR_RE.search(file_name) is not None and fiscal_year.name in file_name
+
+
+async def _get_fiscal_year_or_raise(db: AsyncSession, fiscal_year_id: int) -> FiscalYear:
+    fiscal_year = await db.get(FiscalYear, fiscal_year_id)
+    if fiscal_year is None:
+        raise ValueError("Fiscal year not found")
+    return fiscal_year
+
+
+def _merge_created_objects(summary: dict[str, Any], target: dict[str, set[int]]) -> None:
+    created_objects = summary.get("created_objects", [])
+    if not isinstance(created_objects, list):
+        return
+    for item in created_objects:
+        if not isinstance(item, dict):
+            continue
+        object_type = item.get("object_type")
+        object_id = item.get("object_id")
+        if object_type not in target or not isinstance(object_id, int):
+            continue
+        target[object_type].add(object_id)
+
+
+async def _filter_existing_ids(
+    db: AsyncSession,
+    model: type[Any],
+    ids: set[int],
+) -> set[int]:
+    if not ids:
+        return set()
+    result = await db.execute(select(model.id).where(model.id.in_(ids)))
+    return set(result.scalars().all())
+
+
+async def _refresh_existing_root_objects(db: AsyncSession, object_ids: dict[str, set[int]]) -> None:
+    model_by_type: dict[str, type[Any]] = {
+        "contact": Contact,
+        "invoice": Invoice,
+        "payment": Payment,
+        "salary": Salary,
+        "cash_register": CashRegister,
+        "bank_transaction": BankTransaction,
+        "accounting_entry": AccountingEntry,
+    }
+    for object_type, model in model_by_type.items():
+        object_ids[object_type] = await _filter_existing_ids(db, model, object_ids[object_type])
+
+
+async def _collect_import_scope_plan(
+    db: AsyncSession,
+    payload: SelectiveResetRequest,
+) -> _SelectiveResetPlan:
+    fiscal_year = await _get_fiscal_year_or_raise(db, payload.fiscal_year_id)
+    plan = _SelectiveResetPlan(import_type=payload.import_type, fiscal_year=fiscal_year)
+
+    import_logs = (
+        (
+            await db.execute(
+                select(ImportLog).where(
+                    ImportLog.import_type == payload.import_type,
+                    ImportLog.status == ImportLogStatus.SUCCESS,
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    for import_log in import_logs:
+        if not _file_matches_fiscal_year(import_log.file_name, fiscal_year):
+            continue
+        plan.import_log_ids.add(import_log.id)
+        _merge_created_objects(_deserialize_json(import_log.summary), plan.root_object_ids)
+
+    import_runs = (
+        (await db.execute(select(ImportRun).where(ImportRun.import_type == payload.import_type)))
+        .scalars()
+        .all()
+    )
+    for import_run in import_runs:
+        if not _file_matches_fiscal_year(import_run.file_name, fiscal_year):
+            continue
+        summary = _deserialize_json(import_run.summary_json)
+        if not summary.get("created_objects"):
+            continue
+        plan.import_run_ids.add(import_run.id)
+        _merge_created_objects(summary, plan.root_object_ids)
+
+    await _refresh_existing_root_objects(db, plan.root_object_ids)
+    for object_type in _ROOT_OBJECT_TYPES:
+        plan.delete_object_ids[object_type].update(plan.root_object_ids[object_type])
+
+    return plan
+
+
+async def _derive_invoice_payments(db: AsyncSession, invoice_ids: set[int]) -> set[int]:
+    if not invoice_ids:
+        return set()
+    result = await db.execute(select(Payment.id).where(Payment.invoice_id.in_(invoice_ids)))
+    return set(result.scalars().all())
+
+
+async def _derive_transaction_payments(
+    db: AsyncSession,
+    bank_transaction_ids: set[int],
+) -> set[int]:
+    if not bank_transaction_ids:
+        return set()
+    result = await db.execute(
+        select(bank_transaction_payments.c.payment_id).where(
+            bank_transaction_payments.c.transaction_id.in_(bank_transaction_ids)
+        )
+    )
+    linked_ids = set(result.scalars().all())
+    legacy_result = await db.execute(
+        select(BankTransaction.payment_id).where(BankTransaction.id.in_(bank_transaction_ids))
+    )
+    linked_ids.update(payment_id for payment_id in legacy_result.scalars().all() if payment_id)
+    return linked_ids
+
+
+async def _derive_payment_deposits(db: AsyncSession, payment_ids: set[int]) -> set[int]:
+    if not payment_ids:
+        return set()
+    result = await db.execute(
+        select(deposit_payments.c.deposit_id).where(deposit_payments.c.payment_id.in_(payment_ids))
+    )
+    return set(result.scalars().all())
+
+
+async def _derive_payment_cash_entries(db: AsyncSession, payment_ids: set[int]) -> set[int]:
+    if not payment_ids:
+        return set()
+    result = await db.execute(
+        select(CashRegister.id).where(CashRegister.payment_id.in_(payment_ids))
+    )
+    return set(result.scalars().all())
+
+
+async def _derive_deposit_cash_entries(db: AsyncSession, deposit_ids: set[int]) -> set[int]:
+    if not deposit_ids:
+        return set()
+    deposits = (
+        (await db.execute(select(Deposit).where(Deposit.id.in_(deposit_ids)))).scalars().all()
+    )
+    cash_entry_ids: set[int] = set()
+    for deposit in deposits:
+        reference = deposit.bank_reference or f"DEP-ESP-{deposit.id}"
+        result = await db.execute(
+            select(CashRegister.id).where(
+                CashRegister.source == CashEntrySource.DEPOSIT,
+                CashRegister.date == deposit.date,
+                CashRegister.amount == deposit.total_amount,
+                CashRegister.reference == reference,
+            )
+        )
+        cash_entry_ids.update(result.scalars().all())
+    return cash_entry_ids
+
+
+async def _derive_generated_entries(
+    db: AsyncSession,
+    *,
+    invoice_ids: set[int],
+    payment_ids: set[int],
+    deposit_ids: set[int],
+    salary_ids: set[int],
+    bank_transaction_ids: set[int],
+) -> set[int]:
+    entry_ids: set[int] = set()
+    source_groups = [
+        (EntrySourceType.INVOICE, invoice_ids),
+        (EntrySourceType.PAYMENT, payment_ids),
+        (EntrySourceType.DEPOSIT, deposit_ids),
+        (EntrySourceType.SALARY, salary_ids),
+        (EntrySourceType.GESTION, bank_transaction_ids),
+    ]
+    for source_type, source_ids in source_groups:
+        if not source_ids:
+            continue
+        result = await db.execute(
+            select(AccountingEntry.id).where(
+                AccountingEntry.source_type == source_type,
+                AccountingEntry.source_id.in_(source_ids),
+            )
+        )
+        entry_ids.update(result.scalars().all())
+    return entry_ids
+
+
+async def _find_deletable_contact_ids(
+    db: AsyncSession,
+    candidate_contact_ids: set[int],
+    delete_object_ids: dict[str, set[int]],
+) -> set[int]:
+    if not candidate_contact_ids:
+        return set()
+    deletable_ids: set[int] = set()
+    for contact_id in candidate_contact_ids:
+        invoice_count = await db.scalar(
+            select(func.count(Invoice.id)).where(
+                Invoice.contact_id == contact_id,
+                Invoice.id.not_in(delete_object_ids["invoice"] or {-1}),
+            )
+        )
+        payment_count = await db.scalar(
+            select(func.count(Payment.id)).where(
+                Payment.contact_id == contact_id,
+                Payment.id.not_in(delete_object_ids["payment"] or {-1}),
+            )
+        )
+        cash_count = await db.scalar(
+            select(func.count(CashRegister.id)).where(
+                CashRegister.contact_id == contact_id,
+                CashRegister.id.not_in(delete_object_ids["cash_register"] or {-1}),
+            )
+        )
+        if (invoice_count or 0) == 0 and (payment_count or 0) == 0 and (cash_count or 0) == 0:
+            deletable_ids.add(contact_id)
+    return deletable_ids
+
+
+async def _enrich_gestion_plan(db: AsyncSession, plan: _SelectiveResetPlan) -> None:
+    derived_payment_ids = await _derive_invoice_payments(db, plan.delete_object_ids["invoice"])
+    derived_payment_ids.update(
+        await _derive_transaction_payments(db, plan.delete_object_ids["bank_transaction"])
+    )
+    derived_payment_ids -= plan.delete_object_ids["payment"]
+    plan.derived_object_ids["payment"].update(derived_payment_ids)
+    plan.delete_object_ids["payment"].update(derived_payment_ids)
+
+    derived_deposit_ids = await _derive_payment_deposits(db, plan.delete_object_ids["payment"])
+    plan.derived_object_ids["deposit"].update(derived_deposit_ids)
+    plan.delete_object_ids["deposit"].update(derived_deposit_ids)
+
+    derived_cash_ids = await _derive_payment_cash_entries(db, plan.delete_object_ids["payment"])
+    derived_cash_ids.update(
+        await _derive_deposit_cash_entries(db, plan.delete_object_ids["deposit"])
+    )
+    derived_cash_ids -= plan.delete_object_ids["cash_register"]
+    plan.derived_object_ids["cash_register"].update(derived_cash_ids)
+    plan.delete_object_ids["cash_register"].update(derived_cash_ids)
+
+    derived_entry_ids = await _derive_generated_entries(
+        db,
+        invoice_ids=plan.delete_object_ids["invoice"],
+        payment_ids=plan.delete_object_ids["payment"],
+        deposit_ids=plan.delete_object_ids["deposit"],
+        salary_ids=plan.delete_object_ids["salary"],
+        bank_transaction_ids=plan.delete_object_ids["bank_transaction"],
+    )
+    derived_entry_ids -= plan.delete_object_ids["accounting_entry"]
+    plan.derived_object_ids["accounting_entry"].update(derived_entry_ids)
+    plan.delete_object_ids["accounting_entry"].update(derived_entry_ids)
+
+    linked_transaction_ids = await _derive_transaction_ids_from_payments(
+        db,
+        plan.delete_object_ids["payment"],
+    )
+    plan.unlink_bank_transaction_ids.update(
+        linked_transaction_ids - plan.delete_object_ids["bank_transaction"]
+    )
+
+    deletable_contact_ids = await _find_deletable_contact_ids(
+        db,
+        plan.root_object_ids["contact"],
+        plan.delete_object_ids,
+    )
+    plan.delete_object_ids["contact"] = deletable_contact_ids
+
+
+async def _derive_transaction_ids_from_payments(
+    db: AsyncSession,
+    payment_ids: set[int],
+) -> set[int]:
+    if not payment_ids:
+        return set()
+    result = await db.execute(
+        select(bank_transaction_payments.c.transaction_id).where(
+            bank_transaction_payments.c.payment_id.in_(payment_ids)
+        )
+    )
+    transaction_ids = set(result.scalars().all())
+    legacy_result = await db.execute(
+        select(BankTransaction.id).where(BankTransaction.payment_id.in_(payment_ids))
+    )
+    transaction_ids.update(legacy_result.scalars().all())
+    return transaction_ids
+
+
+async def _build_selective_reset_plan(
+    db: AsyncSession,
+    payload: SelectiveResetRequest,
+) -> _SelectiveResetPlan:
+    plan = await _collect_import_scope_plan(db, payload)
+    if payload.import_type == ImportLogType.GESTION:
+        await _enrich_gestion_plan(db, plan)
+    elif payload.import_type == ImportLogType.COMPTABILITE:
+        plan.delete_object_ids["accounting_entry"].update(plan.root_object_ids["accounting_entry"])
+    return plan
+
+
+async def preview_selective_reset(
+    db: AsyncSession,
+    payload: SelectiveResetRequest,
+) -> SelectiveResetPreviewRead:
+    plan = await _build_selective_reset_plan(db, payload)
+    return plan.to_preview()
+
+
+async def _delete_model_ids(db: AsyncSession, model: type[Any], ids: set[int]) -> None:
+    if not ids:
+        return
+    await db.execute(delete(model).where(model.id.in_(ids)))
+
+
+async def _refresh_linked_bank_transactions(db: AsyncSession, tx_ids: set[int]) -> None:
+    if not tx_ids:
+        return
+    transactions = (
+        (await db.execute(select(BankTransaction).where(BankTransaction.id.in_(tx_ids))))
+        .scalars()
+        .all()
+    )
+    link_rows = (
+        await db.execute(
+            select(
+                bank_transaction_payments.c.transaction_id,
+                bank_transaction_payments.c.payment_id,
+            ).where(bank_transaction_payments.c.transaction_id.in_(tx_ids))
+        )
+    ).all()
+    payment_ids_by_tx: dict[int, list[int]] = defaultdict(list)
+    for transaction_id, payment_id in link_rows:
+        payment_ids_by_tx[int(transaction_id)].append(int(payment_id))
+
+    linked_payment_ids = {payment_id for _, payment_id in link_rows}
+    invoice_rows = (
+        await db.execute(
+            select(Payment.id, Invoice.number)
+            .join(Invoice, Payment.invoice_id == Invoice.id)
+            .where(Payment.id.in_(linked_payment_ids or {-1}))
+        )
+    ).all()
+    invoice_numbers: dict[int, str] = {
+        int(payment_id): invoice_number for payment_id, invoice_number in invoice_rows
+    }
+    payment_reference_rows = (
+        await db.execute(
+            select(Payment.id, Payment.reference).where(Payment.id.in_(linked_payment_ids or {-1}))
+        )
+    ).all()
+    payment_references: dict[int, str | None] = {
+        int(payment_id): reference for payment_id, reference in payment_reference_rows
+    }
+
+    for tx in transactions:
+        payment_ids = payment_ids_by_tx.get(tx.id, [])
+        tx.reconciled = bool(payment_ids)
+        tx.payment_id = payment_ids[0] if len(payment_ids) == 1 else None
+        if not payment_ids:
+            tx.reconciled_with = None
+            continue
+        labels = [
+            invoice_numbers.get(payment_id)
+            or payment_references.get(payment_id)
+            or f"payment-{payment_id}"
+            for payment_id in payment_ids
+        ]
+        tx.reconciled_with = labels[0] if len(labels) == 1 else f"{labels[0]} +{len(labels) - 1}"
+
+
+async def apply_selective_reset(
+    db: AsyncSession,
+    payload: SelectiveResetRequest,
+) -> SelectiveResetPreviewRead:
+    plan = await _build_selective_reset_plan(db, payload)
+
+    if plan.delete_object_ids["payment"]:
+        await db.execute(
+            delete(bank_transaction_payments).where(
+                bank_transaction_payments.c.payment_id.in_(plan.delete_object_ids["payment"])
+            )
+        )
+        linked_transactions = (
+            (
+                await db.execute(
+                    select(BankTransaction).where(
+                        BankTransaction.payment_id.in_(plan.delete_object_ids["payment"])
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        for transaction in linked_transactions:
+            if transaction.id not in plan.delete_object_ids["bank_transaction"]:
+                transaction.payment_id = None
+
+    if plan.delete_object_ids["deposit"]:
+        await db.execute(
+            delete(deposit_payments).where(
+                deposit_payments.c.deposit_id.in_(plan.delete_object_ids["deposit"])
+            )
+        )
+    elif plan.delete_object_ids["payment"]:
+        await db.execute(
+            delete(deposit_payments).where(
+                deposit_payments.c.payment_id.in_(plan.delete_object_ids["payment"])
+            )
+        )
+
+    await _delete_model_ids(db, AccountingEntry, plan.delete_object_ids["accounting_entry"])
+    await _delete_model_ids(db, CashRegister, plan.delete_object_ids["cash_register"])
+    await _delete_model_ids(db, Deposit, plan.delete_object_ids["deposit"])
+    await _delete_model_ids(db, Payment, plan.delete_object_ids["payment"])
+    await _delete_model_ids(db, Invoice, plan.delete_object_ids["invoice"])
+    await _delete_model_ids(db, Salary, plan.delete_object_ids["salary"])
+    await _delete_model_ids(db, BankTransaction, plan.delete_object_ids["bank_transaction"])
+    await _delete_model_ids(db, Contact, plan.delete_object_ids["contact"])
+    await _refresh_linked_bank_transactions(db, plan.unlink_bank_transaction_ids)
+    await _delete_model_ids(db, ImportRun, plan.import_run_ids)
+    await _delete_model_ids(db, ImportLog, plan.import_log_ids)
+
+    from backend.services.bank_service import recompute_bank_balances  # noqa: PLC0415
+    from backend.services.cash_service import recompute_cash_balances  # noqa: PLC0415
+
+    await recompute_bank_balances(db)
+    await recompute_cash_balances(db)
+    await db.commit()
+    db.expunge_all()
+    return plan.to_preview()
 
 
 async def get_settings(db: AsyncSession) -> AppSettings:
@@ -47,8 +579,8 @@ async def get_settings(db: AsyncSession) -> AppSettings:
 async def update_settings(db: AsyncSession, payload: AppSettingsUpdate) -> AppSettings:
     """Partially update settings with provided fields."""
     settings = await get_settings(db)
-    for field, value in payload.model_dump(exclude_unset=True).items():
-        setattr(settings, field, value)
+    for field_name, value in payload.model_dump(exclude_unset=True).items():
+        setattr(settings, field_name, value)
     await db.commit()
     await db.refresh(settings)
     return settings

--- a/doc/backlog.md
+++ b/doc/backlog.md
@@ -50,19 +50,16 @@ Tout sujet concret qui doit survivre au-delà de la séance en cours doit être 
 
 ## Priorités proposées pour la prochaine discussion
 
-1. **BL-030** — définir une politique explicite de modification des objets métier déjà créés ou validés.
-2. **BL-021** — finaliser le manuel utilisateur illustré avec stabilisation éditoriale et enrichissement visuel.
+1. **BL-021** — finaliser le manuel utilisateur illustré avec stabilisation éditoriale et enrichissement visuel.
 
 ## Récapitulatif des sujets ouverts
 
 | ID | Créé le | Type | Zone | Priorité proposée | Sujet |
 |---|---|---|---|---|---|
 | BL-006 | 2026-04-12 | Technique | API / Framework | P3 | Traiter les warnings de dépréciation `HTTP_422_UNPROCESSABLE_ENTITY` remontés par la suite de tests |
-| BL-015 | 2026-04-13 | Amélioration | Import Excel / Outillage | P2 | Ajouter un reset sélectif orienté reprise pour rejouer proprement un import par filière ou période sans repartir systématiquement d'un effacement global |
 | BL-019 | 2026-04-13 | Documentation | Projet / Exploitation | P1 | Refaire le README et la documentation technique d'installation, mise à jour, pile techno, configuration et exploitation Docker |
 | BL-020 | 2026-04-13 | Documentation | Développement | P3 | Documenter clairement comment participer au projet : prérequis, environnement local, commandes utiles, qualité attendue et workflow PR |
 | BL-021 | 2026-04-13 | Documentation | Utilisateur / Parcours | P1 | Rédiger un manuel utilisateur illustré et pas à pas aligné sur les écrans réellement disponibles |
-| BL-030 | 2026-04-16 | Décision | Métier / Edition des données | P1 | Définir une politique explicite de modification des objets métier déjà créés ou validés (factures, paiements, achats, etc.) avec règles de recalcul, traçabilité et limites selon le statut |
 
 ## Détail des sujets
 
@@ -241,10 +238,11 @@ Tout sujet concret qui doit survivre au-delà de la séance en cours doit être 
 
 ### BL-015 — Reset sélectif orienté reprise d'import
 
-- **Dates** : `created=2026-04-13`
+- **Dates** : `created=2026-04-13`, `started=2026-04-20`, `completed=2026-04-20`
 - **Pourquoi** : le reset global actuel est utile pour les essais complets, mais il reste trop brutal quand on veut simplement rejouer une filière d'import, un exercice ou une séquence de reprise précise.
 - **Recadrage après BL-004** : le cycle `prepare -> execute -> undo/redo` couvre désormais le cas standard de rejeu sûr pour les nouveaux imports réversibles, au niveau d'une opération ou d'un run complet. `BL-015` ne vise donc plus à rejouer ces imports normaux, mais les cas où le journal réversible ne suffit pas ou n'existe pas.
 - **Résultat attendu** : proposer un reset plus fin, compréhensible et sûr, capable de supprimer uniquement le périmètre utile à rejouer tout en explicitant le traitement des journaux d'import et des dépendances métier, en particulier pour les imports legacy, les données modifiées après coup qui bloquent un `undo` strict, ou les nettoyages administratifs ciblés par filière, période ou exercice.
+- **Livré parce que** : l'administration expose maintenant un reset sélectif avec prévisualisation puis exécution pour un couple `type d'import + exercice`, le backend s'appuie sur les traces `import_logs` et `import_runs` pour retrouver les objets racines puis supprimer aussi, côté `Gestion`, les dépendances métier dérivées explicitement cadrées, l'interface `Paramètres` est branchée de bout en bout, la documentation utilisateur a été consolidée, et toute la matrice de validation locale est passée, y compris `pytest tests/` (`710 passed`), `ruff`, `mypy`, `vue-tsc`, `eslint` et `vitest`.
 - **Point d'attention** : ce sujet ne doit pas fragiliser l'intégrité des données ; il faut privilégier des scénarios de reset explicitement cadrés plutôt qu'un outil générique trop puissant, et éviter tout chevauchement fonctionnel inutile avec le journal réversible de `BL-004`.
 
 ### BL-016 — Harmonisation i18n et microcopie UI
@@ -521,6 +519,7 @@ Tout sujet concret qui doit survivre au-delà de la séance en cours doit être 
 - **BL-012** — `created=2026-04-12`, `completed=2026-04-12` — La liste des paiements affiche la référence métier et permet l'édition directe.
 - **BL-013** — `created=2026-04-12`, `completed=2026-04-12` — Le journal de caisse propose désormais référence, détail et édition directe.
 - **BL-014** — `created=2026-04-12`, `completed=2026-04-12` — Le journal comptable est enrichi pour la lecture métier, le détail et la navigation vers les factures.
+- **BL-015** — `created=2026-04-13`, `started=2026-04-20`, `completed=2026-04-20` — L'administration propose désormais un reset sélectif par filière d'import et exercice, avec prévisualisation, suppression des objets importés et des dépendances métier dérivées explicitement cadrées, branchement complet dans `Paramètres`, documentation utilisateur mise à jour et validation locale complète passée.
 - **BL-016** — `created=2026-04-13`, `started=2026-04-14`, `completed=2026-04-14` — Les microcopies et états visibles les plus incohérents ont été harmonisés sur `Banque`, `Caisse` et `Salaires` via des clés i18n dédiées.
 - **BL-017** — `created=2026-04-13`, `started=2026-04-14`, `completed=2026-04-14` — L'affichage des mois et périodes métier est maintenant uniformisé au format français sur `Salaires` et le `Dashboard` sans changer les formats d'échange ISO.
 - **BL-018** — `created=2026-04-13`, `started=2026-04-14`, `completed=2026-04-14` — Les écrans de liste principaux partagent maintenant un socle commun de tri, filtres et compteurs d'état, avec filtres de date FR/ISO et exclusion explicite des tableaux fixes `bilan` / `résultat`.

--- a/doc/user/import-excel-et-reinitialisation.md
+++ b/doc/user/import-excel-et-reinitialisation.md
@@ -2,210 +2,69 @@
 
 ## But
 
-Ce document explique comment utiliser l'import Excel dans Solde pour :
+Ce document explique comment utiliser dans Solde :
 
-- initialiser l'application à partir des fichiers historiques existants ;
-- contrôler le résultat d'un import avant validation ;
-- comprendre les messages affichés par la prévisualisation et par l'import ;
-- savoir exactement ce que fait la réinitialisation des données.
+- l'import Excel `Gestion` ;
+- l'import Excel `Comptabilite` ;
+- l'historique d'import réversible ;
+- le reset sélectif de reprise ;
+- la réinitialisation complète de la base.
 
-Ce guide est orienté usage métier et tests manuels. Il complète le manuel utilisateur principal quand vous devez travailler sur une reprise historique ou un contrôle d'import.
-
-## Les deux types d'import
-
-### Import `Gestion`
-
-L'import `Gestion` sert à reprendre les données de gestion courante contenues dans un classeur historique.
-
-Il peut créer :
-
-- des contacts ;
-- des factures ;
-- des paiements ;
-- des mouvements de caisse ;
-- des mouvements bancaires ;
-- des écritures comptables générées à partir des règles comptables configurées dans Solde.
-
-Sur les fichiers historiques actuellement utilisés, l'import `Gestion` peut aussi reconstituer des factures fournisseurs et leur règlement quand il détecte des références de type `FF-...` dans les feuilles `Banque` ou `Caisse`.
-
-### Import `Comptabilité`
-
-L'import `Comptabilité` sert à importer les écritures du `Journal` Excel comme écritures comptables supplémentaires.
-
-Il ne crée pas de contacts, de factures ni de paiements. Il ajoute uniquement des écritures comptables manuelles.
-
-Si des écritures ont déjà été générées dans Solde depuis la gestion, l'import `Comptabilité` reste autorisé :
-
-- les doublons exacts sont ignorés ;
-- seules les écritures nouvelles sont ajoutées.
-
-## Avant de commencer
-
-Avant toute reprise ou tout test manuel, vérifiez les points suivants.
-
-1. Travaillez sur une base sauvegardée ou restaurable facilement.
-2. Utilisez un fichier Excel source non modifié entre deux essais, sinon le garde-fou de réimport exact devient moins utile.
-3. Créez d'abord les exercices comptables couvrant toutes les dates réellement présentes dans les fichiers à importer.
-4. Préparez le plan comptable si vous voulez relire et contrôler correctement les écritures importées.
-5. Préparez les règles comptables si vous voulez que l'import `Gestion` génère automatiquement les écritures correspondantes.
-
-Important : l'import Excel ne crée pas automatiquement :
-
-- les exercices comptables ;
-- le plan comptable ;
-- les règles comptables.
-
-## Comment utiliser la prévisualisation
-
-La prévisualisation est l'étape obligatoire avant un import.
-
-Elle permet de voir :
-
-- si le fichier est importable dans l'état actuel de la base ;
-- combien d'objets ou d'écritures seront probablement créés ;
-- quelles feuilles sont reconnues ;
-- quelles lignes seront ignorées ;
-- quelles lignes bloquent l'import.
-
-Procédure recommandée :
-
-1. Choisir le bon type de fichier : `Gestion` ou `Comptabilité`.
-2. Sélectionner le fichier Excel.
-3. Lancer la prévisualisation.
-4. Vérifier que l'état général permet l'import.
-5. Relire les avertissements feuille par feuille.
-6. Contrôler les compteurs de lignes ignorées et bloquantes.
-
-Si la prévisualisation est bloquée, il ne faut pas lancer l'import. Il faut d'abord corriger la donnée source ou la stratégie de reprise.
-
-## Comment interpréter les diagnostics
-
-### Avertissements
-
-Un avertissement indique qu'une ligne ou une feuille a été ignorée, ou qu'une adaptation automatique a été appliquée sans bloquer l'import.
-
-### Lignes bloquantes
-
-Une ligne bloquante empêche l'import complet du fichier.
-
-### Réimport exact
-
-Si un même fichier a déjà été importé avec succès, Solde refuse son réimport exact.
-
-Ce comportement est volontaire. Il évite les doublons involontaires et protège la reprise historique.
-
-## Réinitialisation des données
-
-La réinitialisation des données est une action d'administration destinée surtout aux démonstrations et aux tests de reprise.
-
-Elle supprime toutes les données applicatives, y compris :
-
-- les contacts ;
-- les factures ;
-- les paiements ;
-- les écritures comptables ;
-- les données de banque et de caisse ;
-- l'historique d'import.
-
-Conséquence importante : après une réinitialisation, il faut reconfigurer l'environnement avant de relancer un import, en particulier les exercices comptables, le plan comptable et les règles comptables utiles.
-
-Cette action est irréversible. Elle ne doit pas être utilisée sur une base que vous souhaitez conserver en l'état.
-
-## En cas de doute
-
-Si un import donne un résultat inattendu :
-
-1. ne relancez pas immédiatement sans comprendre ce qui s'est passé ;
-2. relisez la prévisualisation ;
-3. vérifiez les lignes ignorées et bloquantes ;
-4. vérifiez que les exercices nécessaires existent bien ;
-5. repartez d'une base restaurée si vous devez refaire une reprise complète propre.# Guide utilisateur — import Excel et réinitialisation
-
-## But
-
-Ce document explique comment utiliser l'import Excel dans Solde pour :
-
-- initialiser l'application à partir des fichiers historiques existants ;
-- contrôler le résultat d'un import avant validation ;
-- comprendre les messages affichés par la prévisualisation et par l'import ;
-- savoir exactement ce que fait la réinitialisation des données.
-
-Ce guide est orienté usage métier et tests manuels. Il complète la documentation technique, mais n'a pas besoin d'être lu comme une spécification.
+Il est orienté usage métier et tests manuels.
 
 ## Les deux types d'import
 
 ### Import `Gestion`
 
-L'import `Gestion` sert à reprendre les données de gestion courante contenues dans un classeur historique.
+L'import `Gestion` sert à reprendre la gestion courante depuis un classeur historique.
 
-Il peut créer :
+Il peut créer ou alimenter :
 
 - des contacts ;
 - des factures ;
 - des paiements ;
 - des mouvements de caisse ;
-- des mouvements bancaires ;
-- des écritures comptables générées à partir des règles comptables configurées dans Solde.
+- des transactions bancaires ;
+- des écritures comptables générées à partir des règles présentes dans Solde.
 
-Sur les fichiers historiques actuellement utilisés, l'import `Gestion` peut aussi reconstituer des factures fournisseurs et leur règlement quand il détecte des références de type `FF-...` dans les feuilles `Banque` ou `Caisse`.
+Sur les fichiers historiques actuellement utilisés, il peut aussi reconstituer des factures fournisseurs et leur règlement quand des références de type `FF-...` sont détectées dans `Banque` ou `Caisse`.
 
-### Import `Comptabilité`
+### Import `Comptabilite`
 
-L'import `Comptabilité` sert à importer les écritures du `Journal` Excel comme écritures comptables supplémentaires.
+L'import `Comptabilite` sert à reprendre les écritures du `Journal` Excel.
 
-Il ne crée pas de contacts, de factures ni de paiements. Il ajoute uniquement des écritures comptables manuelles.
+Il ne crée pas de contacts, de factures ni de paiements. Il ajoute uniquement des écritures comptables.
 
-Si des écritures ont déjà été générées dans Solde depuis la gestion, l'import `Comptabilité` reste autorisé :
+Si des écritures existent déjà dans Solde :
 
 - les doublons exacts sont ignorés ;
-- seules les écritures nouvelles sont ajoutées.
+- les lignes réellement nouvelles restent importables ;
+- certaines proximités avec des écritures manuelles existantes peuvent être seulement signalées en avertissement.
 
 ## Avant de commencer
 
-Avant toute reprise ou tout test manuel, vérifier les points suivants.
+Avant toute reprise ou tout retest manuel, vérifier les points suivants.
 
 1. Travailler sur une base sauvegardée ou restaurable facilement.
-2. Utiliser un fichier Excel source non modifié entre deux essais, sinon le garde-fou de réimport exact devient moins utile.
-3. Créer d'abord les exercices comptables couvrant toutes les dates réellement présentes dans les fichiers à importer.
-4. Préparer le plan comptable si vous voulez relire et contrôler correctement les écritures importées.
-5. Préparer les règles comptables si vous voulez que l'import `Gestion` génère automatiquement les écritures correspondantes.
+2. Utiliser un fichier Excel source inchangé entre deux essais comparables.
+3. Créer les exercices comptables couvrant réellement les dates présentes dans les fichiers.
+4. Préparer le plan comptable si vous voulez relire les écritures importées.
+5. Préparer les règles comptables si vous voulez que `Gestion` génère automatiquement ses écritures.
 
-Important : l'import Excel ne crée pas automatiquement :
+Important : l'import Excel ne crée pas automatiquement les exercices, le plan comptable ou les règles comptables.
 
-- les exercices comptables ;
-- le plan comptable ;
-- les règles comptables.
+## Workflow recommandé
 
-Pour les fichiers historiques actuellement rejoués dans le projet, il faut prévoir des exercices couvrant les dates de `2022` à `2026`, même si les fichiers portent les noms `2024` et `2025`.
+Quand l'import a été préparé par Solde via le flux réversible, l'ordre recommandé est le suivant :
 
-## Ordre recommandé pour les tests historiques actuels
+1. Prévisualiser.
+2. Exécuter l'import si le diagnostic est acceptable.
+3. Vérifier le résultat métier.
+4. Utiliser l'historique d'import pour `undo` ou `redo` tant que le journal réversible reste applicable.
 
-Pour le rejeu manuel des fichiers actuellement disponibles, l'ordre recommandé est le suivant.
+Quand le flux réversible ne suffit pas, ou pour des imports historiques plus anciens non couverts par ce mécanisme, utiliser le reset sélectif décrit plus bas.
 
-1. Importer `Gestion 2024.xlsx`.
-2. Importer `Gestion 2025.xlsx`.
-3. Vérifier que le résultat est cohérent côté gestion et écritures générées.
-4. Importer ensuite `Comptabilité 2024.xlsx` si vous voulez compléter la comptabilité avec le journal Excel.
-5. Importer enfin `Comptabilité 2025.xlsx`.
-
-Cet ordre est important, car certains rapprochements de paiements deviennent non ambigus seulement si le fichier `Gestion` précédent a déjà été repris.
-
-## Raccourcis temporaires de test
-
-En développement local, la page `Import Excel` peut afficher quatre boutons temporaires pour rejouer directement les fichiers historiques sans passer par la prévisualisation ni la confirmation des avertissements.
-
-Ces boutons sont volontairement réservés aux tests locaux. Ils utilisent des chemins de fichiers configurés côté serveur et restent désactivés tant que les classeurs attendus ne sont pas trouvés.
-
-Quand ils sont activés, l'ordre recommandé reste le même :
-
-1. `Gestion 2024`
-2. `Gestion 2025`
-3. `Comptabilité 2024`
-4. `Comptabilité 2025`
-
-Le résultat détaillé de chaque import reste affiché dans la page après exécution, ce qui permet de contrôler immédiatement les créations, lignes ignorées et blocages sans masquer un éventuel problème dans une opération globale.
-
-## Comment utiliser la prévisualisation
+## Prévisualisation
 
 La prévisualisation est l'étape obligatoire avant un import.
 
@@ -219,398 +78,135 @@ Elle permet de voir :
 
 Procédure recommandée :
 
-1. Choisir le bon type de fichier : `Gestion` ou `Comptabilité`.
+1. Choisir le bon type de fichier : `Gestion` ou `Comptabilite`.
 2. Sélectionner le fichier Excel.
 3. Lancer la prévisualisation.
 4. Vérifier que l'état général permet l'import.
 5. Relire les avertissements feuille par feuille.
 6. Contrôler les compteurs de lignes ignorées et bloquantes.
 
-Si la prévisualisation est bloquée, il ne faut pas lancer l'import. Il faut d'abord corriger la donnée source ou la stratégie de reprise.
+Si la prévisualisation est bloquée, il ne faut pas lancer l'import.
 
-## Comment interpréter les diagnostics
-
-Tous les messages n'ont pas la même gravité.
+## Comment lire les diagnostics
 
 ### Avertissements
 
 Un avertissement indique qu'une ligne ou une feuille a été ignorée, ou qu'une adaptation automatique a été appliquée sans bloquer l'import.
 
-Exemples fréquents :
-
-- feuille auxiliaire ignorée ;
-- ligne `Total` ignorée dans `Factures` ;
-- ligne de solde initial ignorée dans `Caisse` ;
-- ligne descriptive de solde ignorée dans `Banque` ;
-- ligne `Journal` à débit et crédit nuls ignorée ;
-- doublon exact déjà présent en comptabilité.
-
 ### Lignes bloquantes
 
 Une ligne bloquante empêche l'import complet du fichier.
-
-Exemples fréquents :
-
-- colonnes requises absentes ;
-- date ou montant invalide ;
-- paiement impossible à rapprocher ;
-- paiement ambigu ;
-- contact ou facture impossible à déterminer sans ambiguïté.
 
 ### Réimport exact
 
 Si un même fichier a déjà été importé avec succès, Solde refuse son réimport exact.
 
-Ce comportement est volontaire. Il évite les doublons involontaires et protège la reprise historique.
+Ce comportement évite les doublons involontaires et protège la reprise historique.
 
-## Ce que fait réellement l'import `Gestion`
+## Historique d'import réversible
 
-L'import `Gestion` lit plusieurs feuilles du classeur historique.
+L'historique d'import réversible est le premier outil à utiliser pour rejouer proprement un import récent préparé par Solde.
 
-En pratique, il peut :
+Il permet, selon le cas :
 
-- créer les contacts absents ;
-- créer les factures absentes ;
-- rapprocher les paiements avec les factures existantes ou importées dans le même flux ;
-- créer les mouvements de caisse et de banque ;
-- générer les écritures comptables correspondantes si les règles existent déjà dans Solde ;
-- créer des factures fournisseurs historiques et leur règlement si une référence `FF-...` est détectée dans `Banque` ou `Caisse`.
+- de relire les opérations préparées ;
+- d'exécuter un import préparé ;
+- d'annuler un import ou une opération ;
+- de rejouer une opération annulée.
 
-L'import `Gestion` n'est donc pas limité aux seules factures clients. Sur les fichiers historiques, il peut enrichir sensiblement la reprise comptable.
+Ce mécanisme est strict : si l'état courant ne correspond plus à l'état attendu, Solde bloque l'`undo` ou le `redo` pour éviter une annulation incohérente.
 
-## Ce que fait réellement l'import `Comptabilité`
+## Reset sélectif de reprise
 
-L'import `Comptabilité` se concentre sur la feuille `Journal`.
+Le reset sélectif est disponible dans la zone de danger des paramètres.
 
-Il :
+Il sert à supprimer un périmètre d'import ciblé sans effacer toute la base.
 
-- importe les écritures exploitables ;
-- rattache chaque écriture à l'exercice couvrant sa date, si cet exercice existe ;
-- ignore les lignes à débit et crédit nuls ;
-- ignore les doublons exacts déjà présents ;
-- laisse de côté les feuilles de reporting et `Journal (saisie)`.
+### Quand l'utiliser
 
-Il ne remplace pas la préparation du plan comptable et ne crée pas les règles comptables.
+Utiliser ce reset quand :
 
-## Contrôles manuels après import
+- l'import d'origine n'était pas couvert par le journal réversible ;
+- l'`undo` strict n'est plus applicable ;
+- vous devez rejouer un import historique `Gestion` ou `Comptabilite` pour un exercice précis.
 
-Après chaque import, vérifier au minimum les points suivants.
+### Comment il est ciblé
 
-1. Le résumé global de l'import.
-2. Le détail feuille par feuille.
-3. Les compteurs de créations, de lignes ignorées et de lignes bloquantes.
-4. La présence des objets attendus dans l'interface.
-5. Le rattachement des écritures au bon exercice.
-6. L'absence d'erreur inattendue dans le résultat final.
+Le reset sélectif demande deux choix :
 
-Pour les tests historiques actuels, il est utile de comparer le résultat obtenu avec les ordres de grandeur déjà rejoués dans le projet :
+- la filière d'import : `Gestion` ou `Comptabilite` ;
+- l'exercice à nettoyer.
 
-- `Gestion 2024.xlsx` : `64` contacts, `303` factures, `308` paiements, `1222` écritures, `102` mouvements de caisse, `210` transactions bancaires ;
-- `Gestion 2025.xlsx` : `18` contacts, `211` factures, `211` paiements, `844` écritures, `75` mouvements de caisse, `145` transactions bancaires ;
-- `Comptabilité 2024.xlsx` : `1367` écritures importées ;
-- `Comptabilité 2025.xlsx` : `928` écritures importées.
+Solde construit alors un plan de suppression à partir des traces d'import et affiche une prévisualisation avant confirmation.
 
-Ces chiffres correspondent au rejeu réel validé sur base isolée avec les fichiers historiques présents dans `data/`.
+### Ce que supprime le reset sélectif
 
-## Quand clôturer les exercices historiques
+Pour `Gestion`, Solde supprime :
 
-Pendant une reprise historique, il ne faut pas clôturer les exercices au fil de l'eau.
+- les objets importés retrouvés dans les traces ;
+- les objets dérivés ensuite créés dans Solde à partir de ces objets importés quand ils font partie des dépendances métier connues ;
+- les traces d'import associées au périmètre supprimé.
 
-La bonne séquence est la suivante :
+Pour `Comptabilite`, Solde supprime :
 
-1. créer tous les exercices nécessaires ;
-2. importer tous les fichiers historiques ;
-3. vérifier le résultat métier et comptable ;
-4. clôturer ensuite les anciens exercices avec la clôture administrative.
+- les écritures importées pour l'exercice ciblé ;
+- les traces d'import associées.
 
-La clôture administrative sert uniquement à marquer un exercice comme clôturé sans créer de nouvelles écritures de clôture ou de report à nouveau. Elle est adaptée aux exercices déjà clôturés dans Excel avant reprise.
+La prévisualisation liste séparément :
 
-La clôture classique de Solde doit rester réservée aux exercices gérés directement dans l'application.
+- les objets importés retrouvés ;
+- les objets dérivés identifiés ;
+- le plan de suppression final.
 
-## Réinitialisation des données
+### Limites à connaître
 
-La réinitialisation des données est une action d'administration destinée surtout aux démonstrations et aux tests de reprise.
+Le reset sélectif n'est pas un moteur générique de nettoyage universel.
 
-Elle supprime toutes les données applicatives, y compris :
+Il applique les règles métier actuellement connues pour la reprise d'import. Il faut donc toujours relire la prévisualisation avant de confirmer.
 
-- les paramètres ;
-- le plan comptable ;
-- les règles comptables ;
-- les exercices comptables ;
+### Précaution importante
+
+Cette action est irréversible.
+
+Avant de l'utiliser, vérifier que vous travaillez bien sur l'exercice voulu et sur la bonne filière d'import.
+
+## Réinitialisation complète de la base
+
+La réinitialisation complète supprime toutes les données applicatives.
+
+Elle efface notamment :
+
 - les contacts ;
 - les factures ;
 - les paiements ;
 - les écritures comptables ;
 - les données de banque et de caisse ;
-- l'historique d'import.
+- les traces d'import.
 
-Seuls les utilisateurs sont conservés.
-
-Conséquence importante : après une réinitialisation, il faut reconfigurer l'environnement avant de relancer un import, en particulier :
-
-1. recréer les exercices comptables nécessaires ;
-2. recharger ou recréer le plan comptable ;
-3. recharger ou recréer les règles comptables si l'on veut régénérer les écritures depuis la gestion.
-
-Cette action est irréversible. Elle ne doit pas être utilisée sur une base que vous souhaitez conserver en l'état.
-
-## En cas de doute
-
-Si un import donne un résultat inattendu :
-
-1. ne pas relancer immédiatement sans comprendre ce qui s'est passé ;
-2. relire la prévisualisation ;
-3. vérifier les lignes ignorées et bloquantes ;
-4. vérifier que les exercices nécessaires existent bien ;
-5. repartir d'une base restaurée si vous devez refaire une reprise complète propre.
-
-En phase de transition, si vous tenez encore la comptabilité en parallèle dans Excel et dans Solde, l'import doit aussi servir de contrôle régulier pour vérifier qu'aucune écriture ne manque et qu'aucune divergence n'a été introduite.
-||||||| parent of 8704648 (feat(import): improve replay and accounting workflows)
-=======
-# Guide utilisateur — import Excel et réinitialisation
-
-## But
-
-Ce document explique comment utiliser l'import Excel dans Solde pour :
-
-- initialiser l'application à partir des fichiers historiques existants ;
-- contrôler le résultat d'un import avant validation ;
-- comprendre les messages affichés par la prévisualisation et par l'import ;
-- savoir exactement ce que fait la réinitialisation des données.
-
-Ce guide est orienté usage métier et tests manuels. Il complète la documentation technique, mais n'a pas besoin d'être lu comme une spécification.
-
-## Les deux types d'import
-
-### Import `Gestion`
-
-L'import `Gestion` sert à reprendre les données de gestion courante contenues dans un classeur historique.
-
-Il peut créer :
-
-- des contacts ;
-- des factures ;
-- des paiements ;
-- des mouvements de caisse ;
-- des mouvements bancaires ;
-- des écritures comptables générées à partir des règles comptables configurées dans Solde.
-
-Sur les fichiers historiques actuellement utilisés, l'import `Gestion` peut aussi reconstituer des factures fournisseurs et leur règlement quand il détecte des références de type `FF-...` dans les feuilles `Banque` ou `Caisse`.
-
-### Import `Comptabilité`
-
-L'import `Comptabilité` sert à importer les écritures du `Journal` Excel comme écritures comptables supplémentaires.
-
-Il ne crée pas de contacts, de factures ni de paiements. Il ajoute uniquement des écritures comptables manuelles.
-
-Si des écritures ont déjà été générées dans Solde depuis la gestion, l'import `Comptabilité` reste autorisé :
-
-- les doublons exacts sont ignorés ;
-- seules les écritures nouvelles sont ajoutées.
-
-## Avant de commencer
-
-Avant toute reprise ou tout test manuel, vérifier les points suivants.
-
-1. Travailler sur une base sauvegardée ou restaurable facilement.
-2. Utiliser un fichier Excel source non modifié entre deux essais, sinon le garde-fou de réimport exact devient moins utile.
-3. Créer d'abord les exercices comptables couvrant toutes les dates réellement présentes dans les fichiers à importer.
-4. Préparer le plan comptable si vous voulez relire et contrôler correctement les écritures importées.
-5. Préparer les règles comptables si vous voulez que l'import `Gestion` génère automatiquement les écritures correspondantes.
-
-Important : l'import Excel ne crée pas automatiquement :
+Après une réinitialisation complète, il faut reconfigurer l'environnement avant de relancer une reprise, en particulier :
 
 - les exercices comptables ;
 - le plan comptable ;
-- les règles comptables.
+- les règles comptables utiles ;
+- les éventuels paramétrages de trésorerie d'ouverture.
 
-Pour les fichiers historiques actuellement rejoués dans le projet, il faut prévoir des exercices couvrant les dates de `2022` à `2026`, même si les fichiers portent les noms `2024` et `2025`.
+Cette action doit rester réservée aux démonstrations, essais isolés et reprises complètes sur base jetable ou restaurable.
 
-## Ordre recommandé pour les tests historiques actuels
+## Contrôles manuels après import ou reset
 
-Pour le rejeu manuel des fichiers actuellement disponibles, l'ordre recommandé est le suivant.
+Après chaque import, `undo`, reset sélectif ou reset complet, vérifier au minimum :
 
-1. Importer `Gestion 2024.xlsx`.
-2. Importer `Gestion 2025.xlsx`.
-3. Vérifier que le résultat est cohérent côté gestion et écritures générées.
-4. Importer ensuite `Comptabilité 2024.xlsx` si vous voulez compléter la comptabilité avec le journal Excel.
-5. Importer enfin `Comptabilité 2025.xlsx`.
-
-Cet ordre est important, car certains rapprochements de paiements deviennent non ambigus seulement si le fichier `Gestion` précédent a déjà été repris.
-
-## Raccourcis temporaires de test
-
-En développement local, la page `Import Excel` peut afficher quatre boutons temporaires pour rejouer directement les fichiers historiques sans passer par la prévisualisation ni la confirmation des avertissements.
-
-Ces boutons sont volontairement réservés aux tests locaux. Ils utilisent des chemins de fichiers configurés côté serveur et restent désactivés tant que les classeurs attendus ne sont pas trouvés.
-
-Quand ils sont activés, l'ordre recommandé reste le même :
-
-1. `Gestion 2024`
-2. `Gestion 2025`
-3. `Comptabilité 2024`
-4. `Comptabilité 2025`
-
-Le résultat détaillé de chaque import reste affiché dans la page après exécution, ce qui permet de contrôler immédiatement les créations, lignes ignorées et blocages sans masquer un éventuel problème dans une opération globale.
-
-## Comment utiliser la prévisualisation
-
-La prévisualisation est l'étape obligatoire avant un import.
-
-Elle permet de voir :
-
-- si le fichier est importable dans l'état actuel de la base ;
-- combien d'objets ou d'écritures seront probablement créés ;
-- quelles feuilles sont reconnues ;
-- quelles lignes seront ignorées ;
-- quelles lignes bloquent l'import.
-
-Procédure recommandée :
-
-1. Choisir le bon type de fichier : `Gestion` ou `Comptabilité`.
-2. Sélectionner le fichier Excel.
-3. Lancer la prévisualisation.
-4. Vérifier que l'état général permet l'import.
-5. Relire les avertissements feuille par feuille.
-6. Contrôler les compteurs de lignes ignorées et bloquantes.
-
-Si la prévisualisation est bloquée, il ne faut pas lancer l'import. Il faut d'abord corriger la donnée source ou la stratégie de reprise.
-
-## Comment interpréter les diagnostics
-
-Tous les messages n'ont pas la même gravité.
-
-### Avertissements
-
-Un avertissement indique qu'une ligne ou une feuille a été ignorée, ou qu'une adaptation automatique a été appliquée sans bloquer l'import.
-
-Exemples fréquents :
-
-- feuille auxiliaire ignorée ;
-- ligne `Total` ignorée dans `Factures` ;
-- ligne de solde initial ignorée dans `Caisse` ;
-- ligne descriptive de solde ignorée dans `Banque` ;
-- ligne `Journal` à débit et crédit nuls ignorée ;
-- doublon exact déjà présent en comptabilité.
-
-### Lignes bloquantes
-
-Une ligne bloquante empêche l'import complet du fichier.
-
-Exemples fréquents :
-
-- colonnes requises absentes ;
-- date ou montant invalide ;
-- paiement impossible à rapprocher ;
-- paiement ambigu ;
-- contact ou facture impossible à déterminer sans ambiguïté.
-
-### Réimport exact
-
-Si un même fichier a déjà été importé avec succès, Solde refuse son réimport exact.
-
-Ce comportement est volontaire. Il évite les doublons involontaires et protège la reprise historique.
-
-## Ce que fait réellement l'import `Gestion`
-
-L'import `Gestion` lit plusieurs feuilles du classeur historique.
-
-En pratique, il peut :
-
-- créer les contacts absents ;
-- créer les factures absentes ;
-- rapprocher les paiements avec les factures existantes ou importées dans le même flux ;
-- créer les mouvements de caisse et de banque ;
-- générer les écritures comptables correspondantes si les règles existent déjà dans Solde ;
-- créer des factures fournisseurs historiques et leur règlement si une référence `FF-...` est détectée dans `Banque` ou `Caisse`.
-
-L'import `Gestion` n'est donc pas limité aux seules factures clients. Sur les fichiers historiques, il peut enrichir sensiblement la reprise comptable.
-
-## Ce que fait réellement l'import `Comptabilité`
-
-L'import `Comptabilité` se concentre sur la feuille `Journal`.
-
-Il :
-
-- importe les écritures exploitables ;
-- rattache chaque écriture à l'exercice couvrant sa date, si cet exercice existe ;
-- ignore les lignes à débit et crédit nuls ;
-- ignore les doublons exacts déjà présents ;
-- laisse de côté les feuilles de reporting et `Journal (saisie)`.
-
-Il ne remplace pas la préparation du plan comptable et ne crée pas les règles comptables.
-
-## Contrôles manuels après import
-
-Après chaque import, vérifier au minimum les points suivants.
-
-1. Le résumé global de l'import.
-2. Le détail feuille par feuille.
-3. Les compteurs de créations, de lignes ignorées et de lignes bloquantes.
-4. La présence des objets attendus dans l'interface.
-5. Le rattachement des écritures au bon exercice.
-6. L'absence d'erreur inattendue dans le résultat final.
-
-Pour les tests historiques actuels, il est utile de comparer le résultat obtenu avec les ordres de grandeur déjà rejoués dans le projet :
-
-- `Gestion 2024.xlsx` : `64` contacts, `303` factures, `308` paiements, `1222` écritures, `102` mouvements de caisse, `210` transactions bancaires ;
-- `Gestion 2025.xlsx` : `18` contacts, `211` factures, `211` paiements, `844` écritures, `75` mouvements de caisse, `145` transactions bancaires ;
-- `Comptabilité 2024.xlsx` : `1367` écritures importées ;
-- `Comptabilité 2025.xlsx` : `928` écritures importées.
-
-Ces chiffres correspondent au rejeu réel validé sur base isolée avec les fichiers historiques présents dans `data/`.
-
-## Quand clôturer les exercices historiques
-
-Pendant une reprise historique, il ne faut pas clôturer les exercices au fil de l'eau.
-
-La bonne séquence est la suivante :
-
-1. créer tous les exercices nécessaires ;
-2. importer tous les fichiers historiques ;
-3. vérifier le résultat métier et comptable ;
-4. clôturer ensuite les anciens exercices avec la clôture administrative.
-
-La clôture administrative sert uniquement à marquer un exercice comme clôturé sans créer de nouvelles écritures de clôture ou de report à nouveau. Elle est adaptée aux exercices déjà clôturés dans Excel avant reprise.
-
-La clôture classique de Solde doit rester réservée aux exercices gérés directement dans l'application.
-
-## Réinitialisation des données
-
-La réinitialisation des données est une action d'administration destinée surtout aux démonstrations et aux tests de reprise.
-
-Elle supprime toutes les données applicatives, y compris :
-
-- les paramètres ;
-- le plan comptable ;
-- les règles comptables ;
-- les exercices comptables ;
-- les contacts ;
-- les factures ;
-- les paiements ;
-- les écritures comptables ;
-- les données de banque et de caisse ;
-- l'historique d'import.
-
-Seuls les utilisateurs sont conservés.
-
-Conséquence importante : après une réinitialisation, il faut reconfigurer l'environnement avant de relancer un import, en particulier :
-
-1. recréer les exercices comptables nécessaires ;
-2. recharger ou recréer le plan comptable ;
-3. recharger ou recréer les règles comptables si l'on veut régénérer les écritures depuis la gestion.
-
-Cette action est irréversible. Elle ne doit pas être utilisée sur une base que vous souhaitez conserver en l'état.
+1. le résumé global de l'opération ;
+2. les objets attendus ou supprimés ;
+3. les exercices concernés ;
+4. les journaux de banque, de caisse et de comptabilité si le périmètre les touche ;
+5. l'absence d'effet de bord inattendu sur les autres données conservées.
 
 ## En cas de doute
 
-Si un import donne un résultat inattendu :
+Si un résultat semble incohérent :
 
-1. ne pas relancer immédiatement sans comprendre ce qui s'est passé ;
-2. relire la prévisualisation ;
-3. vérifier les lignes ignorées et bloquantes ;
-4. vérifier que les exercices nécessaires existent bien ;
-5. repartir d'une base restaurée si vous devez refaire une reprise complète propre.
-
-En phase de transition, si vous tenez encore la comptabilité en parallèle dans Excel et dans Solde, l'import doit aussi servir de contrôle régulier pour vérifier qu'aucune écriture ne manque et qu'aucune divergence n'a été introduite.
->>>>>>> 8704648 (feat(import): improve replay and accounting workflows)
+1. ne pas rejouer immédiatement sans comprendre ;
+2. relire la prévisualisation ou l'historique d'import ;
+3. vérifier le bon exercice et le bon type d'import ;
+4. repartir d'une base restaurée si vous devez refaire une reprise complète propre.

--- a/frontend/src/api/accounting.ts
+++ b/frontend/src/api/accounting.ts
@@ -599,8 +599,18 @@ export async function listTestImportShortcutsApi(): Promise<TestImportShortcut[]
   return response.data
 }
 
-export async function importTestShortcutApi(alias: string): Promise<ImportResult> {
-  const response = await apiClient.post<ImportResult>(`/api/import/excel/test-shortcuts/${alias}`)
+export async function importTestShortcutApi(
+  alias: string,
+  comparisonWindow: PreviewComparisonWindow = {},
+): Promise<ImportRunRead> {
+  const response = await apiClient.post<ImportRunRead>(
+    `/api/import/excel/test-shortcuts/${alias}`,
+    undefined,
+    {
+      params: comparisonWindow,
+      timeout: 120000,
+    },
+  )
   return response.data
 }
 
@@ -917,27 +927,45 @@ export async function getImportRunApi(runId: number): Promise<ImportRunRead> {
 }
 
 export async function executeImportRunApi(runId: number): Promise<ImportRunRead> {
-  const response = await apiClient.post<ImportRunRead>(`/api/import/runs/${runId}/execute`)
+  const response = await apiClient.post<ImportRunRead>(`/api/import/runs/${runId}/execute`, undefined, {
+    timeout: 120000,
+  })
   return response.data
 }
 
 export async function undoImportRunApi(runId: number): Promise<ImportRunRead> {
-  const response = await apiClient.post<ImportRunRead>(`/api/import/runs/${runId}/undo`)
+  const response = await apiClient.post<ImportRunRead>(`/api/import/runs/${runId}/undo`, undefined, {
+    timeout: 120000,
+  })
   return response.data
 }
 
 export async function redoImportRunApi(runId: number): Promise<ImportRunRead> {
-  const response = await apiClient.post<ImportRunRead>(`/api/import/runs/${runId}/redo`)
+  const response = await apiClient.post<ImportRunRead>(`/api/import/runs/${runId}/redo`, undefined, {
+    timeout: 120000,
+  })
   return response.data
 }
 
 export async function undoImportOperationApi(operationId: number): Promise<ImportRunRead> {
-  const response = await apiClient.post<ImportRunRead>(`/api/import/operations/${operationId}/undo`)
+  const response = await apiClient.post<ImportRunRead>(
+    `/api/import/operations/${operationId}/undo`,
+    undefined,
+    {
+      timeout: 120000,
+    },
+  )
   return response.data
 }
 
 export async function redoImportOperationApi(operationId: number): Promise<ImportRunRead> {
-  const response = await apiClient.post<ImportRunRead>(`/api/import/operations/${operationId}/redo`)
+  const response = await apiClient.post<ImportRunRead>(
+    `/api/import/operations/${operationId}/redo`,
+    undefined,
+    {
+      timeout: 120000,
+    },
+  )
   return response.data
 }
 

--- a/frontend/src/api/settings.ts
+++ b/frontend/src/api/settings.ts
@@ -49,6 +49,25 @@ export interface TreasurySystemOpeningUpdate {
   bank: SystemOpeningUpdate
   cash: SystemOpeningUpdate
 }
+export type SelectiveResetImportType = 'gestion' | 'comptabilite'
+
+export interface SelectiveResetRequest {
+  import_type: SelectiveResetImportType
+  fiscal_year_id: number
+}
+
+export interface SelectiveResetPreview {
+  import_type: SelectiveResetImportType
+  fiscal_year_id: number
+  fiscal_year_name: string
+  fiscal_year_start_date: string
+  fiscal_year_end_date: string
+  matched_import_logs: number
+  matched_import_runs: number
+  root_objects: Record<string, number>
+  derived_objects: Record<string, number>
+  delete_plan: Record<string, number>
+}
 
 export async function getSettingsApi(): Promise<AppSettings> {
   const response = await apiClient.get<AppSettings>('/api/settings/')
@@ -77,6 +96,26 @@ export async function updateSystemOpeningApi(
 
 export async function resetDbApi(): Promise<Record<string, number>> {
   const response = await apiClient.post<Record<string, number>>('/api/settings/reset-db')
+  return response.data
+}
+
+export async function previewSelectiveResetApi(
+  payload: SelectiveResetRequest,
+): Promise<SelectiveResetPreview> {
+  const response = await apiClient.post<SelectiveResetPreview>(
+    '/api/settings/selective-reset/preview',
+    payload,
+  )
+  return response.data
+}
+
+export async function applySelectiveResetApi(
+  payload: SelectiveResetRequest,
+): Promise<SelectiveResetPreview> {
+  const response = await apiClient.post<SelectiveResetPreview>(
+    '/api/settings/selective-reset/apply',
+    payload,
+  )
   return response.data
 }
 

--- a/frontend/src/i18n/fr.ts
+++ b/frontend/src/i18n/fr.ts
@@ -676,6 +676,39 @@ export default {
     bootstrap_accounting_error: 'Erreur lors de la recréation du socle comptable.',
     reset_db_done: '{count} ligne(s) supprimée(s). La base est réinitialisée.',
     reset_db_error: 'Erreur lors de la réinitialisation.',
+    selective_reset_title: 'Reset sélectif de reprise',
+    selective_reset_subtitle:
+      'Supprime un périmètre d’import ciblé par filière et exercice sans effacer toute la base.',
+    selective_reset_type: 'Filière d’import',
+    selective_reset_fiscal_year: 'Exercice à nettoyer',
+    selective_reset_preview: 'Prévisualiser le reset',
+    selective_reset_apply: 'Appliquer le reset sélectif',
+    selective_reset_help:
+      'Utilisez ce reset seulement quand l’undo strict ne suffit pas ou quand l’import d’origine n’était pas réversible.',
+    selective_reset_missing_fiscal_year: 'Choisissez un exercice avant de lancer la prévisualisation.',
+    selective_reset_preview_ready: 'Plan de suppression prêt pour {type} {year}.',
+    selective_reset_preview_empty: 'Aucun objet correspondant trouvé pour ce périmètre.',
+    selective_reset_done: '{count} objet(s) et traces associées supprimés pour {type} {year}.',
+    selective_reset_error: 'Erreur lors du reset sélectif.',
+    selective_reset_confirm:
+      'Cette suppression ciblée est irréversible. Le périmètre prévisualisé va être supprimé avec ses dépendances métier. Confirmer ?',
+    selective_reset_confirm_header: 'Confirmer le reset sélectif',
+    selective_reset_apply_yes: 'Oui, supprimer ce périmètre',
+    selective_reset_import_type_gestion: 'Gestion',
+    selective_reset_import_type_comptabilite: 'Comptabilité',
+    selective_reset_root_objects: 'Objets importés repérés',
+    selective_reset_derived_objects: 'Objets dérivés ajoutés ensuite dans Solde',
+    selective_reset_delete_plan: 'Plan de suppression',
+    selective_reset_object_contact: 'Contacts',
+    selective_reset_object_invoice: 'Factures',
+    selective_reset_object_payment: 'Paiements',
+    selective_reset_object_salary: 'Salaires',
+    selective_reset_object_cash_register: 'Mouvements de caisse',
+    selective_reset_object_bank_transaction: 'Transactions bancaires',
+    selective_reset_object_accounting_entry: 'Écritures comptables',
+    selective_reset_object_deposit: 'Bordereaux de remise',
+    selective_reset_object_import_logs: 'Journaux d’import legacy',
+    selective_reset_object_import_runs: 'Runs d’import réversibles',
   },
   accounting: {
     account_types: {
@@ -1051,11 +1084,8 @@ export default {
     confirm_import: "Confirmer l'import",
     import_ready: 'La prévisualisation est valide. Vous pouvez lancer l’import.',
     run_not_executable: 'Cette préparation ne peut pas être exécutée dans son état actuel.',
-    warning_ack_label:
-      'J’ai vérifié les avertissements et je confirme que l’import peut continuer.',
-    warning_ack_help:
-      'Les avertissements signalent des lignes ignorées ou des adaptations automatiques. Une confirmation explicite est requise avant l’import.',
-    warning_ack_required: 'Confirmez explicitement les avertissements avant de lancer l’import.',
+    warning_review_hint:
+      'Des avertissements ont été détectés. L’import reste possible, mais vérifiez-les avant de continuer.',
     result_title: "Résultat de l'import",
     contacts_created: 'Contacts créés',
     invoices_created: 'Factures créées',
@@ -1072,6 +1102,7 @@ export default {
     no_warnings: 'Aucun avertissement.',
     success: 'Import terminé avec succès.',
     completed_with_issues: 'Import terminé avec remarques.',
+    failed: 'Import terminé en échec.',
     undo_run: 'Annuler ce run',
     redo_run: 'Rejouer ce run',
     undo_operation: 'Annuler l’opération',
@@ -1094,9 +1125,13 @@ export default {
     unknown_file: 'Fichier sans nom',
     result_persistent_hint:
       '{count} élément(s) créé(s), {ignored} ligne(s) ignorée(s) et {blocked} ligne(s) bloquantes. Le détail complet reste affiché ci-dessous.',
+    result_failed_hint:
+      'Le run a échoué après {count} création(s). {errors} erreur(s) sont listées ci-dessous.',
     file_required: 'Veuillez sélectionner un fichier.',
     request_timeout:
       'L’import prend plus de temps que prévu. Le traitement a peut-être continué côté serveur ; vérifiez le résultat puis relancez si nécessaire.',
+    request_timeout_refreshed:
+      'Le traitement a pu se terminer côté serveur. L’état affiché vient d’être rechargé.',
     result_sheets_title: 'Détail par feuille',
     sheet_ignored_rows: '{count} ligne(s) ignorée(s)',
     sheet_blocked_rows: '{count} ligne(s) bloquante(s)',

--- a/frontend/src/tests/views/ImportExcelView.spec.ts
+++ b/frontend/src/tests/views/ImportExcelView.spec.ts
@@ -228,7 +228,7 @@ describe('ImportExcelView', () => {
     ).toBe('2026-07-31')
   })
 
-  it('requires explicit warning acknowledgment before import', async () => {
+  it('keeps import enabled and shows a warning hint when preview has warnings', async () => {
     mockPrepareGestionRunApi.mockResolvedValueOnce(
       buildImportRun({
         preview: buildPreviewResult({
@@ -259,20 +259,15 @@ describe('ImportExcelView', () => {
 
     expect(
       (wrapper.get('[data-testid="primary-import-button"]').element as HTMLButtonElement).disabled,
-    ).toBe(true)
-    expect(
-      (wrapper.get('[data-testid="confirm-import-button"]').element as HTMLButtonElement).disabled,
-    ).toBe(true)
-
-    await wrapper.get('[data-testid="warning-ack-checkbox"]').setValue(true)
-    await nextTick()
-
-    expect(
-      (wrapper.get('[data-testid="primary-import-button"]').element as HTMLButtonElement).disabled,
     ).toBe(false)
     expect(
       (wrapper.get('[data-testid="confirm-import-button"]').element as HTMLButtonElement).disabled,
     ).toBe(false)
+
+    expect(wrapper.find('[data-testid="warning-ack-checkbox"]').exists()).toBe(false)
+    expect(wrapper.get('[data-testid="confirm-import-warning"]').text()).toContain(
+      'Des avertissements ont été détectés. L’import reste possible',
+    )
   })
 
   it('shows extra rows already present only in Solde inside the comparison summary', async () => {
@@ -514,6 +509,38 @@ describe('ImportExcelView', () => {
     )
   })
 
+  it('shows a failed result banner after an import run fails', async () => {
+    mockPrepareGestionRunApi.mockResolvedValueOnce(buildImportRun())
+    mockExecuteImportRunApi.mockResolvedValueOnce(
+      buildImportRun({
+        status: 'failed',
+        can_execute: false,
+        can_undo: true,
+        summary: buildImportResult({
+          errors: ['2024-0170 — Le paiement préparé existe déjà'],
+        }),
+      }),
+    )
+
+    const wrapper = mountView()
+    await selectFile(wrapper)
+    await wrapper.get('[data-testid="preview-button"]').trigger('click')
+    await flushView()
+    await wrapper.get('[data-testid="primary-import-button"]').trigger('click')
+    await flushView()
+
+    expect(wrapper.get('[data-testid="import-result-banner"]').text()).toContain(
+      'Import terminé en échec',
+    )
+    expect(wrapper.get('[data-testid="import-result-banner"]').text()).toContain(
+      '1 erreur(s) sont listées ci-dessous.',
+    )
+    expect(wrapper.get('[data-testid="import-result-banner-errors"]').text()).toContain(
+      '2024-0170 — Le paiement préparé existe déjà',
+    )
+    expect(wrapper.text()).toContain('2024-0170 — Le paiement préparé existe déjà')
+  })
+
   it('does not show an import result banner after preview only', async () => {
     mockPrepareGestionRunApi.mockResolvedValueOnce(
       buildImportRun({
@@ -582,9 +609,9 @@ describe('ImportExcelView', () => {
             source_sheet: 'Paiements',
             source_row_numbers: [18, 19],
             decision: 'apply',
-            status: 'prepared',
+            status: 'failed',
             diagnostics: [],
-            error_message: null,
+            error_message: 'Le paiement préparé existe déjà',
             can_undo: false,
             can_redo: false,
             effects: [
@@ -611,6 +638,7 @@ describe('ImportExcelView', () => {
     expect(wrapper.get('[data-testid="preview-quick-summary"]').text()).toContain(
       'Opérations préparées',
     )
+    expect(wrapper.text()).toContain('En échec: 1')
 
     expect(wrapper.get('[data-testid="operations-table"]').text()).toContain('Factures')
     expect(wrapper.get('[data-testid="operations-table"]').text()).toContain('Paiements')
@@ -838,7 +866,7 @@ describe('ImportExcelView', () => {
     expect(wrapper.get('[data-testid="operation-detail-202"]').text()).toContain('Christine LOPES')
   })
 
-  it('runs a temporary shortcut import without preview', async () => {
+  it('runs a temporary shortcut import through the reversible flow', async () => {
     mockListTestImportShortcutsApi.mockResolvedValueOnce([
       {
         alias: 'gestion-2024',
@@ -850,7 +878,17 @@ describe('ImportExcelView', () => {
         message: null,
       },
     ])
-    mockImportTestShortcutApi.mockResolvedValueOnce(buildImportResult())
+    mockImportTestShortcutApi.mockResolvedValueOnce(
+      buildImportRun({
+        status: 'completed',
+        file_name: 'Gestion 2024.xlsx',
+        comparison_start_date: '2024-08-01',
+        comparison_end_date: '2025-07-31',
+        summary: buildImportResult(),
+        can_execute: false,
+        can_undo: true,
+      }),
+    )
 
     const wrapper = mountView()
     await flushView()
@@ -859,7 +897,10 @@ describe('ImportExcelView', () => {
     await wrapper.get('[data-testid="quick-import-gestion-2024"]').trigger('click')
     await flushView()
 
-    expect(mockImportTestShortcutApi).toHaveBeenCalledWith('gestion-2024')
+    expect(mockImportTestShortcutApi).toHaveBeenCalledWith('gestion-2024', {
+      comparison_start_date: '2024-08-01',
+      comparison_end_date: '2025-07-31',
+    })
     expect(wrapper.get('[data-testid="import-result-banner"]').text()).toContain(
       'Import terminé avec succès',
     )

--- a/frontend/src/tests/views/ImportHistoryView.spec.ts
+++ b/frontend/src/tests/views/ImportHistoryView.spec.ts
@@ -14,6 +14,10 @@ vi.mock('vue-router', () => ({
 }))
 
 const mockListImportHistoryApi = vi.spyOn(accountingApi, 'listImportHistoryApi')
+const mockUndoImportRunApi = vi.spyOn(accountingApi, 'undoImportRunApi')
+const mockRedoImportRunApi = vi.spyOn(accountingApi, 'redoImportRunApi')
+const mockUndoImportOperationApi = vi.spyOn(accountingApi, 'undoImportOperationApi')
+const mockRedoImportOperationApi = vi.spyOn(accountingApi, 'redoImportOperationApi')
 
 const ButtonStub = defineComponent({
   props: {
@@ -78,6 +82,28 @@ function buildImportHistoryItem(overrides: Record<string, unknown> = {}) {
   } satisfies accountingApi.ImportHistoryItem
 }
 
+function buildImportOperation(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 11,
+    position: 1,
+    operation_type: 'client_invoice_row_import',
+    title: '2025-0142',
+    description: null,
+    source_sheet: 'Factures',
+    source_row_numbers: [2],
+    decision: 'apply' as const,
+    status: 'applied' as const,
+    diagnostics: [],
+    error_message: null,
+    can_undo: true,
+    can_redo: false,
+    effects: [],
+    planned_effects: [],
+    source_data: [],
+    ...overrides,
+  } satisfies accountingApi.ImportOperationRead
+}
+
 async function flushView() {
   await Promise.resolve()
   await nextTick()
@@ -101,6 +127,10 @@ function mountView() {
 describe('ImportHistoryView', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockUndoImportRunApi.mockReset()
+    mockRedoImportRunApi.mockReset()
+    mockUndoImportOperationApi.mockReset()
+    mockRedoImportOperationApi.mockReset()
   })
 
   it('loads and displays import history with diagnostics and created objects', async () => {
@@ -180,5 +210,126 @@ describe('ImportHistoryView', () => {
 
     expect(wrapper.get('[data-testid="import-history"]').text()).toContain('Erreur 12')
     expect(wrapper.get('[data-testid="history-errors-toggle-1"]').text()).toContain('Réduire')
+  })
+
+  it('shows failed operation errors and allows per-operation undo from history', async () => {
+    mockListImportHistoryApi.mockResolvedValueOnce([
+      buildImportHistoryItem({
+        id: 7,
+        kind: 'run',
+        import_type: 'gestion',
+        status: 'failed',
+        can_undo: true,
+        summary: {
+          contacts_created: 0,
+          invoices_created: 1,
+          payments_created: 0,
+          salaries_created: 0,
+          entries_created: 0,
+          cash_created: 0,
+          bank_created: 0,
+          skipped: 0,
+          ignored_rows: 0,
+          blocked_rows: 0,
+          warnings: [],
+          errors: ['Banque ligne 267 — forced payment generation failure'],
+          warning_details: [],
+          error_details: [],
+          sheets: [],
+          created_objects: [],
+        },
+        operations: [
+          buildImportOperation({
+            id: 41,
+            title: '2025-0142',
+            can_undo: true,
+          }),
+          buildImportOperation({
+            id: 42,
+            title: 'Banque ligne 267',
+            status: 'failed',
+            error_message: 'forced payment generation failure',
+            can_undo: false,
+            diagnostics: ['Paiement client détecté'],
+          }),
+        ],
+      }),
+    ])
+    mockUndoImportOperationApi.mockResolvedValueOnce({} as accountingApi.ImportRunRead)
+    mockListImportHistoryApi.mockResolvedValueOnce([
+      buildImportHistoryItem({
+        id: 7,
+        kind: 'run',
+        import_type: 'gestion',
+        status: 'partially_reverted',
+        can_undo: false,
+        can_redo: true,
+        operations: [
+          buildImportOperation({
+            id: 41,
+            title: '2025-0142',
+            status: 'undone',
+            can_undo: false,
+            can_redo: true,
+          }),
+          buildImportOperation({
+            id: 42,
+            title: 'Banque ligne 267',
+            status: 'failed',
+            error_message: 'forced payment generation failure',
+            can_undo: false,
+          }),
+        ],
+      }),
+    ])
+
+    const wrapper = mountView()
+    await flushView()
+    await flushView()
+
+    expect(wrapper.get('[data-testid="import-history"]').text()).toContain(
+      'forced payment generation failure',
+    )
+    await wrapper.get('[data-testid="history-operation-undo-41"]').trigger('click')
+    await flushView()
+    await flushView()
+
+    expect(mockUndoImportOperationApi).toHaveBeenCalledWith(41)
+    expect(wrapper.get('[data-testid="import-history"]').text()).toContain('Partiellement annulé')
+  })
+
+  it('reloads history after a timeout while undoing a run', async () => {
+    mockListImportHistoryApi.mockResolvedValueOnce([
+      buildImportHistoryItem({
+        id: 9,
+        kind: 'run',
+        import_type: 'gestion',
+        status: 'failed',
+        can_undo: true,
+      }),
+    ])
+    mockUndoImportRunApi.mockRejectedValueOnce({ code: 'ECONNABORTED' })
+    mockListImportHistoryApi.mockResolvedValueOnce([
+      buildImportHistoryItem({
+        id: 9,
+        kind: 'run',
+        import_type: 'gestion',
+        status: 'reverted',
+        can_undo: false,
+        can_redo: true,
+      }),
+    ])
+
+    const wrapper = mountView()
+    await flushView()
+    await flushView()
+
+    await wrapper.findAll('button').find((button) => button.text() === 'Annuler ce run')?.trigger('click')
+    await flushView()
+    await flushView()
+
+    expect(mockUndoImportRunApi).toHaveBeenCalledWith(9)
+    expect(mockListImportHistoryApi).toHaveBeenCalledTimes(2)
+    expect(wrapper.get('[data-testid="import-history"]').text()).toContain('Annulé')
   })
 })

--- a/frontend/src/views/ImportExcelView.vue
+++ b/frontend/src/views/ImportExcelView.vue
@@ -136,7 +136,12 @@
             @click="doImport"
           />
         </div>
-        <p class="import-action-hint">{{ importActionHint }}</p>
+        <p
+          class="import-action-hint"
+          :class="{ 'import-action-hint--warning': hasPreviewWarnings && preview?.can_import }"
+        >
+          {{ importActionHint }}
+        </p>
         <div
           v-if="result"
           data-testid="import-result-banner"
@@ -147,6 +152,15 @@
         >
           <strong>{{ resultStateMessage }}</strong>
           <p>{{ resultStateDetail }}</p>
+          <div
+            v-if="activeRun?.status === 'failed' && result.errors.length"
+            data-testid="import-result-banner-errors"
+            class="import-result-banner-errors"
+          >
+            <ul class="import-errors">
+              <li v-for="(err, idx) in result.errors" :key="`banner-error-${idx}`">{{ err }}</li>
+            </ul>
+          </div>
         </div>
       </div>
     </AppPanel>
@@ -248,6 +262,9 @@
               </span>
               <span class="import-operation-metric import-operation-metric--danger">
                 {{ t('import.operation_decision.block') }}: {{ operationDecisionStats.block }}
+              </span>
+              <span class="import-operation-metric import-operation-metric--danger">
+                {{ t('import.operation_status.failed') }}: {{ operationDecisionStats.failed }}
               </span>
             </div>
           </div>
@@ -597,6 +614,9 @@
                   </span>
                   <span class="import-operation-metric import-operation-metric--danger">
                     {{ t('import.operation_decision.block') }}: {{ operationDecisionStats.block }}
+                  </span>
+                  <span class="import-operation-metric import-operation-metric--danger">
+                    {{ t('import.operation_status.failed') }}: {{ operationDecisionStats.failed }}
                   </span>
                 </div>
               </div>
@@ -1022,18 +1042,6 @@
               </ul>
             </div>
 
-            <div v-if="hasPreviewWarnings && preview.can_import" class="import-confirmation-guard">
-              <label class="import-confirmation-guard__checkbox">
-                <Checkbox
-                  v-model="warningsAcknowledged"
-                  binary
-                  data-testid="warning-ack-checkbox"
-                />
-                <span>{{ t('import.warning_ack_label') }}</span>
-              </label>
-              <p class="import-confirmation-guard__help">{{ t('import.warning_ack_help') }}</p>
-            </div>
-
             <div v-if="preview.errors.length" class="import-errors">
               <span class="app-field__label">{{ t('import.errors') }}</span>
               <ul>
@@ -1082,6 +1090,13 @@
               @click="redoRun(activeRun.id)"
             />
           </div>
+          <p
+            v-if="hasPreviewWarnings && preview.can_import"
+            data-testid="confirm-import-warning"
+            class="import-action-hint import-action-hint--warning"
+          >
+            {{ t('import.warning_review_hint') }}
+          </p>
         </AppPanel>
       </div>
 
@@ -1198,7 +1213,6 @@ import { computed, nextTick, onMounted, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import Button from 'primevue/button'
-import Checkbox from 'primevue/checkbox'
 import RadioButton from 'primevue/radiobutton'
 import Toast from 'primevue/toast'
 import { useToast } from 'primevue/usetoast'
@@ -1209,6 +1223,7 @@ import { getSettingsApi } from '../api/settings'
 import {
   importTestShortcutApi,
   executeImportRunApi,
+  getImportRunApi,
   listTestImportShortcutsApi,
   prepareComptabiliteRunApi,
   prepareGestionRunApi,
@@ -1253,7 +1268,6 @@ const operationSortField = ref<
 >('position')
 const operationSortDirection = ref<'asc' | 'desc'>('asc')
 const expandedOperationIds = ref<number[]>([])
-const warningsAcknowledged = ref(false)
 const testShortcuts = ref<TestImportShortcut[]>([])
 const runningShortcutAlias = ref<string | null>(null)
 
@@ -1271,7 +1285,12 @@ type OperationTableRow = {
   operation: ImportOperationRead
 }
 const resultHasIssues = computed(() =>
-  Boolean(result.value && (result.value.errors.length > 0 || result.value.warnings.length > 0)),
+  Boolean(
+    result.value &&
+      (activeRun.value?.status === 'failed' ||
+        result.value.errors.length > 0 ||
+        result.value.warnings.length > 0),
+  ),
 )
 const resultCreatedCount = computed(() => {
   if (!result.value) return 0
@@ -1287,10 +1306,17 @@ const resultCreatedCount = computed(() => {
 })
 const resultStateMessage = computed(() => {
   if (!result.value) return ''
+  if (activeRun.value?.status === 'failed') return t('import.failed')
   return resultHasIssues.value ? t('import.completed_with_issues') : t('import.success')
 })
 const resultStateDetail = computed(() => {
   if (!result.value) return ''
+  if (activeRun.value?.status === 'failed') {
+    return t('import.result_failed_hint', {
+      count: resultCreatedCount.value,
+      errors: result.value.errors.length,
+    })
+  }
   return t('import.result_persistent_hint', {
     count: resultCreatedCount.value,
     ignored: result.value.ignored_rows,
@@ -1311,8 +1337,7 @@ const canConfirmImport = computed(() =>
   Boolean(
     selectedFile.value &&
     preview.value?.can_import &&
-    activeRun.value?.can_execute !== false &&
-    (!hasPreviewWarnings.value || warningsAcknowledged.value),
+    activeRun.value?.can_execute !== false,
   ),
 )
 const previewState = computed<'ready' | 'noop' | 'blocked'>(() => {
@@ -1505,6 +1530,7 @@ const operationDecisionStats = computed(() => {
     apply: operations.filter((operation) => operation.decision === 'apply').length,
     ignore: operations.filter((operation) => operation.decision === 'ignore').length,
     block: operations.filter((operation) => operation.decision === 'block').length,
+    failed: operations.filter((operation) => operation.status === 'failed').length,
   }
 })
 const blockedOperationRows = computed(() =>
@@ -1519,9 +1545,8 @@ const hasBlockingOperations = computed(
 const importActionHint = computed(() => {
   if (!selectedFile.value) return t('import.file_required')
   if (!preview.value) return t('import.preview_required')
-  if (hasPreviewWarnings.value && !warningsAcknowledged.value)
-    return t('import.warning_ack_required')
   if (!preview.value.can_import) return t('import.preview_blocked')
+  if (hasPreviewWarnings.value) return t('import.warning_review_hint')
   return t('import.import_ready')
 })
 
@@ -1529,7 +1554,6 @@ function resetImportFlow() {
   result.value = null
   preview.value = null
   activeRun.value = null
-  warningsAcknowledged.value = false
   resetOperationTableState()
 }
 
@@ -1829,6 +1853,20 @@ function getImportErrorSummary(error: unknown): string {
   return t('common.error.unknown')
 }
 
+function isRequestTimeout(error: unknown): boolean {
+  return (error as { code?: string }).code === 'ECONNABORTED'
+}
+
+async function refreshRunAfterTimeout(runId: number) {
+  try {
+    const refreshedRun = await getImportRunApi(runId)
+    syncRunState(refreshedRun)
+    toast.add({ severity: 'info', summary: t('import.request_timeout_refreshed'), life: 5000 })
+  } catch {
+    toast.add({ severity: 'warn', summary: t('import.request_timeout'), life: 5000 })
+  }
+}
+
 async function loadTestShortcuts() {
   try {
     testShortcuts.value = (await listTestImportShortcutsApi()).sort(
@@ -1856,7 +1894,6 @@ async function loadSettings() {
 async function doPreview() {
   if (!selectedFile.value) return
   previewing.value = true
-  warningsAcknowledged.value = false
   preview.value = null
   result.value = null
   activeRun.value = null
@@ -1887,10 +1924,6 @@ async function doImport() {
     toast.add({ severity: 'warn', summary: t('import.preview_required'), life: 3000 })
     return
   }
-  if (hasPreviewWarnings.value && !warningsAcknowledged.value) {
-    toast.add({ severity: 'warn', summary: t('import.warning_ack_required'), life: 3500 })
-    return
-  }
   if (!preview.value.can_import) {
     toast.add({ severity: 'warn', summary: t('import.preview_blocked'), life: 3500 })
     return
@@ -1905,15 +1938,27 @@ async function doImport() {
     const run = await executeImportRunApi(activeRun.value.id)
     syncRunState(run)
     const runResult = run.summary
+    const hasFailed = run.status === 'failed'
     const hasIssues = Boolean(
-      runResult && (runResult.errors.length > 0 || runResult.warnings.length > 0),
+      hasFailed || (runResult && (runResult.errors.length > 0 || runResult.warnings.length > 0)),
     )
     toast.add({
-      severity: hasIssues ? 'warn' : 'success',
-      summary: hasIssues ? t('import.completed_with_issues') : t('import.success'),
-      life: 3500,
+      severity: hasFailed ? 'error' : hasIssues ? 'warn' : 'success',
+      summary: hasFailed
+        ? t('import.failed')
+        : hasIssues
+          ? t('import.completed_with_issues')
+          : t('import.success'),
+      detail: hasFailed
+        ? getImportErrorSummary(runResult)
+        : undefined,
+      life: hasFailed ? 5000 : 3500,
     })
   } catch (error: unknown) {
+    if (isRequestTimeout(error) && activeRun.value?.id != null) {
+      await refreshRunAfterTimeout(activeRun.value.id)
+      return
+    }
     toast.add({ severity: 'error', summary: getImportErrorSummary(error), life: 5000 })
   } finally {
     importing.value = false
@@ -1928,6 +1973,10 @@ async function undoRun(runId: number) {
       syncRunState(run)
     }
   } catch (error: unknown) {
+    if (isRequestTimeout(error)) {
+      await refreshRunAfterTimeout(runId)
+      return
+    }
     toast.add({ severity: 'error', summary: getImportErrorSummary(error), life: 5000 })
   } finally {
     busyRunId.value = null
@@ -1942,6 +1991,10 @@ async function redoRun(runId: number) {
       syncRunState(run)
     }
   } catch (error: unknown) {
+    if (isRequestTimeout(error)) {
+      await refreshRunAfterTimeout(runId)
+      return
+    }
     toast.add({ severity: 'error', summary: getImportErrorSummary(error), life: 5000 })
   } finally {
     busyRunId.value = null
@@ -1954,6 +2007,10 @@ async function undoOperation(operationId: number) {
     const run = await undoImportOperationApi(operationId)
     syncRunState(run)
   } catch (error: unknown) {
+    if (isRequestTimeout(error) && activeRun.value?.id != null) {
+      await refreshRunAfterTimeout(activeRun.value.id)
+      return
+    }
     toast.add({ severity: 'error', summary: getImportErrorSummary(error), life: 5000 })
   } finally {
     busyOperationId.value = null
@@ -1966,6 +2023,10 @@ async function redoOperation(operationId: number) {
     const run = await redoImportOperationApi(operationId)
     syncRunState(run)
   } catch (error: unknown) {
+    if (isRequestTimeout(error) && activeRun.value?.id != null) {
+      await refreshRunAfterTimeout(activeRun.value.id)
+      return
+    }
     toast.add({ severity: 'error', summary: getImportErrorSummary(error), life: 5000 })
   } finally {
     busyOperationId.value = null
@@ -1980,24 +2041,45 @@ async function runTestShortcut(alias: string) {
     fileInput.value.value = ''
   }
   preview.value = null
-  warningsAcknowledged.value = false
   result.value = null
   try {
     const shortcut = testShortcuts.value.find((item) => item.alias === alias)
     if (shortcut) {
       importType.value = shortcut.import_type
+      applyDefaultComparisonRange(shortcut.file_name ?? undefined)
     }
-    result.value = await importTestShortcutApi(alias)
-    const hasIssues = result.value.errors.length > 0 || result.value.warnings.length > 0
-    toast.add({
-      severity: hasIssues ? 'warn' : 'success',
-      summary: hasIssues ? t('import.completed_with_issues') : t('import.success'),
-      life: 3500,
-    })
+    const comparisonWindow = {
+      comparison_start_date: comparisonStartDate.value || undefined,
+      comparison_end_date: comparisonEndDate.value || undefined,
+    }
+    const run = await importTestShortcutApi(alias, comparisonWindow)
+    syncRunState(run)
+    if (run.summary) {
+      const hasFailed = run.status === 'failed'
+      const hasIssues = Boolean(
+        hasFailed || run.summary.errors.length > 0 || run.summary.warnings.length > 0,
+      )
+      toast.add({
+        severity: hasFailed ? 'error' : hasIssues ? 'warn' : 'success',
+        summary: hasFailed
+          ? t('import.failed')
+          : hasIssues
+            ? t('import.completed_with_issues')
+            : t('import.success'),
+        detail: hasFailed ? getImportErrorSummary(run.summary) : undefined,
+        life: hasFailed ? 5000 : 3500,
+      })
+    } else {
+      toast.add({
+        severity: 'warn',
+        summary: run.preview?.can_import ? t('import.run_not_executable') : t('import.preview_blocked'),
+        life: 4000,
+      })
+    }
+    await scrollToPreviewPanel()
     await loadTestShortcuts()
   } catch (error: unknown) {
-    const detail = (error as { response?: { data?: { detail?: string } } }).response?.data?.detail
-    toast.add({ severity: 'error', summary: detail ?? t('common.error.unknown'), life: 4500 })
+    toast.add({ severity: 'error', summary: getImportErrorSummary(error), life: 4500 })
   } finally {
     importing.value = false
     runningShortcutAlias.value = null
@@ -2121,6 +2203,10 @@ async function runTestShortcut(alias: string) {
   font-size: 0.95rem;
 }
 
+.import-action-hint--warning {
+  color: color-mix(in srgb, var(--p-amber-700) 78%, var(--p-text-color) 22%);
+}
+
 .import-result-banner {
   display: flex;
   flex-direction: column;
@@ -2131,6 +2217,15 @@ async function runTestShortcut(alias: string) {
 
 .import-result-banner strong,
 .import-result-banner p {
+  margin: 0;
+}
+
+.import-result-banner-errors {
+  padding-top: var(--app-space-1);
+  border-top: 1px solid currentColor;
+}
+
+.import-result-banner-errors .import-errors {
   margin: 0;
 }
 
@@ -2299,28 +2394,6 @@ async function runTestShortcut(alias: string) {
   padding-left: 1rem;
   color: var(--p-amber-700);
   font-size: 0.92rem;
-}
-
-.import-confirmation-guard {
-  display: flex;
-  flex-direction: column;
-  gap: var(--app-space-2);
-  padding: var(--app-space-3) var(--app-space-4);
-  border: 1px solid color-mix(in srgb, var(--p-amber-500) 35%, var(--app-surface-border) 65%);
-  border-radius: var(--app-radius-md);
-  background: color-mix(in srgb, var(--p-amber-500) 10%, var(--app-surface-bg) 90%);
-}
-
-.import-confirmation-guard__checkbox {
-  display: inline-flex;
-  align-items: flex-start;
-  gap: var(--app-space-3);
-}
-
-.import-confirmation-guard__help {
-  margin: 0;
-  color: var(--p-text-muted-color);
-  font-size: 0.95rem;
 }
 
 .import-sheet-list {

--- a/frontend/src/views/ImportHistoryView.vue
+++ b/frontend/src/views/ImportHistoryView.vue
@@ -183,10 +183,49 @@
                 :key="`${historyItem.id}-history-operation-${operation.id}`"
                 class="import-comparison-detail-item"
               >
-                <strong>{{ operation.title }}</strong>
-                <span class="import-comparison-detail-field">
-                  {{ t(`import.operation_status.${operation.status}`) }}
-                </span>
+                <div class="import-history-operation-item__header">
+                  <strong>{{ operation.title }}</strong>
+                  <span class="import-comparison-detail-field">
+                    {{ t(`import.operation_status.${operation.status}`) }}
+                  </span>
+                </div>
+                <p
+                  v-if="operation.error_message"
+                  class="import-history-operation-item__error"
+                >
+                  {{ operation.error_message }}
+                </p>
+                <ul v-if="operation.diagnostics.length" class="import-warnings">
+                  <li
+                    v-for="(diagnostic, index) in operation.diagnostics"
+                    :key="`${historyItem.id}-history-operation-${operation.id}-diagnostic-${index}`"
+                  >
+                    {{ diagnostic }}
+                  </li>
+                </ul>
+                <div
+                  v-if="operation.can_undo || operation.can_redo"
+                  class="app-form-actions import-inline-actions"
+                >
+                  <Button
+                    v-if="operation.can_undo"
+                    :data-testid="`history-operation-undo-${operation.id}`"
+                    :label="t('import.undo_operation')"
+                    severity="secondary"
+                    outlined
+                    :loading="busyOperationId === operation.id"
+                    @click="undoOperation(operation.id)"
+                  />
+                  <Button
+                    v-if="operation.can_redo"
+                    :data-testid="`history-operation-redo-${operation.id}`"
+                    :label="t('import.redo_operation')"
+                    severity="secondary"
+                    outlined
+                    :loading="busyOperationId === operation.id"
+                    @click="redoOperation(operation.id)"
+                  />
+                </div>
               </li>
             </ul>
           </div>
@@ -231,8 +270,10 @@ import AppPage from '../components/ui/AppPage.vue'
 import AppPageHeader from '../components/ui/AppPageHeader.vue'
 import AppPanel from '../components/ui/AppPanel.vue'
 import {
+  redoImportOperationApi,
   listImportHistoryApi,
   redoImportRunApi,
+  undoImportOperationApi,
   type ImportHistoryItem,
   undoImportRunApi,
 } from '../api/accounting'
@@ -243,6 +284,7 @@ const router = useRouter()
 
 const importHistory = ref<ImportHistoryItem[]>([])
 const busyRunId = ref<number | null>(null)
+const busyOperationId = ref<number | null>(null)
 const loading = ref(false)
 const expandedSections = ref<string[]>([])
 
@@ -326,16 +368,27 @@ function getImportErrorSummary(error: unknown): string {
   return t('common.error.unknown')
 }
 
-async function loadImportHistory() {
+function isRequestTimeout(error: unknown): boolean {
+  return (error as { code?: string }).code === 'ECONNABORTED'
+}
+
+async function loadImportHistory(): Promise<ImportHistoryItem[]> {
   loading.value = true
   try {
     importHistory.value = await listImportHistoryApi()
+    return importHistory.value
   } catch (error: unknown) {
     importHistory.value = []
     toast.add({ severity: 'error', summary: getImportErrorSummary(error), life: 5000 })
+    return []
   } finally {
     loading.value = false
   }
+}
+
+async function refreshHistoryAfterTimeout() {
+  await loadImportHistory()
+  toast.add({ severity: 'info', summary: t('import.request_timeout_refreshed'), life: 5000 })
 }
 
 async function undoRun(runId: number) {
@@ -344,6 +397,10 @@ async function undoRun(runId: number) {
     await undoImportRunApi(runId)
     await loadImportHistory()
   } catch (error: unknown) {
+    if (isRequestTimeout(error)) {
+      await refreshHistoryAfterTimeout()
+      return
+    }
     toast.add({ severity: 'error', summary: getImportErrorSummary(error), life: 5000 })
   } finally {
     busyRunId.value = null
@@ -356,9 +413,45 @@ async function redoRun(runId: number) {
     await redoImportRunApi(runId)
     await loadImportHistory()
   } catch (error: unknown) {
+    if (isRequestTimeout(error)) {
+      await refreshHistoryAfterTimeout()
+      return
+    }
     toast.add({ severity: 'error', summary: getImportErrorSummary(error), life: 5000 })
   } finally {
     busyRunId.value = null
+  }
+}
+
+async function undoOperation(operationId: number) {
+  busyOperationId.value = operationId
+  try {
+    await undoImportOperationApi(operationId)
+    await loadImportHistory()
+  } catch (error: unknown) {
+    if (isRequestTimeout(error)) {
+      await refreshHistoryAfterTimeout()
+      return
+    }
+    toast.add({ severity: 'error', summary: getImportErrorSummary(error), life: 5000 })
+  } finally {
+    busyOperationId.value = null
+  }
+}
+
+async function redoOperation(operationId: number) {
+  busyOperationId.value = operationId
+  try {
+    await redoImportOperationApi(operationId)
+    await loadImportHistory()
+  } catch (error: unknown) {
+    if (isRequestTimeout(error)) {
+      await refreshHistoryAfterTimeout()
+      return
+    }
+    toast.add({ severity: 'error', summary: getImportErrorSummary(error), life: 5000 })
+  } finally {
+    busyOperationId.value = null
   }
 }
 
@@ -471,6 +564,18 @@ onMounted(async () => {
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
+}
+
+.import-history-operation-item__header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--app-space-2);
+}
+
+.import-history-operation-item__error {
+  margin: 0;
+  color: var(--p-red-300);
 }
 
 .import-comparison-detail-field {

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -342,6 +342,105 @@
             @click="confirmReset"
           />
         </div>
+        <section class="settings-selective-reset">
+          <div class="settings-selective-reset__header">
+            <h3 class="settings-selective-reset__title">
+              {{ t('settings.selective_reset_title') }}
+            </h3>
+            <p class="settings-selective-reset__subtitle">
+              {{ t('settings.selective_reset_subtitle') }}
+            </p>
+          </div>
+          <p class="settings-selective-reset__hint">{{ t('settings.selective_reset_help') }}</p>
+
+          <div class="app-form-grid">
+            <div class="app-field">
+              <label class="app-field__label">{{ t('settings.selective_reset_type') }}</label>
+              <Select
+                v-model="selectiveResetForm.importType"
+                :options="selectiveResetImportTypeOptions"
+                option-label="label"
+                option-value="value"
+                class="w-full"
+              />
+            </div>
+            <div class="app-field">
+              <label class="app-field__label">{{ t('settings.selective_reset_fiscal_year') }}</label>
+              <Select
+                v-model="selectiveResetForm.fiscalYearId"
+                :options="selectiveResetFiscalYearOptions"
+                option-label="label"
+                option-value="value"
+                class="w-full"
+              />
+            </div>
+          </div>
+
+          <div class="app-form-actions">
+            <Button
+              :label="t('settings.selective_reset_preview')"
+              icon="pi pi-search"
+              severity="secondary"
+              outlined
+              :loading="selectiveResetPreviewLoading"
+              @click="previewSelectiveReset"
+            />
+            <Button
+              :label="t('settings.selective_reset_apply')"
+              icon="pi pi-trash"
+              severity="danger"
+              :disabled="!canApplySelectiveReset"
+              :loading="selectiveResetApplying"
+              @click="confirmSelectiveReset"
+            />
+          </div>
+
+          <Message
+            v-if="selectiveResetSuccessMessage"
+            severity="success"
+            class="mt-2"
+            :closable="true"
+          >
+            {{ selectiveResetSuccessMessage }}
+          </Message>
+          <Message
+            v-if="selectiveResetErrorMessage"
+            severity="error"
+            class="mt-2"
+            :closable="true"
+          >
+            {{ selectiveResetErrorMessage }}
+          </Message>
+
+          <div v-if="selectiveResetPreview" class="settings-selective-reset__preview">
+            <div class="settings-selective-reset__groups">
+              <section>
+                <h4>{{ t('settings.selective_reset_root_objects') }}</h4>
+                <ul>
+                  <li v-for="entry in selectiveResetRootEntries" :key="`root-${entry.key}`">
+                    {{ selectiveResetObjectLabel(entry.key) }} : {{ entry.count }}
+                  </li>
+                </ul>
+              </section>
+              <section>
+                <h4>{{ t('settings.selective_reset_derived_objects') }}</h4>
+                <ul>
+                  <li v-for="entry in selectiveResetDerivedEntries" :key="`derived-${entry.key}`">
+                    {{ selectiveResetObjectLabel(entry.key) }} : {{ entry.count }}
+                  </li>
+                </ul>
+              </section>
+              <section>
+                <h4>{{ t('settings.selective_reset_delete_plan') }}</h4>
+                <ul>
+                  <li v-for="entry in selectiveResetDeleteEntries" :key="`delete-${entry.key}`">
+                    {{ selectiveResetObjectLabel(entry.key) }} : {{ entry.count }}
+                  </li>
+                </ul>
+              </section>
+            </div>
+          </div>
+        </section>
         <Message v-if="resetMessage" severity="warn" class="mt-2" :closable="true">
           {{ resetMessage }}
         </Message>
@@ -356,7 +455,7 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, ref, computed } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import Button from 'primevue/button'
 import ConfirmDialog from 'primevue/confirmdialog'
@@ -371,13 +470,17 @@ import Textarea from 'primevue/textarea'
 import ToggleSwitch from 'primevue/toggleswitch'
 import { useConfirm } from 'primevue/useconfirm'
 import {
+  applySelectiveResetApi,
   bootstrapAccountingApi,
   getSystemOpeningApi,
   getSettingsApi,
+  previewSelectiveResetApi,
   resetDbApi,
   updateSystemOpeningApi,
   updateSettingsApi,
   type AppSettingsUpdate,
+  type SelectiveResetImportType,
+  type SelectiveResetPreview,
   type SystemOpening,
   type TreasurySystemOpening,
   type TreasurySystemOpeningUpdate,
@@ -423,6 +526,11 @@ interface TreasurySystemOpeningForm {
   cash: SystemOpeningFormValue
 }
 
+interface SelectiveResetForm {
+  importType: SelectiveResetImportType
+  fiscalYearId: number | null
+}
+
 const defaultForm = (): SettingsForm => ({
   association_name: '',
   association_address: '',
@@ -465,6 +573,15 @@ const resetMessage = ref('')
 const bootstrapMessage = ref('')
 const systemOpeningSuccessMessage = ref('')
 const systemOpeningErrorMessage = ref('')
+const selectiveResetForm = ref<SelectiveResetForm>({
+  importType: 'gestion',
+  fiscalYearId: null,
+})
+const selectiveResetPreview = ref<SelectiveResetPreview | null>(null)
+const selectiveResetPreviewLoading = ref(false)
+const selectiveResetApplying = ref(false)
+const selectiveResetSuccessMessage = ref('')
+const selectiveResetErrorMessage = ref('')
 
 const MONTHS = [
   'Janvier',
@@ -481,11 +598,40 @@ const MONTHS = [
   'Décembre',
 ]
 const monthOptions = MONTHS.map((label, i) => ({ label, value: i + 1 }))
+const selectiveResetImportTypeOptions = computed(() => [
+  { label: t('settings.selective_reset_import_type_gestion'), value: 'gestion' },
+  { label: t('settings.selective_reset_import_type_comptabilite'), value: 'comptabilite' },
+])
+const selectiveResetFiscalYearOptions = computed(() =>
+  fiscalYearStore.fiscalYears.map((fiscalYear) => ({
+    label: fiscalYear.name,
+    value: fiscalYear.id,
+  })),
+)
+const selectiveResetRootEntries = computed(() =>
+  Object.entries(selectiveResetPreview.value?.root_objects ?? {}).map(([key, count]) => ({ key, count })),
+)
+const selectiveResetDerivedEntries = computed(() =>
+  Object.entries(selectiveResetPreview.value?.derived_objects ?? {}).map(([key, count]) => ({ key, count })),
+)
+const selectiveResetDeleteEntries = computed(() =>
+  Object.entries(selectiveResetPreview.value?.delete_plan ?? {}).map(([key, count]) => ({ key, count })),
+)
+const canApplySelectiveReset = computed(
+  () =>
+    selectiveResetPreview.value !== null &&
+    selectiveResetPreviewLoading.value === false &&
+    selectiveResetDeleteEntries.value.length > 0,
+)
 const systemOpeningDefaultDateLabel = computed(() =>
   systemOpeningDefaultDate.value
     ? systemOpeningDefaultDate.value.split('-').reverse().join('/')
     : '',
 )
+
+function selectiveResetObjectLabel(key: string): string {
+  return t(`settings.selective_reset_object_${key}`)
+}
 
 function toIsoDate(value: Date): string {
   const year = value.getFullYear()
@@ -684,8 +830,98 @@ async function bootstrapAccounting(): Promise<void> {
   }
 }
 
+function buildSelectiveResetPayload(): { import_type: SelectiveResetImportType; fiscal_year_id: number } | null {
+  if (selectiveResetForm.value.fiscalYearId === null) {
+    selectiveResetErrorMessage.value = t('settings.selective_reset_missing_fiscal_year')
+    return null
+  }
+
+  return {
+    import_type: selectiveResetForm.value.importType,
+    fiscal_year_id: selectiveResetForm.value.fiscalYearId,
+  }
+}
+
+async function previewSelectiveReset(): Promise<void> {
+  selectiveResetPreviewLoading.value = true
+  selectiveResetSuccessMessage.value = ''
+  selectiveResetErrorMessage.value = ''
+
+  const payload = buildSelectiveResetPayload()
+  if (!payload) {
+    selectiveResetPreviewLoading.value = false
+    return
+  }
+
+  try {
+    const preview = await previewSelectiveResetApi(payload)
+    selectiveResetPreview.value = preview
+    selectiveResetSuccessMessage.value =
+      Object.keys(preview.delete_plan).length > 0
+        ? t('settings.selective_reset_preview_ready', {
+            type: t(`settings.selective_reset_import_type_${preview.import_type}`),
+            year: preview.fiscal_year_name,
+          })
+        : t('settings.selective_reset_preview_empty')
+  } catch {
+    selectiveResetErrorMessage.value = t('settings.selective_reset_error')
+  } finally {
+    selectiveResetPreviewLoading.value = false
+  }
+}
+
+function confirmSelectiveReset(): void {
+  confirm.require({
+    message: t('settings.selective_reset_confirm'),
+    header: t('settings.selective_reset_confirm_header'),
+    icon: 'pi pi-exclamation-triangle',
+    acceptProps: { severity: 'danger', label: t('settings.selective_reset_apply_yes') },
+    rejectProps: { severity: 'secondary', outlined: true, label: t('common.cancel') },
+    accept: applySelectiveReset,
+  })
+}
+
+async function applySelectiveReset(): Promise<void> {
+  selectiveResetApplying.value = true
+  selectiveResetSuccessMessage.value = ''
+  selectiveResetErrorMessage.value = ''
+
+  const payload = buildSelectiveResetPayload()
+  if (!payload) {
+    selectiveResetApplying.value = false
+    return
+  }
+
+  try {
+    const result = await applySelectiveResetApi(payload)
+    selectiveResetPreview.value = result
+    const deletedCount = Object.values(result.delete_plan).reduce((sum, value) => sum + value, 0)
+    selectiveResetSuccessMessage.value = t('settings.selective_reset_done', {
+      count: deletedCount,
+      type: t(`settings.selective_reset_import_type_${result.import_type}`),
+      year: result.fiscal_year_name,
+    })
+  } catch {
+    selectiveResetErrorMessage.value = t('settings.selective_reset_error')
+  } finally {
+    selectiveResetApplying.value = false
+  }
+}
+
+watch(
+  () => [selectiveResetForm.value.importType, selectiveResetForm.value.fiscalYearId],
+  () => {
+    selectiveResetPreview.value = null
+    selectiveResetSuccessMessage.value = ''
+    selectiveResetErrorMessage.value = ''
+  },
+)
+
 onMounted(() => {
-  void Promise.all([load(), loadSystemOpening()])
+  void Promise.all([load(), loadSystemOpening(), fiscalYearStore.initialize()]).then(() => {
+    selectiveResetForm.value.fiscalYearId =
+      fiscalYearStore.selectedFiscalYearId ?? fiscalYearStore.fiscalYears[0]?.id ?? null
+  })
 })
 </script>
 
@@ -752,6 +988,47 @@ onMounted(() => {
   gap: var(--app-space-3);
 }
 
+.settings-selective-reset {
+  display: flex;
+  flex-direction: column;
+  gap: var(--app-space-3);
+  padding: var(--app-space-4);
+  border: 1px solid var(--app-border-subtle);
+  border-radius: var(--app-radius-lg);
+  background: var(--app-surface-subtle);
+}
+
+.settings-selective-reset__header,
+.settings-selective-reset__title,
+.settings-selective-reset__subtitle {
+  margin: 0;
+}
+
+.settings-selective-reset__subtitle,
+.settings-selective-reset__hint {
+  color: var(--app-text-muted);
+}
+
+.settings-selective-reset__preview {
+  border-top: 1px solid var(--app-border-subtle);
+  padding-top: var(--app-space-3);
+}
+
+.settings-selective-reset__groups {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--app-space-4);
+}
+
+.settings-selective-reset__groups h4,
+.settings-selective-reset__groups ul {
+  margin: 0;
+}
+
+.settings-selective-reset__groups ul {
+  padding-left: 1rem;
+}
+
 .danger-panel :deep(.app-panel__header) {
   background-color: v-bind(dangerHeaderBg);
   border-bottom: 1px solid v-bind(dangerBorderColor);
@@ -764,6 +1041,10 @@ onMounted(() => {
 
 @media (max-width: 767px) {
   .settings-opening-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .settings-selective-reset__groups {
     grid-template-columns: 1fr;
   }
 

--- a/tests/integration/test_import_api.py
+++ b/tests/integration/test_import_api.py
@@ -339,11 +339,23 @@ async def test_test_import_shortcuts_list_and_run_configured_file(
     auth_headers: dict,
     tmp_path,
 ) -> None:
-    """Configured test shortcuts should be listed and executable."""
+    """Configured test shortcuts should create and execute a reversible import run."""
     from backend import config as config_module
 
     shortcut_file = tmp_path / "Gestion 2024.xlsx"
-    shortcut_file.write_bytes(_make_simple_xlsx(["date", "montant", "nom"], [[]]))
+    shortcut_file.write_bytes(
+        _make_multi_sheet_xlsx(
+            {
+                "Contacts": (
+                    ["Nom", "Email"],
+                    [
+                        ["Christine LOPES", "christine@example.test"],
+                        ["Thi BE NGUYEN", "thi@example.test"],
+                    ],
+                )
+            }
+        )
+    )
 
     original_settings = config_module._settings
     config_module._settings = config_module.Settings(
@@ -365,13 +377,22 @@ async def test_test_import_shortcuts_list_and_run_configured_file(
 
         import_response = await client.post(
             "/api/import/excel/test-shortcuts/gestion-2024",
+            params={
+                "comparison_start_date": "2024-08-01",
+                "comparison_end_date": "2025-07-31",
+            },
             headers=auth_headers,
         )
 
         assert import_response.status_code == 200
         data = import_response.json()
-        assert "contacts_created" in data
-        assert data["entries_created"] == 0
+        assert data["kind"] == "run"
+        assert data["status"] == "completed"
+        assert data["comparison_start_date"] == "2024-08-01"
+        assert data["comparison_end_date"] == "2025-07-31"
+        assert data["summary"]["contacts_created"] == 2
+        assert data["summary"]["entries_created"] == 0
+        assert data["can_undo"] is True
     finally:
         config_module._settings = original_settings
 
@@ -1510,13 +1531,567 @@ async def test_reversible_import_run_prepare_execute_undo_redo_cycle(
     assert redone_run["can_undo"] is True
     assert all(operation["status"] == "applied" for operation in redone_run["operations"])
 
-    contacts_after_redo = list(
-        (await db_session.execute(select(Contact).order_by(Contact.nom))).scalars()
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not OPENPYXL_AVAILABLE, reason="openpyxl not installed")
+async def test_reversible_comptabilite_run_undo_tolerates_decimal_scale_differences(
+    client: AsyncClient,
+    auth_headers: dict,
+    db_session,
+) -> None:
+    """Undo should accept semantically identical Numeric values.
+
+    This remains true even if SQLite round-trips them with a different scale.
+    """
+    from backend.models.accounting_account import AccountingAccount, AccountType
+    from backend.models.accounting_entry import AccountingEntry
+
+    db_session.add(
+        AccountingAccount(number="401100", label="Fournisseurs", type=AccountType.PASSIF)
     )
-    assert [(contact.nom, contact.prenom) for contact in contacts_after_redo] == [
-        ("BE NGUYEN", "Thi"),
-        ("LOPES", "Christine"),
+    await db_session.commit()
+
+    content = _make_multi_sheet_xlsx(
+        {
+            "Journal": (
+                ["Date", "N° compte", "Libellé de l'écriture", "Débit", "Crédit"],
+                [["2025-08-01", "401100", "Facture fournisseur", None, 261.5]],
+            ),
+        }
+    )
+
+    prepare_response = await client.post(
+        "/api/import/runs/prepare/comptabilite",
+        files={"file": ("Comptabilite 2025.xlsx", content, _XLSX_MIME)},
+        headers=auth_headers,
+    )
+
+    assert prepare_response.status_code == 200
+    run_id = prepare_response.json()["id"]
+
+    execute_response = await client.post(
+        f"/api/import/runs/{run_id}/execute",
+        headers=auth_headers,
+    )
+
+    assert execute_response.status_code == 200
+    executed_run = execute_response.json()
+    assert executed_run["status"] == "completed"
+    assert executed_run["can_undo"] is True
+    assert executed_run["summary"]["entries_created"] == 1
+
+    entries_before_undo = list((await db_session.execute(select(AccountingEntry))).scalars())
+    assert len(entries_before_undo) == 1
+
+    undo_response = await client.post(
+        f"/api/import/runs/{run_id}/undo",
+        headers=auth_headers,
+    )
+
+    assert undo_response.status_code == 200
+    undone_run = undo_response.json()
+    assert undone_run["status"] == "reverted"
+    remaining_entries = list((await db_session.execute(select(AccountingEntry))).scalars())
+    assert not remaining_entries
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not OPENPYXL_AVAILABLE, reason="openpyxl not installed")
+async def test_reversible_bank_operation_failure_rolls_back_payment_side_effects(
+    client: AsyncClient,
+    auth_headers: dict,
+    db_session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed bank operation must not leave a paid invoice or created payment behind."""
+    from backend.models.bank import BankTransaction
+    from backend.models.invoice import Invoice, InvoiceStatus
+    from backend.models.payment import Payment
+    from backend.services import import_reversible
+
+    content = _make_multi_sheet_xlsx(
+        {
+            "Factures": (
+                ["Date facture", "Réf facture", "Client", "Montant"],
+                [["2025-08-01", "2025-0142", "Christine LOPES", 55]],
+            ),
+            "Banque": (
+                ["Date", "Montant", "Référence", "Libellé", "Solde"],
+                [["2025-08-02", 55, "2025-0142", "Paiement facture client", 537]],
+            ),
+        }
+    )
+
+    async def _crash_generate_entries_for_payment(*args, **kwargs):
+        raise RuntimeError("forced payment generation failure")
+
+    monkeypatch.setattr(
+        import_reversible,
+        "generate_entries_for_payment",
+        _crash_generate_entries_for_payment,
+    )
+
+    prepare_response = await client.post(
+        "/api/import/runs/prepare/gestion",
+        files={"file": ("Gestion 2025.xlsx", content, _XLSX_MIME)},
+        headers=auth_headers,
+    )
+
+    assert prepare_response.status_code == 200
+    run_id = prepare_response.json()["id"]
+
+    execute_response = await client.post(
+        f"/api/import/runs/{run_id}/execute",
+        headers=auth_headers,
+    )
+
+    assert execute_response.status_code == 200
+    executed_run = execute_response.json()
+    assert executed_run["status"] == "failed"
+    assert executed_run["can_undo"] is True
+    assert [operation["status"] for operation in executed_run["operations"]] == [
+        "applied",
+        "failed",
     ]
+    assert executed_run["operations"][1]["error_message"] == "forced payment generation failure"
+    assert executed_run["operations"][1]["effects"] == []
+    assert any(
+        "forced payment generation failure" in error for error in executed_run["summary"]["errors"]
+    )
+
+    invoices = list((await db_session.execute(select(Invoice).order_by(Invoice.id))).scalars())
+    assert len(invoices) == 1
+    assert invoices[0].number == "2025-0142"
+    assert invoices[0].paid_amount == Decimal("0.00")
+    assert invoices[0].status == InvoiceStatus.SENT
+
+    payments = list((await db_session.execute(select(Payment).order_by(Payment.id))).scalars())
+    bank_entries = list(
+        (await db_session.execute(select(BankTransaction).order_by(BankTransaction.id))).scalars()
+    )
+    assert payments == []
+    assert bank_entries == []
+
+    undo_response = await client.post(
+        f"/api/import/runs/{run_id}/undo",
+        headers=auth_headers,
+    )
+
+    assert undo_response.status_code == 200
+    undone_run = undo_response.json()
+    assert undone_run["status"] == "reverted"
+    remaining_invoices = list((await db_session.execute(select(Invoice))).scalars())
+    remaining_payments = list((await db_session.execute(select(Payment))).scalars())
+    assert remaining_invoices == []
+    assert remaining_payments == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not OPENPYXL_AVAILABLE, reason="openpyxl not installed")
+async def test_reversible_bank_virement_run_executes_with_accounting_rules(
+    client: AsyncClient,
+    auth_headers: dict,
+    db_session,
+) -> None:
+    """A reversible bank client-payment run should complete.
+
+    This covers the case where payment accounting rules are active.
+    """
+    from backend.models.accounting_entry import AccountingEntry
+    from backend.models.invoice import Invoice, InvoiceStatus
+    from backend.models.payment import Payment, PaymentMethod
+    from backend.services.accounting_engine import seed_default_rules
+
+    await seed_default_rules(db_session)
+
+    content = _make_multi_sheet_xlsx(
+        {
+            "Factures": (
+                ["Date facture", "Réf facture", "Client", "Montant"],
+                [["2025-08-01", "2025-0142", "Christine LOPES", 55]],
+            ),
+            "Banque": (
+                ["Date", "Montant", "Référence", "Libellé", "Solde"],
+                [["2025-08-02", 55, "2025-0142", "Paiement facture client", 537]],
+            ),
+        }
+    )
+
+    prepare_response = await client.post(
+        "/api/import/runs/prepare/gestion",
+        files={"file": ("Gestion 2025.xlsx", content, _XLSX_MIME)},
+        headers=auth_headers,
+    )
+
+    assert prepare_response.status_code == 200
+    run_id = prepare_response.json()["id"]
+
+    execute_response = await client.post(
+        f"/api/import/runs/{run_id}/execute",
+        headers=auth_headers,
+    )
+
+    assert execute_response.status_code == 200
+    executed_run = execute_response.json()
+    assert executed_run["status"] == "completed"
+    assert all(operation["status"] == "applied" for operation in executed_run["operations"])
+    assert executed_run["summary"]["payments_created"] == 1
+    assert executed_run["summary"]["entries_created"] >= 2
+
+    invoice = (await db_session.execute(select(Invoice))).scalar_one()
+    payment = (await db_session.execute(select(Payment))).scalar_one()
+    entries = list((await db_session.execute(select(AccountingEntry))).scalars())
+
+    assert invoice.number == "2025-0142"
+    assert invoice.paid_amount == Decimal("55.00")
+    assert invoice.status == InvoiceStatus.PAID
+    assert payment.method == PaymentMethod.VIREMENT
+    assert len(entries) >= 2
+
+    undo_response = await client.post(
+        f"/api/import/runs/{run_id}/undo",
+        headers=auth_headers,
+    )
+
+    assert undo_response.status_code == 200
+    undone_run = undo_response.json()
+    assert undone_run["status"] == "reverted"
+    assert list((await db_session.execute(select(Invoice))).scalars()) == []
+    assert list((await db_session.execute(select(Payment))).scalars()) == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not OPENPYXL_AVAILABLE, reason="openpyxl not installed")
+async def test_reversible_prepare_and_execute_ignore_duplicate_salary_rows_in_same_file(
+    client: AsyncClient,
+    auth_headers: dict,
+) -> None:
+    """Reversible preview/prepare should ignore duplicate salary employee-month rows.
+
+    This applies when the same workbook already contains the employee-month pair.
+    """
+    content = _make_multi_sheet_xlsx_rows(
+        {
+            "Aide Salaires": [
+                ["2025.03"],
+                ["NOM", "Heures", "Brut", "Salariales", "Patronales", "Impôts", "Net"],
+                ["LAY", 104, 1605, 355.36, 350.47, 0, 1249.64],
+                ["WOLFF P.", 10, 249.99, 54.33, 110.12, 1.62, 194.04],
+                ["LAY", 104, 1605, 355.36, 350.47, 0, 1249.64],
+                ["WOLFF P.", 2, 50, 11.16, 20.21, 0.32, 38.52],
+            ]
+        }
+    )
+
+    preview_response = await client.post(
+        "/api/import/excel/gestion/preview",
+        files={"file": ("Gestion 2024.xlsx", content, _XLSX_MIME)},
+        headers=auth_headers,
+    )
+
+    assert preview_response.status_code == 200
+    preview_data = preview_response.json()
+    assert preview_data["estimated_salaries"] == 2
+    assert preview_data["warnings"]
+    assert any("ligne ignoree" in warning.lower() for warning in preview_data["warnings"])
+
+    prepare_response = await client.post(
+        "/api/import/runs/prepare/gestion",
+        files={"file": ("Gestion 2024.xlsx", content, _XLSX_MIME)},
+        headers=auth_headers,
+    )
+
+    assert prepare_response.status_code == 200
+    prepared_run = prepare_response.json()
+    assert prepared_run["can_execute"] is True
+    salary_operations = [
+        operation
+        for operation in prepared_run["operations"]
+        if operation["operation_type"] == "salary_month_import"
+    ]
+    ignored_operations = [
+        operation
+        for operation in prepared_run["operations"]
+        if operation["operation_type"] == "ignored_by_policy"
+    ]
+    assert len(salary_operations) == 1
+    assert salary_operations[0]["title"] == "2025-03"
+    assert salary_operations[0]["source_row_numbers"] == [3, 4]
+    assert len(ignored_operations) == 2
+    assert all("Salaire ligne" in operation["title"] for operation in ignored_operations)
+
+    execute_response = await client.post(
+        f"/api/import/runs/{prepared_run['id']}/execute",
+        headers=auth_headers,
+    )
+
+    assert execute_response.status_code == 200
+    executed_run = execute_response.json()
+    assert executed_run["status"] == "completed"
+    assert executed_run["summary"]["salaries_created"] == 2
+    assert executed_run["summary"]["ignored_rows"] == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not OPENPYXL_AVAILABLE, reason="openpyxl not installed")
+async def test_reversible_prepare_ignores_existing_client_payment_rows(
+    client: AsyncClient,
+    auth_headers: dict,
+    db_session,
+) -> None:
+    """Reversible gestion prepare should ignore a client payment row already present in Solde."""
+    from backend.models.contact import Contact, ContactType
+    from backend.models.invoice import Invoice, InvoiceStatus, InvoiceType
+    from backend.models.payment import Payment, PaymentMethod
+
+    contact = Contact(nom="Valérie", prenom="POIROT", type=ContactType.CLIENT)
+    db_session.add(contact)
+    await db_session.flush()
+
+    invoice = Invoice(
+        number="2024-0170",
+        reference="2024-0170",
+        type=InvoiceType.CLIENT,
+        contact_id=contact.id,
+        date=date(2024, 8, 7),
+        due_date=date(2024, 8, 7),
+        total_amount=Decimal("78"),
+        paid_amount=Decimal("78"),
+        status=InvoiceStatus.PAID,
+        description="Cours août",
+    )
+    db_session.add(invoice)
+    await db_session.flush()
+
+    db_session.add(
+        Payment(
+            invoice_id=invoice.id,
+            contact_id=contact.id,
+            date=date(2024, 8, 7),
+            amount=Decimal("78"),
+            method=PaymentMethod.VIREMENT,
+            reference="2024-0170",
+            deposited=True,
+            deposit_date=date(2024, 8, 7),
+        )
+    )
+    await db_session.commit()
+
+    content = _make_multi_sheet_xlsx(
+        {
+            "Paiements": (
+                [
+                    "Date",
+                    "Montant",
+                    "Référence facture",
+                    "Client",
+                    "Mode",
+                    "Numéro chèque",
+                    "Déposé",
+                    "Date dépôt",
+                ],
+                [
+                    [
+                        "2024-08-07",
+                        78,
+                        "2024-0170",
+                        "Valérie POIROT",
+                        "virement",
+                        None,
+                        True,
+                        "2024-08-07",
+                    ]
+                ],
+            )
+        }
+    )
+
+    preview_response = await client.post(
+        "/api/import/excel/gestion/preview",
+        files={"file": ("Gestion 2024.xlsx", content, _XLSX_MIME)},
+        headers=auth_headers,
+    )
+
+    assert preview_response.status_code == 200
+    preview_data = preview_response.json()
+    assert preview_data["estimated_payments"] == 0
+    assert any("ligne ignoree" in warning.lower() for warning in preview_data["warnings"])
+
+    prepare_response = await client.post(
+        "/api/import/runs/prepare/gestion",
+        files={"file": ("Gestion 2024.xlsx", content, _XLSX_MIME)},
+        headers=auth_headers,
+        data={
+            "comparison_start_date": "2024-08-01",
+            "comparison_end_date": "2025-07-31",
+        },
+    )
+
+    assert prepare_response.status_code == 200
+    prepared_run = prepare_response.json()
+    assert prepared_run["can_execute"] is False
+    payment_operations = [
+        operation
+        for operation in prepared_run["operations"]
+        if operation["operation_type"] == "client_payment_row_import"
+    ]
+    ignored_operations = [
+        operation
+        for operation in prepared_run["operations"]
+        if operation["operation_type"] == "ignored_by_policy"
+    ]
+    assert not payment_operations
+    assert len(ignored_operations) == 1
+    assert ignored_operations[0]["title"] == "Paiement ligne 2"
+    assert "ligne ignoree" in ignored_operations[0]["diagnostics"][0].lower()
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not OPENPYXL_AVAILABLE, reason="openpyxl not installed")
+async def test_reversible_prepare_ignores_existing_bank_client_transfer_rows(
+    client: AsyncClient,
+    auth_headers: dict,
+    db_session,
+) -> None:
+    """Reversible gestion prepare should ignore a bank transfer row already present in Solde."""
+    from backend.models.bank import BankTransaction, BankTransactionSource
+    from backend.models.contact import Contact, ContactType
+    from backend.models.invoice import Invoice, InvoiceStatus, InvoiceType
+    from backend.models.payment import Payment, PaymentMethod
+
+    contact = Contact(nom="RIBEIRO", prenom="", type=ContactType.CLIENT)
+    db_session.add(contact)
+    await db_session.flush()
+
+    invoice = Invoice(
+        number="2025-0141",
+        reference="2025-0141",
+        type=InvoiceType.CLIENT,
+        contact_id=contact.id,
+        date=date(2025, 7, 21),
+        due_date=date(2025, 7, 21),
+        total_amount=Decimal("170"),
+        paid_amount=Decimal("170"),
+        status=InvoiceStatus.PAID,
+        description="Cours été",
+    )
+    db_session.add(invoice)
+    await db_session.flush()
+
+    payment = Payment(
+        invoice_id=invoice.id,
+        contact_id=contact.id,
+        date=date(2025, 8, 1),
+        amount=Decimal("170"),
+        method=PaymentMethod.VIREMENT,
+        reference="2025-0141",
+        notes="Paiement facture client",
+        deposited=True,
+        deposit_date=date(2025, 8, 1),
+    )
+    db_session.add(payment)
+    await db_session.flush()
+
+    db_session.add(
+        BankTransaction(
+            date=date(2025, 8, 1),
+            amount=Decimal("170"),
+            reference="2025-0141",
+            description="Paiement facture client",
+            source=BankTransactionSource.IMPORT,
+            payment_id=payment.id,
+        )
+    )
+    await db_session.commit()
+
+    content = _make_multi_sheet_xlsx(
+        {
+            "Banque": (
+                ["Date", "Montant", "Référence", "Libellé", "Solde"],
+                [["2025-08-01", 170, "2025-0141", "Paiement facture client", 2844.77]],
+            ),
+        }
+    )
+
+    prepare_response = await client.post(
+        "/api/import/runs/prepare/gestion",
+        files={"file": ("Gestion 2025.xlsx", content, _XLSX_MIME)},
+        headers=auth_headers,
+    )
+
+    assert prepare_response.status_code == 200
+    prepared_run = prepare_response.json()
+    bank_operations = [
+        operation
+        for operation in prepared_run["operations"]
+        if operation["operation_type"] == "bank_row_import"
+    ]
+    ignored_operations = [
+        operation
+        for operation in prepared_run["operations"]
+        if operation["operation_type"] == "ignored_by_policy"
+    ]
+    assert not bank_operations
+    assert len(ignored_operations) == 1
+    assert ignored_operations[0]["title"] == "2025-0141"
+    assert "ligne ignoree" in ignored_operations[0]["diagnostics"][0].lower()
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not OPENPYXL_AVAILABLE, reason="openpyxl not installed")
+async def test_reversible_prepare_ignores_payment_row_already_covered_by_bank_row(
+    client: AsyncClient,
+    auth_headers: dict,
+) -> None:
+    """A bank client transfer should suppress the duplicate payment-sheet row.
+
+    This applies when the duplicate appears in the same workbook.
+    """
+    content = _make_multi_sheet_xlsx(
+        {
+            "Factures": (
+                ["Date facture", "Réf facture", "Client", "Montant"],
+                [["2025-08-01", "2025-0142", "Christine LOPES", 55]],
+            ),
+            "Banque": (
+                ["Date", "Montant", "Référence", "Libellé", "Solde"],
+                [["2025-08-02", 55, "2025-0142", "Paiement facture client", 1000]],
+            ),
+            "Paiements": (
+                ["Réf facture", "Adhérent", "Montant", "Date paiement"],
+                [["2025-0142", "Christine LOPES", 55, "2025-08-02"]],
+            ),
+        }
+    )
+
+    prepare_response = await client.post(
+        "/api/import/runs/prepare/gestion",
+        files={"file": ("Gestion 2025.xlsx", content, _XLSX_MIME)},
+        headers=auth_headers,
+    )
+
+    assert prepare_response.status_code == 200
+    prepared_run = prepare_response.json()
+    assert prepared_run["status"] == "prepared"
+    assert [operation["operation_type"] for operation in prepared_run["operations"]] == [
+        "client_invoice_row_import",
+        "bank_row_import",
+        "ignored_by_policy",
+    ]
+    ignored_operation = prepared_run["operations"][2]
+    assert ignored_operation["title"] == "Paiement ligne 2"
+    assert "paiement deja couvert" in ignored_operation["diagnostics"][0].lower()
+
+    execute_response = await client.post(
+        f"/api/import/runs/{prepared_run['id']}/execute",
+        headers=auth_headers,
+    )
+
+    assert execute_response.status_code == 200
+    executed_run = execute_response.json()
+    assert executed_run["status"] == "completed"
+    assert executed_run["summary"]["payments_created"] == 1
+    assert executed_run["summary"]["ignored_rows"] == 1
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_settings_api.py
+++ b/tests/integration/test_settings_api.py
@@ -360,6 +360,24 @@ class TestResetDatabase:
 
 
 class TestSelectiveReset:
+    async def test_selective_reset_returns_404_for_unknown_fiscal_year(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+    ) -> None:
+        for endpoint in (
+            "/api/settings/selective-reset/preview",
+            "/api/settings/selective-reset/apply",
+        ):
+            response = await client.post(
+                endpoint,
+                json={"import_type": "gestion", "fiscal_year_id": 999999},
+                headers=auth_headers,
+            )
+
+            assert response.status_code == 404
+            assert response.json()["detail"] == "Fiscal year not found"
+
     async def test_selective_reset_preview_and_apply_for_gestion(
         self, client: AsyncClient, auth_headers: dict, db_session
     ) -> None:

--- a/tests/integration/test_settings_api.py
+++ b/tests/integration/test_settings_api.py
@@ -1,13 +1,24 @@
 """Integration tests for GET/PUT /api/settings."""
 
+import json
 from datetime import date
+from decimal import Decimal
 
 from httpx import AsyncClient
 from sqlalchemy import select
 
+from backend.models.accounting_entry import AccountingEntry, EntrySourceType
 from backend.models.bank import BankTransaction, BankTransactionSource
 from backend.models.cash import CashEntrySource, CashMovementType, CashRegister
+from backend.models.contact import Contact, ContactType
 from backend.models.fiscal_year import FiscalYear, FiscalYearStatus
+from backend.models.import_log import ImportLog, ImportLogStatus, ImportLogType
+from backend.models.invoice import Invoice, InvoiceStatus, InvoiceType
+from backend.models.payment import PaymentMethod
+from backend.schemas.bank import DepositCreate
+from backend.schemas.payment import PaymentCreate
+from backend.services import bank_service
+from backend.services import payment as payment_service
 
 
 class TestGetSettings:
@@ -346,6 +357,120 @@ class TestResetDatabase:
         settings_response = await client.get("/api/settings/", headers=auth_headers)
         assert settings_response.status_code == 200
         assert settings_response.json()["association_name"] == "Mon Association"
+
+
+class TestSelectiveReset:
+    async def test_selective_reset_preview_and_apply_for_gestion(
+        self, client: AsyncClient, auth_headers: dict, db_session
+    ) -> None:
+        fiscal_year = FiscalYear(
+            name="2025",
+            start_date=date(2025, 8, 1),
+            end_date=date(2026, 7, 31),
+            status=FiscalYearStatus.OPEN,
+        )
+        imported_contact = Contact(nom="Lopes", type=ContactType.CLIENT)
+        db_session.add_all([fiscal_year, imported_contact])
+        await db_session.flush()
+
+        imported_invoice = Invoice(
+            number="2025-C-0100",
+            type=InvoiceType.CLIENT,
+            contact_id=imported_contact.id,
+            date=date(2025, 9, 12),
+            total_amount=Decimal("90.00"),
+            paid_amount=Decimal("0.00"),
+            status=InvoiceStatus.SENT,
+        )
+        db_session.add(imported_invoice)
+        await db_session.flush()
+
+        db_session.add(
+            ImportLog(
+                import_type=ImportLogType.GESTION,
+                status=ImportLogStatus.SUCCESS,
+                file_hash="gestion-preview-2025",
+                file_name="Gestion 2025.xlsx",
+                summary=json.dumps(
+                    {
+                        "created_objects": [
+                            {
+                                "sheet_name": "Factures",
+                                "kind": "contacts",
+                                "object_type": "contact",
+                                "object_id": imported_contact.id,
+                            },
+                            {
+                                "sheet_name": "Factures",
+                                "kind": "invoices",
+                                "object_type": "invoice",
+                                "object_id": imported_invoice.id,
+                            },
+                        ]
+                    },
+                    ensure_ascii=False,
+                ),
+            )
+        )
+        await db_session.commit()
+
+        payment = await payment_service.create_payment(
+            db_session,
+            PaymentCreate(
+                invoice_id=imported_invoice.id,
+                contact_id=imported_contact.id,
+                amount=Decimal("90.00"),
+                date=date(2025, 9, 20),
+                method=PaymentMethod.ESPECES,
+            ),
+        )
+        deposit = await bank_service.create_deposit(
+            db_session,
+            DepositCreate(
+                date=date(2025, 9, 28),
+                type="especes",
+                payment_ids=[payment.id],
+            ),
+        )
+        db_session.add(
+            AccountingEntry(
+                entry_number="000301",
+                date=payment.date,
+                account_number="530000",
+                label="Paiement derive API",
+                debit=Decimal("90.00"),
+                credit=Decimal("0.00"),
+                fiscal_year_id=fiscal_year.id,
+                source_type=EntrySourceType.PAYMENT,
+                source_id=payment.id,
+            )
+        )
+        await db_session.commit()
+
+        preview_response = await client.post(
+            "/api/settings/selective-reset/preview",
+            json={"import_type": "gestion", "fiscal_year_id": fiscal_year.id},
+            headers=auth_headers,
+        )
+
+        assert preview_response.status_code == 200
+        preview_payload = preview_response.json()
+        assert preview_payload["matched_import_logs"] == 1
+        assert preview_payload["delete_plan"]["invoice"] == 1
+        assert preview_payload["delete_plan"]["payment"] == 1
+        assert preview_payload["delete_plan"]["deposit"] == 1
+
+        apply_response = await client.post(
+            "/api/settings/selective-reset/apply",
+            json={"import_type": "gestion", "fiscal_year_id": fiscal_year.id},
+            headers=auth_headers,
+        )
+
+        assert apply_response.status_code == 200
+        assert (await db_session.get(Contact, imported_contact.id)) is None
+        assert (await db_session.get(Invoice, imported_invoice.id)) is None
+        assert (await db_session.get(type(deposit), deposit.id)) is None
+        assert (await db_session.execute(select(ImportLog))).scalars().all() == []
 
 
 class TestBootstrapAccountingSetup:

--- a/tests/unit/test_settings_service.py
+++ b/tests/unit/test_settings_service.py
@@ -4,6 +4,7 @@ import json
 from datetime import date
 from decimal import Decimal
 
+import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -251,6 +252,16 @@ class TestBootstrapAccountingSetup:
 
 
 class TestSelectiveReset:
+    async def test_preview_selective_reset_raises_lookup_error_for_unknown_fiscal_year(
+        self,
+        db_session: AsyncSession,
+    ) -> None:
+        with pytest.raises(LookupError, match="Fiscal year not found"):
+            await preview_selective_reset(
+                db_session,
+                SelectiveResetRequest(import_type=ImportLogType.GESTION, fiscal_year_id=999999),
+            )
+
     async def test_preview_and_apply_selective_reset_for_gestion_with_solde_derivatives(
         self,
         db_session: AsyncSession,

--- a/tests/unit/test_settings_service.py
+++ b/tests/unit/test_settings_service.py
@@ -1,5 +1,6 @@
 """Unit tests for the settings service."""
 
+import json
 from datetime import date
 from decimal import Decimal
 
@@ -7,6 +8,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.models.accounting_account import AccountingAccount, AccountType
+from backend.models.accounting_entry import AccountingEntry, EntrySourceType
 from backend.models.accounting_rule import (
     AccountingRule,
     AccountingRuleEntry,
@@ -24,18 +26,27 @@ from backend.models.cash import (
 from backend.models.contact import Contact, ContactType
 from backend.models.fiscal_year import FiscalYear, FiscalYearStatus
 from backend.models.import_log import ImportLog, ImportLogStatus, ImportLogType
+from backend.models.invoice import Invoice, InvoiceStatus, InvoiceType
+from backend.models.payment import PaymentMethod
 from backend.models.user import User, UserRole
+from backend.schemas.bank import DepositCreate
+from backend.schemas.payment import PaymentCreate
 from backend.schemas.settings import (
     AppSettingsUpdate,
+    SelectiveResetRequest,
     SystemOpeningUpdate,
     TreasurySystemOpeningUpdate,
 )
+from backend.services import bank_service
+from backend.services import payment as payment_service
 from backend.services.bank_service import recompute_bank_balances
 from backend.services.cash_service import recompute_cash_balances
 from backend.services.settings import (
+    apply_selective_reset,
     bootstrap_accounting_setup,
     get_settings,
     get_treasury_system_opening,
+    preview_selective_reset,
     reset_data,
     update_settings,
     upsert_treasury_system_opening,
@@ -237,6 +248,261 @@ class TestBootstrapAccountingSetup:
             "rules_inserted": 0,
             "fiscal_years_created": 0,
         }
+
+
+class TestSelectiveReset:
+    async def test_preview_and_apply_selective_reset_for_gestion_with_solde_derivatives(
+        self,
+        db_session: AsyncSession,
+    ) -> None:
+        fiscal_year = FiscalYear(
+            name="2025",
+            start_date=date(2025, 8, 1),
+            end_date=date(2026, 7, 31),
+            status=FiscalYearStatus.OPEN,
+        )
+        imported_contact = Contact(nom="Lopes", prenom="Christine", type=ContactType.CLIENT)
+        unrelated_contact = Contact(nom="Martin", prenom="Luc", type=ContactType.CLIENT)
+        db_session.add_all([fiscal_year, imported_contact, unrelated_contact])
+        await db_session.flush()
+
+        imported_invoice = Invoice(
+            number="2025-C-0001",
+            type=InvoiceType.CLIENT,
+            contact_id=imported_contact.id,
+            date=date(2025, 9, 10),
+            total_amount=Decimal("120.00"),
+            paid_amount=Decimal("0.00"),
+            status=InvoiceStatus.SENT,
+        )
+        unrelated_invoice = Invoice(
+            number="2025-C-0002",
+            type=InvoiceType.CLIENT,
+            contact_id=unrelated_contact.id,
+            date=date(2025, 10, 5),
+            total_amount=Decimal("80.00"),
+            paid_amount=Decimal("0.00"),
+            status=InvoiceStatus.SENT,
+        )
+        db_session.add_all([imported_invoice, unrelated_invoice])
+        await db_session.flush()
+
+        db_session.add(
+            ImportLog(
+                import_type=ImportLogType.GESTION,
+                status=ImportLogStatus.SUCCESS,
+                file_hash="gestion-2025-hash",
+                file_name="Gestion 2025.xlsx",
+                summary=json.dumps(
+                    {
+                        "created_objects": [
+                            {
+                                "sheet_name": "Factures",
+                                "kind": "contacts",
+                                "object_type": "contact",
+                                "object_id": imported_contact.id,
+                            },
+                            {
+                                "sheet_name": "Factures",
+                                "kind": "invoices",
+                                "object_type": "invoice",
+                                "object_id": imported_invoice.id,
+                            },
+                        ]
+                    },
+                    ensure_ascii=False,
+                ),
+            )
+        )
+        await db_session.commit()
+
+        derived_payment = await payment_service.create_payment(
+            db_session,
+            PaymentCreate(
+                invoice_id=imported_invoice.id,
+                contact_id=imported_contact.id,
+                amount=Decimal("120.00"),
+                date=date(2025, 9, 20),
+                method=PaymentMethod.ESPECES,
+                reference="REG-2025-001",
+            ),
+        )
+        deposit = await bank_service.create_deposit(
+            db_session,
+            DepositCreate(
+                date=date(2025, 9, 25),
+                type="especes",
+                payment_ids=[derived_payment.id],
+                bank_reference="DEP-2025-001",
+            ),
+        )
+
+        db_session.add_all(
+            [
+                AccountingEntry(
+                    entry_number="000101",
+                    date=imported_invoice.date,
+                    account_number="411000",
+                    label="Facture importee",
+                    debit=Decimal("120.00"),
+                    credit=Decimal("0.00"),
+                    fiscal_year_id=fiscal_year.id,
+                    source_type=EntrySourceType.INVOICE,
+                    source_id=imported_invoice.id,
+                ),
+                AccountingEntry(
+                    entry_number="000102",
+                    date=derived_payment.date,
+                    account_number="512100",
+                    label="Paiement derive",
+                    debit=Decimal("0.00"),
+                    credit=Decimal("120.00"),
+                    fiscal_year_id=fiscal_year.id,
+                    source_type=EntrySourceType.PAYMENT,
+                    source_id=derived_payment.id,
+                ),
+                AccountingEntry(
+                    entry_number="000103",
+                    date=deposit.date,
+                    account_number="530000",
+                    label="Remise derivee",
+                    debit=Decimal("0.00"),
+                    credit=Decimal("120.00"),
+                    fiscal_year_id=fiscal_year.id,
+                    source_type=EntrySourceType.DEPOSIT,
+                    source_id=deposit.id,
+                ),
+                AccountingEntry(
+                    entry_number="000104",
+                    date=unrelated_invoice.date,
+                    account_number="411000",
+                    label="Manuelle hors scope",
+                    debit=Decimal("80.00"),
+                    credit=Decimal("0.00"),
+                    fiscal_year_id=fiscal_year.id,
+                    source_type=EntrySourceType.MANUAL,
+                    source_id=999,
+                ),
+            ]
+        )
+        await db_session.commit()
+
+        preview = await preview_selective_reset(
+            db_session,
+            SelectiveResetRequest(import_type=ImportLogType.GESTION, fiscal_year_id=fiscal_year.id),
+        )
+
+        assert preview.matched_import_logs == 1
+        assert preview.root_objects["contact"] == 1
+        assert preview.root_objects["invoice"] == 1
+        assert preview.derived_objects["payment"] == 1
+        assert preview.delete_plan["deposit"] == 1
+        assert preview.delete_plan["cash_register"] == 2
+        assert preview.delete_plan["accounting_entry"] == 3
+        assert preview.delete_plan["contact"] == 1
+
+        applied = await apply_selective_reset(
+            db_session,
+            SelectiveResetRequest(import_type=ImportLogType.GESTION, fiscal_year_id=fiscal_year.id),
+        )
+
+        assert applied.delete_plan["invoice"] == 1
+        assert applied.delete_plan["payment"] == 1
+        assert applied.delete_plan["deposit"] == 1
+        assert applied.delete_plan["import_logs"] == 1
+        assert (await db_session.get(Contact, imported_contact.id)) is None
+        assert (await db_session.get(Invoice, imported_invoice.id)) is None
+        assert (await db_session.get(type(deposit), deposit.id)) is None
+        assert (await db_session.get(Contact, unrelated_contact.id)) is not None
+        assert (await db_session.get(Invoice, unrelated_invoice.id)) is not None
+        remaining_entries = (await db_session.execute(select(AccountingEntry))).scalars().all()
+        assert [entry.entry_number for entry in remaining_entries] == ["000104"]
+        remaining_cash_entries = (await db_session.execute(select(CashRegister))).scalars().all()
+        assert remaining_cash_entries == []
+        remaining_logs = (await db_session.execute(select(ImportLog))).scalars().all()
+        assert remaining_logs == []
+
+    async def test_apply_selective_reset_for_comptabilite_preserves_manual_entries(
+        self,
+        db_session: AsyncSession,
+    ) -> None:
+        fiscal_year = FiscalYear(
+            name="2025",
+            start_date=date(2025, 8, 1),
+            end_date=date(2026, 7, 31),
+            status=FiscalYearStatus.OPEN,
+        )
+        db_session.add(fiscal_year)
+        await db_session.flush()
+
+        imported_entry = AccountingEntry(
+            entry_number="000201",
+            date=date(2025, 11, 1),
+            account_number="606100",
+            label="Import compta",
+            debit=Decimal("25.00"),
+            credit=Decimal("0.00"),
+            fiscal_year_id=fiscal_year.id,
+            source_type=EntrySourceType.MANUAL,
+            source_id=5001,
+        )
+        manual_entry = AccountingEntry(
+            entry_number="000202",
+            date=date(2025, 11, 2),
+            account_number="606200",
+            label="Saisie manuelle",
+            debit=Decimal("30.00"),
+            credit=Decimal("0.00"),
+            fiscal_year_id=fiscal_year.id,
+            source_type=EntrySourceType.MANUAL,
+            source_id=5002,
+        )
+        db_session.add_all([imported_entry, manual_entry])
+        await db_session.flush()
+        db_session.add(
+            ImportLog(
+                import_type=ImportLogType.COMPTABILITE,
+                status=ImportLogStatus.SUCCESS,
+                file_hash="compta-2025-hash",
+                file_name="Comptabilite 2025.xlsx",
+                summary=json.dumps(
+                    {
+                        "created_objects": [
+                            {
+                                "sheet_name": "Journal",
+                                "kind": "entries",
+                                "object_type": "accounting_entry",
+                                "object_id": imported_entry.id,
+                            }
+                        ]
+                    },
+                    ensure_ascii=False,
+                ),
+            )
+        )
+        await db_session.commit()
+
+        preview = await preview_selective_reset(
+            db_session,
+            SelectiveResetRequest(
+                import_type=ImportLogType.COMPTABILITE,
+                fiscal_year_id=fiscal_year.id,
+            ),
+        )
+
+        assert preview.delete_plan["accounting_entry"] == 1
+        assert preview.delete_plan["import_logs"] == 1
+
+        await apply_selective_reset(
+            db_session,
+            SelectiveResetRequest(
+                import_type=ImportLogType.COMPTABILITE,
+                fiscal_year_id=fiscal_year.id,
+            ),
+        )
+
+        remaining_entries = (await db_session.execute(select(AccountingEntry))).scalars().all()
+        assert [entry.entry_number for entry in remaining_entries] == ["000202"]
 
 
 class TestTreasurySystemOpening:


### PR DESCRIPTION
## Summary
- add selective reset preview/apply endpoints and settings UI to replay one import stream for one fiscal year without wiping the whole database
- route dev test shortcuts through the reversible prepare/execute flow and improve import/history UX for failed runs, per-operation undo/redo, long-running actions, and actionable error surfacing
- harden reversible import preparation and execution around duplicate workbook rows, existing payments already present in Solde, bank/payment overlap, nested rollback isolation, and fingerprint normalization during undo

## Why
- BL-015 needed an admin reset path for legacy or non-reversible replay scenarios where the strict import journal is not enough
- recent reversible import work exposed several consistency and UX gaps when operations fail, time out, or collide with pre-existing data

## Validation
- d:/dev/_misc/solde/.venv/Scripts/python.exe -m ruff check .
- d:/dev/_misc/solde/.venv/Scripts/python.exe -m ruff format --check .
- d:/dev/_misc/solde/.venv/Scripts/python.exe -m mypy .
- d:/dev/_misc/solde/.venv/Scripts/python.exe -m pytest tests/
- cd frontend && npx vue-tsc --noEmit -p tsconfig.app.json
- cd frontend && npx vue-tsc --noEmit
- cd frontend && npx eslint src/
- cd frontend && npx vitest run