### PR TITLE
feat(security): disable Swagger/ReDoc in production (BL-068)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Ce projet respecte le [Versionnage sémantique](https://semver.org/lang/fr/).
 - `doc/user/migration.md` + `doc/user/migration.en.md` : guide de migration / montée de version bilingue FR + EN pour les déploiements Docker sur Synology NAS — couvre la préparation, la mise à jour, la vérification, le rollback et les bonnes pratiques (BL-083)
 - `frontend/src/assets/print.css` : styles `@media print` pour l'impression des vues comptables (journal, balance, grand livre, bilan, résultat) — masque la sidebar, les filtres et les boutons ; optimise les tables en noir et blanc A4 paysage pour impression AG (BL-076)
 - `backend/main.py` : middleware ASGI `UnhandledExceptionMiddleware` interceptant toutes les exceptions non gérées pour renvoyer un JSON structuré `{"detail": ..., "code": "INTERNAL_SERVER_ERROR"}` au lieu d'un 500 HTML avec stack trace — log complet côté serveur (BL-067)
+- `backend/main.py` : `/api/docs`, `/api/redoc` et `/api/openapi.json` désormais désactivés quand `debug=False` — réduit la surface d'attaque en production (BL-068)
 
 **Qualité / Sécurité (audit 2026-04-22)**
 - `backend/routers/auth.py` : le refresh token est désormais transmis via un cookie `HttpOnly`, `Secure`, `SameSite=Strict` au lieu du corps JSON — `/auth/login` et `/auth/refresh` posent le cookie, nouvel endpoint `POST /auth/logout` (204) l'efface (BL-046)

--- a/backend/main.py
+++ b/backend/main.py
@@ -193,9 +193,9 @@ def create_app() -> FastAPI:
     app = FastAPI(
         title=cfg.app_name,
         version=cfg.app_version,
-        docs_url="/api/docs",
-        redoc_url="/api/redoc",
-        openapi_url="/api/openapi.json",
+        docs_url="/api/docs" if cfg.debug else None,
+        redoc_url="/api/redoc" if cfg.debug else None,
+        openapi_url="/api/openapi.json" if cfg.debug else None,
         lifespan=lifespan,
     )
 

--- a/tests/integration/test_swagger_exposure.py
+++ b/tests/integration/test_swagger_exposure.py
@@ -1,0 +1,55 @@
+"""Tests for OpenAPI/Swagger conditional exposure (BL-068)."""
+
+from unittest.mock import patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+
+@pytest.mark.asyncio
+async def test_swagger_available_in_debug_mode() -> None:
+    """When debug=True, /api/docs and /api/openapi.json must be reachable."""
+    with patch("backend.main.get_settings") as mock_settings:
+        mock_settings.return_value = _make_settings(debug=True)
+        from backend.main import create_app
+
+        app = create_app()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        resp_docs = await ac.get("/api/docs")
+        resp_redoc = await ac.get("/api/redoc")
+        resp_openapi = await ac.get("/api/openapi.json")
+
+    assert resp_docs.status_code == 200
+    assert resp_redoc.status_code == 200
+    assert resp_openapi.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_swagger_disabled_in_production() -> None:
+    """When debug=False, /api/docs, /api/redoc and /api/openapi.json must return 404."""
+    with patch("backend.main.get_settings") as mock_settings:
+        mock_settings.return_value = _make_settings(debug=False)
+        from backend.main import create_app
+
+        app = create_app()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        resp_docs = await ac.get("/api/docs")
+        resp_redoc = await ac.get("/api/redoc")
+        resp_openapi = await ac.get("/api/openapi.json")
+
+    assert resp_docs.status_code == 404
+    assert resp_redoc.status_code == 404
+    assert resp_openapi.status_code == 404
+
+
+def _make_settings(*, debug: bool):
+    """Build a Settings instance with the given debug flag."""
+    from backend.config import Settings
+
+    return Settings(
+        debug=debug,
+        jwt_secret_key="test-secret-key-for-testing-only-1234567890",
+        database_url="sqlite+aiosqlite:///:memory:",
+    )


### PR DESCRIPTION
Conditionally disables docs_url, redoc_url, openapi_url when cfg.debug is False. 2 integration tests.

## Summary by Sourcery

Conditionally hide API documentation endpoints in non-debug environments to reduce production attack surface.

New Features:
- Gate FastAPI docs, ReDoc, and OpenAPI JSON endpoints behind the debug configuration flag.

Enhancements:
- Tighten security middleware configuration for production responses.

Documentation:
- Update changelog to document conditional exposure of API documentation endpoints for security.

Tests:
- Add integration tests verifying that documentation endpoints are available in debug mode and return 404 in production mode.