### PR TITLE
feat(backup): add SQLite backup endpoint with rotation and download (BL-069)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Ce projet respecte le [Versionnage sémantique](https://semver.org/lang/fr/).
 - `frontend/src/assets/print.css` : styles `@media print` pour l'impression des vues comptables (journal, balance, grand livre, bilan, résultat) — masque la sidebar, les filtres et les boutons ; optimise les tables en noir et blanc A4 paysage pour impression AG (BL-076)
 - `backend/main.py` : middleware ASGI `UnhandledExceptionMiddleware` interceptant toutes les exceptions non gérées pour renvoyer un JSON structuré `{"detail": ..., "code": "INTERNAL_SERVER_ERROR"}` au lieu d'un 500 HTML avec stack trace — log complet côté serveur (BL-067)
 - `backend/main.py` : `/api/docs`, `/api/redoc` et `/api/openapi.json` désormais désactivés quand `debug=False` — réduit la surface d'attaque en production (BL-068)
+- `backend/services/backup_service.py` + `POST /api/settings/backup` : endpoint admin de sauvegarde SQLite utilisant `sqlite3.backup()` avec rotation automatique (5 derniers backups), téléchargement direct du fichier en réponse (BL-069)
 
 **Qualité / Sécurité (audit 2026-04-22)**
 - `backend/routers/auth.py` : le refresh token est désormais transmis via un cookie `HttpOnly`, `Secure`, `SameSite=Strict` au lieu du corps JSON — `/auth/login` et `/auth/refresh` posent le cookie, nouvel endpoint `POST /auth/logout` (204) l'efface (BL-046)

--- a/backend/routers/settings.py
+++ b/backend/routers/settings.py
@@ -1,8 +1,10 @@
 """Settings API router — GET/PUT /api/settings (admin only)."""
 
+from pathlib import Path
 from typing import Annotated, NoReturn
 
 from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.responses import FileResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.config import get_settings as get_app_config
@@ -134,3 +136,52 @@ async def bootstrap_accounting(
 ) -> dict[str, int]:
     """Recreate the default accounting setup used during replay/testing."""
     return await settings_service.bootstrap_accounting_setup(db)
+
+
+# ---------------------------------------------------------------------------
+# Database backup (BL-069)
+# ---------------------------------------------------------------------------
+
+_BACKUP_DIR = "data/backups"
+_MAX_BACKUPS = 5
+
+
+def _get_db_path() -> str:
+    """Resolve the SQLite file path from the database URL."""
+    url = get_app_config().database_url
+    # "sqlite+aiosqlite:///data/solde.db" → "data/solde.db"
+    return url.split("///", 1)[-1]
+
+
+def _get_backup_dir() -> str:
+    """Return the backup directory path."""
+    return _BACKUP_DIR
+
+
+@router.post("/backup")
+async def create_backup(
+    _current_user: _AdminRequired,
+) -> FileResponse:
+    """Create a SQLite backup and return it as a downloadable file (admin only)."""
+    from backend.services.backup_service import create_backup as do_backup
+
+    db_path = _get_db_path()
+    backup_dir = _get_backup_dir()
+
+    if not Path(db_path).exists():
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Database file not found on disk.",
+        )
+
+    backup_file = await do_backup(
+        db_path=db_path,
+        backup_dir=backup_dir,
+        max_backups=_MAX_BACKUPS,
+    )
+
+    return FileResponse(
+        path=str(backup_file),
+        filename=backup_file.name,
+        media_type="application/octet-stream",
+    )

--- a/backend/routers/settings.py
+++ b/backend/routers/settings.py
@@ -148,9 +148,15 @@ _MAX_BACKUPS = 5
 
 def _get_db_path() -> str:
     """Resolve the SQLite file path from the database URL."""
-    url = get_app_config().database_url
-    # "sqlite+aiosqlite:///data/solde.db" → "data/solde.db"
-    return url.split("///", 1)[-1]
+    from sqlalchemy.engine import make_url
+
+    url = make_url(get_app_config().database_url)
+    if url.get_backend_name() != "sqlite":
+        raise RuntimeError(f"Backup only supports SQLite, got: {url.get_backend_name()}")
+    # make_url().database returns the filesystem path for SQLite URLs
+    if not url.database:
+        raise RuntimeError("Cannot determine database file path from URL.")
+    return url.database
 
 
 def _get_backup_dir() -> str:

--- a/backend/services/backup_service.py
+++ b/backend/services/backup_service.py
@@ -1,0 +1,44 @@
+"""SQLite online backup with rotation (BL-069)."""
+
+import sqlite3
+from datetime import UTC, datetime
+from pathlib import Path
+
+
+async def create_backup(
+    *,
+    db_path: str,
+    backup_dir: str,
+    max_backups: int = 5,
+) -> Path:
+    """Create a backup of the SQLite database using ``sqlite3.backup()``.
+
+    Returns the path to the new backup file.  Older backups beyond
+    *max_backups* are deleted automatically (FIFO).
+    """
+    backup_path = Path(backup_dir)
+    backup_path.mkdir(parents=True, exist_ok=True)
+
+    timestamp = datetime.now(UTC).strftime("%Y%m%d_%H%M%S")
+    dest_file = backup_path / f"solde_backup_{timestamp}.db"
+
+    # sqlite3.backup() is synchronous — safe on a single-writer SQLite WAL DB.
+    src_conn = sqlite3.connect(db_path)
+    dst_conn = sqlite3.connect(str(dest_file))
+    try:
+        src_conn.backup(dst_conn)
+    finally:
+        dst_conn.close()
+        src_conn.close()
+
+    _rotate_backups(backup_path, max_backups)
+
+    return dest_file
+
+
+def _rotate_backups(backup_dir: Path, max_backups: int) -> None:
+    """Keep only the *max_backups* most recent ``.db`` files."""
+    backups = sorted(backup_dir.glob("solde_backup_*.db"))
+    while len(backups) > max_backups:
+        oldest = backups.pop(0)
+        oldest.unlink(missing_ok=True)

--- a/backend/services/backup_service.py
+++ b/backend/services/backup_service.py
@@ -4,6 +4,8 @@ import sqlite3
 from datetime import UTC, datetime
 from pathlib import Path
 
+import anyio
+
 
 async def create_backup(
     *,
@@ -16,13 +18,27 @@ async def create_backup(
     Returns the path to the new backup file.  Older backups beyond
     *max_backups* are deleted automatically (FIFO).
     """
+    if max_backups < 1:
+        raise ValueError("max_backups must be >= 1")
+
     backup_path = Path(backup_dir)
     backup_path.mkdir(parents=True, exist_ok=True)
 
-    timestamp = datetime.now(UTC).strftime("%Y%m%d_%H%M%S")
+    timestamp = datetime.now(UTC).strftime("%Y%m%d_%H%M%S_%f")
     dest_file = backup_path / f"solde_backup_{timestamp}.db"
 
-    # sqlite3.backup() is synchronous — safe on a single-writer SQLite WAL DB.
+    # Run blocking sqlite3 I/O in a worker thread to avoid blocking the event loop.
+    await anyio.to_thread.run_sync(
+        lambda: _do_backup(db_path, dest_file)
+    )
+
+    _rotate_backups(backup_path, max_backups)
+
+    return dest_file
+
+
+def _do_backup(db_path: str, dest_file: Path) -> None:
+    """Perform the actual sqlite3.backup() (synchronous, called from a thread)."""
     src_conn = sqlite3.connect(db_path)
     dst_conn = sqlite3.connect(str(dest_file))
     try:
@@ -30,10 +46,6 @@ async def create_backup(
     finally:
         dst_conn.close()
         src_conn.close()
-
-    _rotate_backups(backup_path, max_backups)
-
-    return dest_file
 
 
 def _rotate_backups(backup_dir: Path, max_backups: int) -> None:

--- a/tests/integration/test_backup.py
+++ b/tests/integration/test_backup.py
@@ -1,0 +1,183 @@
+"""Tests for SQLite backup service and endpoint (BL-069)."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from httpx import AsyncClient
+
+# ---------------------------------------------------------------------------
+# Unit tests — backup_service
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_backup_produces_file(tmp_path: Path) -> None:
+    """create_backup must produce a .db file in the target directory."""
+    # Create a real SQLite source DB
+    import aiosqlite
+
+    src_db = tmp_path / "source.db"
+    async with aiosqlite.connect(str(src_db)) as db:
+        await db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY)")
+        await db.execute("INSERT INTO t VALUES (1)")
+        await db.commit()
+
+    from backend.services.backup_service import create_backup
+
+    backup_dir = tmp_path / "backups"
+    result = await create_backup(
+        db_path=str(src_db),
+        backup_dir=str(backup_dir),
+        max_backups=5,
+    )
+
+    assert result.exists()
+    assert result.suffix == ".db"
+    assert backup_dir.exists()
+
+    # Verify the backup is a valid SQLite DB with the same data
+    async with aiosqlite.connect(str(result)) as db:
+        cursor = await db.execute("SELECT id FROM t")
+        rows = await cursor.fetchall()
+        assert rows == [(1,)]
+
+
+@pytest.mark.asyncio
+async def test_backup_rotation_keeps_max_files(tmp_path: Path) -> None:
+    """Older backups beyond max_backups must be deleted."""
+    import aiosqlite
+
+    src_db = tmp_path / "source.db"
+    async with aiosqlite.connect(str(src_db)) as db:
+        await db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY)")
+        await db.commit()
+
+    from unittest.mock import patch as sync_patch
+
+    from backend.services.backup_service import create_backup
+
+    backup_dir = tmp_path / "backups"
+
+    # Create 6 backups with distinct timestamps by mocking datetime
+    paths = []
+    for i in range(6):
+        fake_ts = f"2026042{i}_12000{i}"
+        with sync_patch("backend.services.backup_service.datetime") as mock_dt:
+            mock_dt.now.return_value.strftime.return_value = fake_ts
+            mock_dt.side_effect = None
+            p = await create_backup(
+                db_path=str(src_db),
+                backup_dir=str(backup_dir),
+                max_backups=3,
+            )
+            paths.append(p)
+
+    remaining = list(backup_dir.glob("*.db"))
+    assert len(remaining) == 3
+
+    # The 3 most recent should be kept
+    remaining_names = {f.name for f in remaining}
+    for p in paths[-3:]:
+        assert p.name in remaining_names
+
+
+@pytest.mark.asyncio
+async def test_backup_filename_contains_timestamp(tmp_path: Path) -> None:
+    """Backup filename must contain a sortable timestamp."""
+    import aiosqlite
+
+    src_db = tmp_path / "source.db"
+    async with aiosqlite.connect(str(src_db)) as db:
+        await db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY)")
+        await db.commit()
+
+    from backend.services.backup_service import create_backup
+
+    result = await create_backup(
+        db_path=str(src_db),
+        backup_dir=str(tmp_path / "backups"),
+        max_backups=5,
+    )
+
+    # Format: solde_backup_YYYYMMDD_HHMMSS.db
+    assert result.name.startswith("solde_backup_")
+    assert len(result.stem) > len("solde_backup_")
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — API endpoint
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_backup_endpoint_requires_admin(
+    client: AsyncClient,
+    secretaire_auth_headers: dict[str, str],
+) -> None:
+    """Non-admin users must get 403 on the backup endpoint."""
+    resp = await client.post("/api/settings/backup", headers=secretaire_auth_headers)
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_backup_endpoint_returns_file(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+    tmp_path: Path,
+) -> None:
+    """POST /api/settings/backup must return the backup as a downloadable file."""
+    import aiosqlite
+
+    # Create a temp SQLite DB as the "app database"
+    src_db = tmp_path / "test_solde.db"
+    async with aiosqlite.connect(str(src_db)) as db:
+        await db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY)")
+        await db.execute("INSERT INTO t VALUES (42)")
+        await db.commit()
+
+    backup_dir = tmp_path / "backups"
+
+    with (
+        patch("backend.routers.settings._get_db_path", return_value=str(src_db)),
+        patch("backend.routers.settings._get_backup_dir", return_value=str(backup_dir)),
+    ):
+        resp = await client.post("/api/settings/backup", headers=auth_headers)
+
+    assert resp.status_code == 200
+    assert "application/octet-stream" in resp.headers["content-type"]
+    assert "attachment" in resp.headers.get("content-disposition", "")
+
+    # Verify the returned bytes are a valid SQLite database
+    downloaded = tmp_path / "downloaded.db"
+    downloaded.write_bytes(resp.content)
+    async with aiosqlite.connect(str(downloaded)) as db:
+        cursor = await db.execute("SELECT id FROM t")
+        rows = await cursor.fetchall()
+        assert rows == [(42,)]
+
+
+@pytest.mark.asyncio
+async def test_backup_endpoint_creates_backup_on_disk(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+    tmp_path: Path,
+) -> None:
+    """POST /api/settings/backup must also store the backup in the backup dir."""
+    import aiosqlite
+
+    src_db = tmp_path / "test_solde.db"
+    async with aiosqlite.connect(str(src_db)) as db:
+        await db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY)")
+        await db.commit()
+
+    backup_dir = tmp_path / "backups"
+
+    with (
+        patch("backend.routers.settings._get_db_path", return_value=str(src_db)),
+        patch("backend.routers.settings._get_backup_dir", return_value=str(backup_dir)),
+    ):
+        await client.post("/api/settings/backup", headers=auth_headers)
+
+    backups = list(backup_dir.glob("*.db"))
+    assert len(backups) == 1

--- a/tests/integration/test_backup.py
+++ b/tests/integration/test_backup.py
@@ -100,9 +100,25 @@ async def test_backup_filename_contains_timestamp(tmp_path: Path) -> None:
         max_backups=5,
     )
 
-    # Format: solde_backup_YYYYMMDD_HHMMSS.db
+    # Format: solde_backup_YYYYMMDD_HHMMSS_ffffff.db
     assert result.name.startswith("solde_backup_")
     assert len(result.stem) > len("solde_backup_")
+
+
+@pytest.mark.asyncio
+async def test_create_backup_rejects_invalid_max_backups(tmp_path: Path) -> None:
+    """create_backup must reject max_backups < 1."""
+    import aiosqlite
+
+    src_db = tmp_path / "source.db"
+    async with aiosqlite.connect(str(src_db)) as db:
+        await db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY)")
+        await db.commit()
+
+    from backend.services.backup_service import create_backup
+
+    with pytest.raises(ValueError, match="max_backups must be >= 1"):
+        await create_backup(db_path=str(src_db), backup_dir=str(tmp_path / "backups"), max_backups=0)
 
 
 # ---------------------------------------------------------------------------
@@ -181,3 +197,16 @@ async def test_backup_endpoint_creates_backup_on_disk(
 
     backups = list(backup_dir.glob("*.db"))
     assert len(backups) == 1
+
+
+@pytest.mark.asyncio
+async def test_backup_endpoint_db_not_found(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+) -> None:
+    """POST /api/settings/backup must return 500 when the DB file is missing."""
+    with patch("backend.routers.settings._get_db_path", return_value="/nonexistent/solde.db"):
+        resp = await client.post("/api/settings/backup", headers=auth_headers)
+
+    assert resp.status_code == 500
+    assert resp.json()["detail"] == "Database file not found on disk."


### PR DESCRIPTION
New backup_service.py + POST /api/settings/backup endpoint. Uses sqlite3.backup(), auto-rotates to keep 5 most recent, returns FileResponse for download. Admin-only. 6 tests.

## Summary by Sourcery

Introduce an admin-only SQLite database backup capability with on-disk rotation and downloadable responses.

New Features:
- Add a backup service for creating timestamped SQLite backups with automatic rotation of older files.
- Expose a POST /api/settings/backup endpoint for admins to trigger a backup and download the resulting file.

Documentation:
- Document the new SQLite backup endpoint and behavior in the changelog.

Tests:
- Add unit tests for the backup service, covering file creation, rotation, and filename format, plus integration tests for the backup API endpoint including permissions and download behavior.