### PR TITLE
feat(ui): add print-friendly CSS styles for accounting views (BL-076)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Ce projet respecte le [Versionnage sémantique](https://semver.org/lang/fr/).
 ### Ajouté
 
 - `doc/user/migration.md` + `doc/user/migration.en.md` : guide de migration / montée de version bilingue FR + EN pour les déploiements Docker sur Synology NAS — couvre la préparation, la mise à jour, la vérification, le rollback et les bonnes pratiques (BL-083)
-- `frontend/src/assets/print.css` : styles `@media print` pour l'impression des vues comptables (journal, balance, grand livre, bilan, résultat) — masque sidebar, filtres, boutons ; optimise les tables en noir et blanc A4 paysage pour impression AG (BL-076)
+- `frontend/src/assets/print.css` : styles `@media print` pour l'impression des vues comptables (journal, balance, grand livre, bilan, résultat) — masque la sidebar, les filtres et les boutons ; optimise les tables en noir et blanc A4 paysage pour impression AG (BL-076)
 
 **Qualité / Sécurité (audit 2026-04-22)**
 - `backend/routers/auth.py` : le refresh token est désormais transmis via un cookie `HttpOnly`, `Secure`, `SameSite=Strict` au lieu du corps JSON — `/auth/login` et `/auth/refresh` posent le cookie, nouvel endpoint `POST /auth/logout` (204) l'efface (BL-046)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Ce projet respecte le [Versionnage sémantique](https://semver.org/lang/fr/).
 ### Ajouté
 
 - `doc/user/migration.md` + `doc/user/migration.en.md` : guide de migration / montée de version bilingue FR + EN pour les déploiements Docker sur Synology NAS — couvre la préparation, la mise à jour, la vérification, le rollback et les bonnes pratiques (BL-083)
+- `frontend/src/assets/print.css` : styles `@media print` pour l'impression des vues comptables (journal, balance, grand livre, bilan, résultat) — masque sidebar, filtres, boutons ; optimise les tables en noir et blanc A4 paysage pour impression AG (BL-076)
 
 **Qualité / Sécurité (audit 2026-04-22)**
 - `backend/routers/auth.py` : le refresh token est désormais transmis via un cookie `HttpOnly`, `Secure`, `SameSite=Strict` au lieu du corps JSON — `/auth/login` et `/auth/refresh` posent le cookie, nouvel endpoint `POST /auth/logout` (204) l'efface (BL-046)

--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -1,6 +1,5 @@
 /* Global styles — PrimeVue handles component theming via CSS variables */
 @import url('https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&display=swap');
-@import './print.css';
 
 :root {
   --app-page-max-width: 1320px;

--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -1,5 +1,6 @@
 /* Global styles — PrimeVue handles component theming via CSS variables */
 @import url('https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&display=swap');
+@import './print.css';
 
 :root {
   --app-page-max-width: 1320px;

--- a/frontend/src/assets/print.css
+++ b/frontend/src/assets/print.css
@@ -1,6 +1,6 @@
 /* Print styles for accounting views (BL-076)
- * Used for AG (assemblée générale) printing: journal, balance,
- * grand livre, bilan, compte de résultat.
+ * Used for general meeting printing: journal, trial balance,
+ * general ledger, balance sheet, income statement.
  */
 
 @media print {
@@ -61,6 +61,7 @@
   /* ------------------------------------------------------------------ */
 
   .app-page-header {
+    display: block !important;
     text-align: center;
     margin-bottom: 0.5rem;
     padding: 0;
@@ -204,13 +205,11 @@
   /* 6. Page settings                                                   */
   /* ------------------------------------------------------------------ */
 
-  @page {
-    size: A4 landscape;
-    margin: 1.5cm;
-  }
-
-  /* Force black text everywhere */
-  * {
+  /* Force black text in accounting content containers */
+  .p-datatable,
+  .p-datatable *,
+  .app-panel,
+  .app-panel * {
     color: #000 !important;
   }
 
@@ -227,4 +226,10 @@
   .p-datatable-tbody > tr {
     break-inside: avoid;
   }
+}
+
+/* @page must be at top level for cross-browser print compatibility */
+@page {
+  size: A4 landscape;
+  margin: 1.5cm;
 }

--- a/frontend/src/assets/print.css
+++ b/frontend/src/assets/print.css
@@ -1,0 +1,230 @@
+/* Print styles for accounting views (BL-076)
+ * Used for AG (assemblée générale) printing: journal, balance,
+ * grand livre, bilan, compte de résultat.
+ */
+
+@media print {
+  /* ------------------------------------------------------------------ */
+  /* 1. Hide non-essential UI elements                                  */
+  /* ------------------------------------------------------------------ */
+
+  /* Sidebar / navigation / topbar */
+  .sidebar,
+  .topbar,
+  .app-drawer,
+  .topbar-menu-btn {
+    display: none !important;
+  }
+
+  /* Layout: full width, no padding constraints */
+  .layout-body {
+    display: block !important;
+  }
+
+  .main-content {
+    margin: 0 !important;
+    padding: 0 !important;
+    max-width: 100% !important;
+    width: 100% !important;
+  }
+
+  .app-page {
+    max-width: 100% !important;
+    padding: 0 !important;
+    gap: 0.5rem !important;
+  }
+
+  /* Filters, toolbars, interactive controls */
+  .app-toolbar,
+  .app-filter-grid,
+  .journal-filters,
+  .app-page-header__actions,
+  .balance-focus-legend {
+    display: none !important;
+  }
+
+  /* Action buttons (new entry, export CSV, filter reset, etc.) */
+  .p-button,
+  .p-button-outlined,
+  .p-paginator,
+  .p-datatable-header {
+    display: none !important;
+  }
+
+  /* Stat cards — hide in print (summary is in tables) */
+  .app-stat-grid {
+    display: none !important;
+  }
+
+  /* ------------------------------------------------------------------ */
+  /* 2. Print-friendly header                                           */
+  /* ------------------------------------------------------------------ */
+
+  .app-page-header {
+    text-align: center;
+    margin-bottom: 0.5rem;
+    padding: 0;
+    border-bottom: 2px solid #000;
+  }
+
+  .app-page-header__eyebrow {
+    font-size: 10pt;
+    color: #666;
+  }
+
+  .app-page-header__title {
+    font-size: 16pt;
+    font-weight: 700;
+    color: #000;
+    margin: 0.25rem 0;
+  }
+
+  .app-page-header__subtitle {
+    font-size: 10pt;
+    color: #666;
+  }
+
+  /* ------------------------------------------------------------------ */
+  /* 3. Panel styling                                                   */
+  /* ------------------------------------------------------------------ */
+
+  .app-panel {
+    box-shadow: none !important;
+    border: none !important;
+    border-radius: 0 !important;
+    background: #fff !important;
+    padding: 0 !important;
+    margin: 0 !important;
+    break-inside: avoid;
+  }
+
+  .app-panel__header {
+    padding: 0.25rem 0 !important;
+    border-bottom: 1px solid #ccc;
+  }
+
+  .app-panel__body {
+    padding: 0 !important;
+  }
+
+  /* ------------------------------------------------------------------ */
+  /* 4. DataTable print optimization                                    */
+  /* ------------------------------------------------------------------ */
+
+  .app-data-table,
+  .p-datatable {
+    font-size: 9pt !important;
+    border-collapse: collapse !important;
+  }
+
+  .p-datatable-table {
+    width: 100% !important;
+  }
+
+  .p-datatable-thead > tr > th {
+    background: #f5f5f5 !important;
+    color: #000 !important;
+    border-bottom: 2px solid #333 !important;
+    padding: 4px 6px !important;
+    font-weight: 700 !important;
+    font-size: 8pt !important;
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+
+  .p-datatable-tbody > tr > td {
+    border-bottom: 1px solid #ddd !important;
+    padding: 3px 6px !important;
+    color: #000 !important;
+    background: #fff !important;
+  }
+
+  .p-datatable-tbody > tr:nth-child(even) > td {
+    background: #fafafa !important;
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+
+  /* Money columns — right-align */
+  .app-money {
+    text-align: right !important;
+  }
+
+  /* Remove row hover effect */
+  .p-datatable-tbody > tr:hover > td {
+    background: inherit !important;
+  }
+
+  /* Remove filter icons from column headers */
+  .p-datatable-column-filter,
+  .p-datatable-sortable-column .p-datatable-sort-icon,
+  .p-datatable-filter-overlay,
+  .p-column-filter-menu-button {
+    display: none !important;
+  }
+
+  /* ------------------------------------------------------------------ */
+  /* 5. Bilan / Résultat specific                                       */
+  /* ------------------------------------------------------------------ */
+
+  .bilan-grid {
+    display: grid !important;
+    grid-template-columns: 1fr 1fr !important;
+    gap: 1rem !important;
+  }
+
+  .bilan-loading {
+    display: none !important;
+  }
+
+  .resultat-grid {
+    display: grid !important;
+    grid-template-columns: 1fr 1fr !important;
+    gap: 1rem !important;
+  }
+
+  .resultat-bottom {
+    text-align: center !important;
+    font-size: 14pt !important;
+    font-weight: 700;
+    margin-top: 1rem;
+    border-top: 2px solid #000;
+    padding-top: 0.5rem;
+  }
+
+  .resultat-total {
+    text-align: right;
+    font-weight: 600;
+    border-top: 1px solid #999;
+    padding-top: 0.25rem;
+    margin-top: 0.25rem;
+  }
+
+  /* ------------------------------------------------------------------ */
+  /* 6. Page settings                                                   */
+  /* ------------------------------------------------------------------ */
+
+  @page {
+    size: A4 landscape;
+    margin: 1.5cm;
+  }
+
+  /* Force black text everywhere */
+  * {
+    color: #000 !important;
+  }
+
+  /* Restore colored amounts */
+  .resultat-excedent {
+    color: #16a34a !important;
+  }
+
+  .resultat-deficit {
+    color: #dc2626 !important;
+  }
+
+  /* Allow tables to break across pages */
+  .p-datatable-tbody > tr {
+    break-inside: avoid;
+  }
+}

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,4 +1,5 @@
 import './assets/main.css'
+import './assets/print.css'
 
 import { createApp } from 'vue'
 import { createPinia } from 'pinia'


### PR DESCRIPTION
New print.css with @media print rules — hides navigation/filters/buttons, print-friendly tables (9pt, borders, alternating rows), A4 landscape, bilan/résultat 2-column grid.

## Summary by Sourcery

Add a dedicated print stylesheet for accounting views and integrate it into the global frontend styles.

New Features:
- Introduce print.css with @media print rules to optimize printing of journal, balance, general ledger, balance sheet, and income statement views for A4 landscape output.

Enhancements:
- Hide non-essential UI elements and adjust layout, headers, panels, and data tables to produce cleaner, monochrome-friendly printed reports, including two-column grids for balance sheet and income statement pages.

Documentation:
- Document the new print stylesheet and its scope in the changelog.