### PR TITLE
docs(user): add bilingual migration/upgrade guide (BL-083)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Ce projet respecte le [Versionnage sémantique](https://semver.org/lang/fr/).
 
 ### Ajouté
 
+- `doc/user/migration.md` + `doc/user/migration.en.md` : guide de migration / montée de version bilingue FR + EN pour les déploiements Docker sur Synology NAS — couvre la préparation, la mise à jour, la vérification, le rollback et les bonnes pratiques (BL-083)
+
 **Qualité / Sécurité (audit 2026-04-22)**
 - `backend/routers/auth.py` : le refresh token est désormais transmis via un cookie `HttpOnly`, `Secure`, `SameSite=Strict` au lieu du corps JSON — `/auth/login` et `/auth/refresh` posent le cookie, nouvel endpoint `POST /auth/logout` (204) l'efface (BL-046)
 - Frontend : `refreshApi()` et `logoutApi()` utilisent le cookie automatiquement (`withCredentials: true`), le store auth ne stocke plus le refresh token en `localStorage` (BL-046)

--- a/doc/user/README.md
+++ b/doc/user/README.md
@@ -8,19 +8,22 @@ Commencez par le guide qui correspond le mieux à votre besoin :
 
 - vous installez ou découvrez l'application : [installation.md](./installation.md) ;
 - vous cherchez un guide général du quotidien : [manuel-utilisateur.md](./manuel-utilisateur.md) ;
-- vous travaillez sur une reprise historique ou un retest d'import : [import-excel-et-reinitialisation.md](./import-excel-et-reinitialisation.md).
+- vous travaillez sur une reprise historique ou un retest d'import : [import-excel-et-reinitialisation.md](./import-excel-et-reinitialisation.md) ;
+- vous mettez à jour l'application vers une nouvelle version : [migration.md](./migration.md).
 
 Guides disponibles :
 
 - Installation et premiers pas : [installation.md](./installation.md)
 - Manuel utilisateur : [manuel-utilisateur.md](./manuel-utilisateur.md)
 - Guide import Excel et réinitialisation : [import-excel-et-reinitialisation.md](./import-excel-et-reinitialisation.md)
+- Guide de migration / montée de version : [migration.md](./migration.md)
 
 Guides disponibles en anglais :
 
 - Installation and getting started: [installation.md](./installation.md)
 - User manual: [manuel-utilisateur.en.md](./manuel-utilisateur.en.md)
 - Excel import and reset guide: [import-excel-et-reinitialisation.en.md](./import-excel-et-reinitialisation.en.md)
+- Migration / upgrade guide: [migration.en.md](./migration.en.md)
 
 Le manuel utilisateur dispose maintenant d'une trame pas à pas consolidée pour les parcours du quotidien. Les captures d'écran annotées restent un lot spécifique qui sera ajouté quand l'interface sera suffisamment stabilisée.
 
@@ -32,18 +35,21 @@ Start with the guide that best matches your need:
 
 - you are installing or discovering the application: [installation.md](./installation.md);
 - you want the main day-to-day guide: [manuel-utilisateur.en.md](./manuel-utilisateur.en.md);
-- you are replaying historical data or testing Excel imports: [import-excel-et-reinitialisation.en.md](./import-excel-et-reinitialisation.en.md).
+- you are replaying historical data or testing Excel imports: [import-excel-et-reinitialisation.en.md](./import-excel-et-reinitialisation.en.md);
+- you are upgrading the application to a new version: [migration.en.md](./migration.en.md).
 
 Available guides:
 
 - Installation and getting started: [installation.md](./installation.md)
 - User manual: [manuel-utilisateur.en.md](./manuel-utilisateur.en.md)
 - Excel import and reset guide: [import-excel-et-reinitialisation.en.md](./import-excel-et-reinitialisation.en.md)
+- Migration / upgrade guide: [migration.en.md](./migration.en.md)
 
 Available in French as well:
 
 - Installation et premiers pas: [installation.md](./installation.md)
 - Manuel utilisateur: [manuel-utilisateur.md](./manuel-utilisateur.md)
 - Guide import Excel et réinitialisation: [import-excel-et-reinitialisation.md](./import-excel-et-reinitialisation.md)
+- Guide de migration / montée de version: [migration.md](./migration.md)
 
 The user manual now has a consolidated step-by-step structure for the main day-to-day workflows. Annotated screenshots remain a separate work item and will be added once the interface is stable enough.

--- a/doc/user/migration.en.md
+++ b/doc/user/migration.en.md
@@ -10,9 +10,9 @@ This guide explains how to upgrade Solde to a new version on a Docker deployment
 
 ## Before you start
 
-- **Back up your database** before any upgrade.
-  - From the UI: **Settings → Back up database** (downloads a `.db` file).
-  - From the NAS: copy the entire `data/` directory to a safe location.
+- **Back up your data** before any upgrade.
+  - Copy the entire `data/` directory to a safe location.
+  - Ideally, stop the container first to avoid copying files mid-write.
 - **Note the current version** shown in the header or via `GET /api/health`.
 - **Read the release notes** in `doc/releases/` to check for breaking changes.
 
@@ -22,9 +22,12 @@ This guide explains how to upgrade Solde to a new version on a Docker deployment
 
 ### 1. Download the new version
 
+Replace `v<x.y.z>` with the target version to deploy (e.g. `v1.4.2`).
+
 ```bash
 cd /path/to/solde
-git pull origin main
+git fetch --tags
+git checkout v<x.y.z>
 ```
 
 Or, on Synology without git:
@@ -70,33 +73,36 @@ Database migrations (Alembic) run automatically on startup. No manual action nee
 ### Restoring a backup
 
 1. Stop the application: `docker compose down`
-2. Replace `data/solde.db` with your backup:
+2. Remove the current SQLite files to avoid an inconsistent restore (SQLite WAL):
+   ```bash
+   rm -f data/solde.db data/solde.db-wal data/solde.db-shm
+   ```
+3. Restore your backup as the new `data/solde.db`:
    ```bash
    cp /path/to/backup/solde_backup_XXXXXXXX_XXXXXX.db data/solde.db
    ```
-3. To revert to the previous application version:
+4. To revert to the previous application version and restart:
    ```bash
    git checkout v<previous-version>
    docker compose up -d --build
    ```
-4. Restart: `docker compose up -d`
 
 ### Restoring from Synology without SSH
 
 1. In **File Station**, navigate to the Docker project folder (`docker/solde/data/`).
-2. Delete (or rename) `solde.db`.
-3. Copy your backup file and rename it to `solde.db`.
+2. Delete (or rename) `solde.db`, `solde.db-wal` and `solde.db-shm`.
+3. Copy your backup file into the folder and rename it to `solde.db`.
 4. Restart the container in **Container Manager**.
 
 ---
 
 ## Best practices
 
-- **Always back up** before each upgrade — from the UI or by copying `data/`.
+- **Always back up** before each upgrade by copying the `data/` directory.
 - **Read the release notes** (`doc/releases/vX.Y.Z.md`) to learn about changes.
-- **Test quickly** after upgrading: login, dashboard, invoice list.
+- **Test quickly** after upgrading: log in, dashboard, invoice list.
 - **Never modify** files in `data/` directly — use the UI or the API.
-- **Keep multiple backups** (the system automatically keeps the last 5 in `data/backups/`).
+- **Keep multiple manual backups** in a safe location (for example outside the server or NAS).
 
 ---
 

--- a/doc/user/migration.en.md
+++ b/doc/user/migration.en.md
@@ -1,0 +1,113 @@
+# Migration / Upgrade guide
+
+## Purpose
+
+This guide explains how to upgrade Solde to a new version on a Docker deployment (Synology NAS or standard server). It covers preparation, the upgrade itself, verification, and rollback if something goes wrong.
+
+**Intended audience**: association administrator, no deep technical expertise required.
+
+---
+
+## Before you start
+
+- **Back up your database** before any upgrade.
+  - From the UI: **Settings → Back up database** (downloads a `.db` file).
+  - From the NAS: copy the entire `data/` directory to a safe location.
+- **Note the current version** shown in the header or via `GET /api/health`.
+- **Read the release notes** in `doc/releases/` to check for breaking changes.
+
+---
+
+## Upgrade procedure
+
+### 1. Download the new version
+
+```bash
+cd /path/to/solde
+git pull origin main
+```
+
+Or, on Synology without git:
+
+1. Download the ZIP archive from GitHub (_Releases_ tab).
+2. Extract it into the application directory, overwriting existing files (except `data/` and `.env`).
+
+### 2. Stop the application
+
+```bash
+docker compose down
+```
+
+On Synology (Container Manager): select the `solde` container → **Stop**.
+
+### 3. Rebuild and restart
+
+```bash
+docker compose up -d --build
+```
+
+On Synology (Container Manager): **Project** → **Rebuild** → **Start**.
+
+Database migrations (Alembic) run automatically on startup. No manual action needed.
+
+### 4. Verify
+
+- Access `http://<your-nas>:8000` — the application should load normally.
+- Check the health endpoint: `http://<your-nas>:8000/api/health` should return `{"status": "ok"}`.
+- Log in and verify your data is intact (contacts, invoices, current fiscal year).
+
+---
+
+## Troubleshooting
+
+### Application does not start
+
+1. Check the logs: `docker compose logs solde --tail=50`
+2. If a migration error appears:
+   - **Do not delete** the `data/` directory.
+   - Restore the backup (see below) and report the error.
+
+### Restoring a backup
+
+1. Stop the application: `docker compose down`
+2. Replace `data/solde.db` with your backup:
+   ```bash
+   cp /path/to/backup/solde_backup_XXXXXXXX_XXXXXX.db data/solde.db
+   ```
+3. To revert to the previous application version:
+   ```bash
+   git checkout v<previous-version>
+   docker compose up -d --build
+   ```
+4. Restart: `docker compose up -d`
+
+### Restoring from Synology without SSH
+
+1. In **File Station**, navigate to the Docker project folder (`docker/solde/data/`).
+2. Delete (or rename) `solde.db`.
+3. Copy your backup file and rename it to `solde.db`.
+4. Restart the container in **Container Manager**.
+
+---
+
+## Best practices
+
+- **Always back up** before each upgrade — from the UI or by copying `data/`.
+- **Read the release notes** (`doc/releases/vX.Y.Z.md`) to learn about changes.
+- **Test quickly** after upgrading: login, dashboard, invoice list.
+- **Never modify** files in `data/` directly — use the UI or the API.
+- **Keep multiple backups** (the system automatically keeps the last 5 in `data/backups/`).
+
+---
+
+## Semantic versioning
+
+Solde follows [semantic versioning](https://semver.org/):
+
+| Type | Format | Meaning |
+|---|---|---|
+| **Patch** | `0.1.1` → `0.1.2` | Bug fixes, no functional changes |
+| **Minor** | `0.1.x` → `0.2.0` | New features, backward-compatible |
+| **Major** | `0.x.x` → `1.0.0` | Breaking changes (requires special attention) |
+
+For minor and patch versions, the upgrade is normally transparent. For a major version, read the migration notes in the release notes carefully.

--- a/doc/user/migration.md
+++ b/doc/user/migration.md
@@ -1,0 +1,113 @@
+# Guide de migration / Montée de version
+
+## Objectif
+
+Ce guide explique comment mettre à jour Solde vers une nouvelle version sur un déploiement Docker (Synology NAS ou serveur classique). Il couvre la préparation, la mise à jour, la vérification et le rollback en cas de problème.
+
+**Public visé** : administrateur de l'association, sans expertise technique poussée.
+
+---
+
+## Avant de commencer
+
+- **Sauvegardez votre base de données** avant toute mise à jour.
+  - Depuis l'interface : **Paramètres → Sauvegarder la base** (télécharge un fichier `.db`).
+  - Depuis le NAS : copiez le dossier `data/` entier vers un emplacement sûr.
+- **Notez la version actuelle** affichée dans l'en-tête ou via `GET /api/health`.
+- **Consultez les notes de version** dans `doc/releases/` pour identifier d'éventuels changements importants (breaking changes).
+
+---
+
+## Procédure de mise à jour
+
+### 1. Télécharger la nouvelle version
+
+```bash
+cd /chemin/vers/solde
+git pull origin main
+```
+
+Ou, sur Synology sans git :
+
+1. Téléchargez l'archive ZIP depuis GitHub (onglet _Releases_).
+2. Décompressez-la dans le dossier de l'application en écrasant les fichiers existants (sauf `data/` et `.env`).
+
+### 2. Arrêter l'application
+
+```bash
+docker compose down
+```
+
+Sur Synology (Container Manager) : sélectionnez le conteneur `solde` → **Arrêter**.
+
+### 3. Reconstruire et redémarrer
+
+```bash
+docker compose up -d --build
+```
+
+Sur Synology (Container Manager) : **Projet** → **Reconstruire** → **Démarrer**.
+
+Les migrations de base de données (Alembic) s'exécutent automatiquement au démarrage. Vous n'avez rien à faire manuellement.
+
+### 4. Vérifier
+
+- Accédez à `http://<votre-nas>:8000` — l'application doit se charger normalement.
+- Vérifiez le health check : `http://<votre-nas>:8000/api/health` doit renvoyer `{"status": "ok"}`.
+- Connectez-vous et vérifiez que vos données sont intactes (contacts, factures, exercice en cours).
+
+---
+
+## En cas de problème
+
+### L'application ne démarre pas
+
+1. Consultez les logs : `docker compose logs solde --tail=50`
+2. Si une erreur de migration apparaît :
+   - **Ne supprimez pas** le dossier `data/`.
+   - Restaurez le backup (voir ci-dessous) et signalez l'erreur.
+
+### Restaurer un backup
+
+1. Arrêtez l'application : `docker compose down`
+2. Remplacez le fichier `data/solde.db` par votre backup :
+   ```bash
+   cp /chemin/vers/backup/solde_backup_XXXXXXXX_XXXXXX.db data/solde.db
+   ```
+3. Pour revenir à la version précédente de l'application :
+   ```bash
+   git checkout v<version-précédente>
+   docker compose up -d --build
+   ```
+4. Redémarrez : `docker compose up -d`
+
+### Restaurer depuis Synology sans SSH
+
+1. Dans **File Station**, naviguez vers le dossier Docker du projet (`docker/solde/data/`).
+2. Supprimez (ou renommez) `solde.db`.
+3. Copiez votre fichier de backup et renommez-le en `solde.db`.
+4. Redémarrez le conteneur dans **Container Manager**.
+
+---
+
+## Bonnes pratiques
+
+- **Sauvegardez systématiquement** avant chaque mise à jour — depuis l'interface ou en copiant `data/`.
+- **Lisez les notes de version** (`doc/releases/vX.Y.Z.md`) pour connaître les changements.
+- **Testez rapidement** après la mise à jour : connexion, tableau de bord, liste des factures.
+- **Ne modifiez jamais** les fichiers dans `data/` directement — utilisez l'interface ou l'API.
+- **Conservez plusieurs backups** (le système en garde 5 automatiquement dans `data/backups/`).
+
+---
+
+## Versionnage sémantique
+
+Solde suit le [versionnage sémantique](https://semver.org/lang/fr/) :
+
+| Type | Format | Signification |
+|---|---|---|
+| **Patch** | `0.1.1` → `0.1.2` | Corrections de bugs, aucun changement fonctionnel |
+| **Mineur** | `0.1.x` → `0.2.0` | Nouvelles fonctionnalités, rétro-compatible |
+| **Majeur** | `0.x.x` → `1.0.0` | Changements incompatibles (nécessite attention particulière) |
+
+Pour les versions mineures et patch, la mise à jour est normalement transparente. Pour une version majeure, lisez attentivement les notes de migration dans les release notes.

--- a/doc/user/migration.md
+++ b/doc/user/migration.md
@@ -10,9 +10,9 @@ Ce guide explique comment mettre à jour Solde vers une nouvelle version sur un 
 
 ## Avant de commencer
 
-- **Sauvegardez votre base de données** avant toute mise à jour.
-  - Depuis l'interface : **Paramètres → Sauvegarder la base** (télécharge un fichier `.db`).
-  - Depuis le NAS : copiez le dossier `data/` entier vers un emplacement sûr.
+- **Sauvegardez vos données** avant toute mise à jour.
+  - Copiez le dossier `data/` entier vers un emplacement sûr.
+  - Idéalement, arrêtez d’abord le conteneur pour éviter de copier des fichiers en cours d’écriture.
 - **Notez la version actuelle** affichée dans l'en-tête ou via `GET /api/health`.
 - **Consultez les notes de version** dans `doc/releases/` pour identifier d'éventuels changements importants (breaking changes).
 
@@ -22,9 +22,12 @@ Ce guide explique comment mettre à jour Solde vers une nouvelle version sur un 
 
 ### 1. Télécharger la nouvelle version
 
+Remplacez `v<x.y.z>` par la version cible à déployer (par exemple `v1.4.2`).
+
 ```bash
 cd /chemin/vers/solde
-git pull origin main
+git fetch --tags
+git checkout v<x.y.z>
 ```
 
 Ou, sur Synology sans git :
@@ -70,33 +73,36 @@ Les migrations de base de données (Alembic) s'exécutent automatiquement au dé
 ### Restaurer un backup
 
 1. Arrêtez l'application : `docker compose down`
-2. Remplacez le fichier `data/solde.db` par votre backup :
+2. Supprimez les fichiers SQLite actuels pour éviter une restauration incohérente (SQLite WAL) :
+   ```bash
+   rm -f data/solde.db data/solde.db-wal data/solde.db-shm
+   ```
+3. Restaurez votre backup comme nouveau fichier `data/solde.db` :
    ```bash
    cp /chemin/vers/backup/solde_backup_XXXXXXXX_XXXXXX.db data/solde.db
    ```
-3. Pour revenir à la version précédente de l'application :
+4. Pour revenir à la version précédente de l'application et la redémarrer :
    ```bash
    git checkout v<version-précédente>
    docker compose up -d --build
    ```
-4. Redémarrez : `docker compose up -d`
 
 ### Restaurer depuis Synology sans SSH
 
 1. Dans **File Station**, naviguez vers le dossier Docker du projet (`docker/solde/data/`).
-2. Supprimez (ou renommez) `solde.db`.
-3. Copiez votre fichier de backup et renommez-le en `solde.db`.
+2. Supprimez (ou renommez) `solde.db`, `solde.db-wal` et `solde.db-shm`.
+3. Copiez votre fichier de backup dans ce dossier et renommez-le en `solde.db`.
 4. Redémarrez le conteneur dans **Container Manager**.
 
 ---
 
 ## Bonnes pratiques
 
-- **Sauvegardez systématiquement** avant chaque mise à jour — depuis l'interface ou en copiant `data/`.
+- **Sauvegardez systématiquement** avant chaque mise à jour en copiant le dossier `data/`.
 - **Lisez les notes de version** (`doc/releases/vX.Y.Z.md`) pour connaître les changements.
 - **Testez rapidement** après la mise à jour : connexion, tableau de bord, liste des factures.
 - **Ne modifiez jamais** les fichiers dans `data/` directement — utilisez l'interface ou l'API.
-- **Conservez plusieurs backups** (le système en garde 5 automatiquement dans `data/backups/`).
+- **Conservez plusieurs backups manuels** dans un emplacement sûr (par exemple hors du serveur ou du NAS).
 
 ---
 
@@ -107,7 +113,7 @@ Solde suit le [versionnage sémantique](https://semver.org/lang/fr/) :
 | Type | Format | Signification |
 |---|---|---|
 | **Patch** | `0.1.1` → `0.1.2` | Corrections de bugs, aucun changement fonctionnel |
-| **Mineur** | `0.1.x` → `0.2.0` | Nouvelles fonctionnalités, rétro-compatible |
+| **Mineur** | `0.1.x` → `0.2.0` | Nouvelles fonctionnalités, rétrocompatible |
 | **Majeur** | `0.x.x` → `1.0.0` | Changements incompatibles (nécessite attention particulière) |
 
 Pour les versions mineures et patch, la mise à jour est normalement transparente. Pour une version majeure, lisez attentivement les notes de migration dans les release notes.


### PR DESCRIPTION
New [migration.md](vscode-file://vscode-app/c:/Users/dpierron001/AppData/Local/Programs/Microsoft%20VS%20Code/10c8e557c8/resources/app/out/vs/code/electron-browser/workbench/workbench.html) (FR) + migration.en.md (EN) — backup procedure, update steps (git pull + docker compose), verification, rollback, Synology-specific instructions.

## Summary by Sourcery

Add a bilingual (French and English) user migration/upgrade guide for Docker deployments, and link it from the user documentation index and changelog.

Documentation:
- Add detailed French and English migration/upgrade guides covering backup, upgrade steps, verification, rollback, and best practices for Docker/Synology deployments.
- Update the user documentation README to reference the new migration guides in both French and English sections.

Chores:
- Record the addition of the bilingual migration/upgrade guides in the changelog under the Added section.