### PR TITLE
feat(ui): lot D — Skeleton loaders & Account color combos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ Ce projet respecte le [Versionnage sémantique](https://semver.org/lang/fr/).
 
 ### Ajouté
 
+- `frontend/src/components/ui/AppTableSkeleton.vue` : composant de skeleton réutilisable (grille de cellules PrimeVue `Skeleton`, props `rows`/`cols` avec valeurs par défaut 8×4) remplaçant les `ProgressSpinner` dans toutes les vues de liste au premier chargement (BL-071)
+- `frontend/src/components/ui/AppAccountSelect.vue` : composant combo comptes comptables avec point coloré pour les 5 comptes de suivi (créances membres, fournisseurs, caisse, courant, chèques à déposer) via `AppAccountSelect` wrappant PrimeVue `Select` avec slots `#option` et `#value` (BL-043)
+- `frontend/src/assets/main.css` : classes globales `.app-table-skeleton`, `.app-table-skeleton__row`, `.account-select-option`, `.account-select-dot` et variantes couleur par compte de suivi
+
+### Modifié
+
+- `frontend/src/views/DashboardView.vue` : remplacement du `ProgressSpinner` central par 7 `<Skeleton height="132px">` dans la grille KPI au chargement — cohérence visuelle avec le layout final (BL-071)
+- `frontend/src/views/AccountingBilanView.vue` : remplacement du `ProgressSpinner` par `AppTableSkeleton :rows="10" :cols="3"` (BL-071)
+- `frontend/src/views/ContactDetailView.vue` : remplacement du `ProgressSpinner` par une grille de 3 `Skeleton` de stat + `AppTableSkeleton` (BL-071)
+- `frontend/src/views/ClientInvoicesView.vue` : skeleton sur la liste principale (`loading && !invoices.length`) et dans le dialogue historique (BL-071)
+- `frontend/src/views/ContactsView.vue` + `PaymentsView.vue` : skeleton sur liste principale au premier chargement (`loading && !*.length`) (BL-071)
+- `frontend/src/views/AccountingJournalView.vue` : skeleton liste + filtre compte remplacé par `AppAccountSelect` avec rechargement automatique à la sélection (BL-071, BL-043)
+- `frontend/src/views/AccountingLedgerView.vue` : select compte remplacé par `AppAccountSelect` avec points colorés (BL-043)
+
 - `frontend/src/composables/useKeyboardShortcuts.ts` : composable Vue 3 gérant les raccourcis clavier Ctrl/Cmd+N (nouveau), Ctrl/Cmd+S (sauvegarder) et Escape (fermer) avec gestion du focus (Ctrl+N ignoré dans les champs de saisie) et nettoyage automatique au démontage (BL-073)
 - `frontend/src/components/ui/AppStatCard.vue` : prop optionnelle `to` (route Vue Router) rendant la carte KPI cliquable via `<RouterLink>` avec animation hover et focus-visible accessible (BL-075)
 - `frontend/src/views/DashboardView.vue` : tous les KPI (solde banque, caisse, factures impayées/en retard, chèques non déposés, exercice courant, résultat) sont désormais cliquables vers les vues filtrées correspondantes (BL-075)

--- a/doc/backlog.md
+++ b/doc/backlog.md
@@ -157,8 +157,8 @@ Tableau de suivi des 19 tickets issus de l'audit autonome du 23/04/2026 avec est
 | BL-074 | UX / Frontend | Réseau | P2 | B | ~45 min | Bandeau « Connexion perdue » | ✅ Fait |
 | BL-075 | UX / Fonctionnel | Dashboard | P2 | C | ~2h | KPI cliquables (absorbe BL-036, BL-041) | ✅ Fait |
 | BL-073 | UX / Frontend | Productivité | P2 | C | ~1h | Raccourcis clavier (Ctrl+N/S, Esc) | ✅ Fait |
-| BL-071 | UX / Frontend | Chargement | P2 | D | ~1h30 | Skeleton loaders PrimeVue | ⬜ Prêt |
-| BL-043 | UX / Fonctionnel | Comptabilité / Filtres | P2 | D | ~1h30 | Combos comptes comptables couleur | ⬜ Prêt |
+| BL-071 | UX / Frontend | Chargement | P2 | D | ~1h30 | Skeleton loaders PrimeVue | ✅ Fait |
+| BL-043 | UX / Fonctionnel | Comptabilité / Filtres | P2 | D | ~1h30 | Combos comptes comptables couleur | ✅ Fait |
 | BL-035 | UX / Fonctionnel | Contacts | P2 | E | ~2h | Onglets clients / fournisseurs | ⬜ Prêt |
 | BL-040 | Import / Fonctionnel | Contacts client | P2 | E | ~2h | Import one-shot emails contacts | ⬜ Prêt |
 | BL-079 | Qualité / Tests | Frontend / Composables | P2 | F | ~1h30 | Tests unitaires composables | ⬜ Prêt |
@@ -175,7 +175,7 @@ Tableau de suivi des 19 tickets issus de l'audit autonome du 23/04/2026 avec est
 | **A** | Backend rapide | BL-085 | ~30 min | — |
 | **B** | UX quick wins | BL-070, BL-072, BL-074, BL-084, BL-042 | ~4h | ✅ Fait 2026-04-23 |
 | **C** | Dashboard interactif | BL-075, BL-073 | ~3h | ✅ Fait 2026-04-23 |
-| **D** | Polish UI | BL-071, BL-043 | ~3h | — |
+| **D** | Polish UI | BL-071, BL-043 | ~3h | ✅ Terminé |
 | **E** | Contacts & import | BL-035, BL-040 | ~4h | — |
 | **F** | Tests | BL-079, BL-080, BL-081 | ~5h | Setup Playwright pour BL-080 |
 | **G** | Refactoring frontend | BL-077 | ~5h | — |

--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -492,6 +492,40 @@ html.dark-mode .app-chip {
   gap: var(--app-space-1);
 }
 
+/* --- AppTableSkeleton --- */
+.app-table-skeleton {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.5rem 0;
+}
+
+.app-table-skeleton__row {
+  display: grid;
+  gap: 0.5rem;
+}
+
+/* --- AppAccountSelect --- */
+.account-select-option {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.account-select-dot {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  flex-shrink: 0;
+  background: var(--account-select-dot-bg, var(--p-text-muted-color));
+}
+
+.account-select-dot--member_receivables { --account-select-dot-bg: rgba(251, 191, 36, 0.9); }
+.account-select-dot--supplier_payables  { --account-select-dot-bg: rgba(56, 189, 248, 0.9); }
+.account-select-dot--cash               { --account-select-dot-bg: rgba(74, 222, 128, 0.9); }
+.account-select-dot--current_account    { --account-select-dot-bg: rgba(248, 113, 113, 0.9); }
+.account-select-dot--cheques_to_deposit { --account-select-dot-bg: rgba(129, 140, 248, 0.9); }
+
 .app-dialog-section__title {
   margin: 0;
   font-size: 0.98rem;

--- a/frontend/src/components/ui/AppAccountSelect.vue
+++ b/frontend/src/components/ui/AppAccountSelect.vue
@@ -1,0 +1,80 @@
+<template>
+  <Select
+    v-bind="$attrs"
+    :model-value="modelValue"
+    :options="accountOptions"
+    option-label="displayLabel"
+    option-value="number"
+    :placeholder="placeholder"
+    filter
+    show-clear
+    @update:model-value="emit('update:modelValue', $event ?? null)"
+  >
+    <template #option="{ option }">
+      <div class="account-select-option">
+        <span
+          v-if="option.focusKey"
+          class="account-select-dot"
+          :class="`account-select-dot--${option.focusKey}`"
+        />
+        <span>{{ option.displayLabel }}</span>
+      </div>
+    </template>
+    <template #value="{ value }">
+      <div v-if="value !== null && value !== undefined && value !== ''" class="account-select-option">
+        <span
+          v-if="selectedFocusKey"
+          class="account-select-dot"
+          :class="`account-select-dot--${selectedFocusKey}`"
+        />
+        <span>{{ selectedDisplayLabel ?? value }}</span>
+      </div>
+    </template>
+  </Select>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import Select from 'primevue/select'
+import type { AccountingAccount } from '@/api/accounting'
+import {
+  formatFocusedAccountLabel,
+  getFocusAccountKey,
+  type FocusAccountKey,
+} from '@/utils/focusAccounts'
+
+const props = withDefaults(
+  defineProps<{
+    modelValue: string | null
+    accounts: AccountingAccount[]
+    placeholder?: string
+  }>(),
+  {
+    placeholder: undefined,
+  },
+)
+
+const emit = defineEmits<{ 'update:modelValue': [value: string | null] }>()
+
+const { t } = useI18n()
+
+const accountOptions = computed(() =>
+  props.accounts.map((a) => ({
+    number: a.number,
+    displayLabel: formatFocusedAccountLabel(a.number, a.label, t),
+    focusKey: getFocusAccountKey(a.number),
+  })),
+)
+
+const selectedFocusKey = computed<FocusAccountKey | null>(() => {
+  if (!props.modelValue) return null
+  return getFocusAccountKey(props.modelValue)
+})
+
+const selectedDisplayLabel = computed<string | null>(() => {
+  if (!props.modelValue) return null
+  const opt = accountOptions.value.find((o) => o.number === props.modelValue)
+  return opt?.displayLabel ?? null
+})
+</script>

--- a/frontend/src/components/ui/AppTableSkeleton.vue
+++ b/frontend/src/components/ui/AppTableSkeleton.vue
@@ -1,0 +1,21 @@
+<template>
+  <div class="app-table-skeleton" role="status" :aria-label="t('common.loading')">
+    <div
+      v-for="n in rows"
+      :key="n"
+      class="app-table-skeleton__row"
+      :style="{ gridTemplateColumns: `repeat(${cols}, 1fr)` }"
+    >
+      <Skeleton v-for="c in cols" :key="c" height="2.25rem" />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+import Skeleton from 'primevue/skeleton'
+
+withDefaults(defineProps<{ rows?: number; cols?: number }>(), { rows: 8, cols: 4 })
+
+const { t } = useI18n()
+</script>

--- a/frontend/src/tests/views/AccountingJournalView.spec.ts
+++ b/frontend/src/tests/views/AccountingJournalView.spec.ts
@@ -21,6 +21,7 @@ vi.mock('../../api/accounting', () => ({
   createManualEntryApi: vi.fn(),
   updateManualEntryApi: vi.fn(),
   getExportCsvUrl: vi.fn(() => '/journal.csv'),
+  listAccountsApi: vi.fn().mockResolvedValue([]),
 }))
 
 const routerPush = vi.fn()
@@ -179,6 +180,8 @@ function mountView() {
         InputText: InputTextStub,
         Select: SelectStub,
         Tag: TagStub,
+        AppAccountSelect: { template: '<div />' },
+        AppTableSkeleton: { template: '<div />' },
       },
     },
   })

--- a/frontend/src/tests/views/PaymentsView.spec.ts
+++ b/frontend/src/tests/views/PaymentsView.spec.ts
@@ -250,6 +250,7 @@ const ColumnStub = defineComponent({
 
 async function flushView() {
   await Promise.resolve()
+  await Promise.resolve()
   await nextTick()
 }
 
@@ -270,6 +271,7 @@ function mountView() {
         Select: SelectStub,
         Tag: TagStub,
         ToggleButton: ToggleButtonStub,
+        AppTableSkeleton: { template: '<div />' },
       },
     },
   })

--- a/frontend/src/views/AccountingBilanView.vue
+++ b/frontend/src/views/AccountingBilanView.vue
@@ -23,9 +23,7 @@
       </template>
     </AppPageHeader>
 
-    <div v-if="loading" class="bilan-loading">
-      <ProgressSpinner />
-    </div>
+    <AppTableSkeleton v-if="loading" :rows="10" :cols="3" />
 
     <div v-else-if="bilan" class="bilan-grid">
       <!-- Actif -->
@@ -110,8 +108,8 @@ import { useI18n } from 'vue-i18n'
 import Button from 'primevue/button'
 import Column from 'primevue/column'
 import DataTable from 'primevue/datatable'
-import ProgressSpinner from 'primevue/progressspinner'
 import Select from 'primevue/select'
+import AppTableSkeleton from '../components/ui/AppTableSkeleton.vue'
 import AppPage from '../components/ui/AppPage.vue'
 import AppPageHeader from '../components/ui/AppPageHeader.vue'
 import AppPanel from '../components/ui/AppPanel.vue'
@@ -162,12 +160,6 @@ onMounted(async () => {
 </script>
 
 <style scoped>
-.bilan-loading {
-  display: flex;
-  justify-content: center;
-  padding: 4rem 0;
-}
-
 .bilan-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/frontend/src/views/AccountingJournalView.vue
+++ b/frontend/src/views/AccountingJournalView.vue
@@ -80,10 +80,11 @@
           </div>
           <div class="app-field">
             <label class="app-field__label">{{ t('accounting.journal.filter_account') }}</label>
-            <InputText
-              v-model="filters.account_number"
+            <AppAccountSelect
+              :model-value="filters.account_number || null"
+              :accounts="journalAccounts"
               :placeholder="t('accounting.journal.account')"
-              @keydown.enter="load"
+              @update:model-value="onAccountFilterChange"
             />
           </div>
           <div class="app-field">
@@ -124,7 +125,9 @@
         </div>
       </div>
 
+      <AppTableSkeleton v-if="loading && !groups.length" :rows="8" :cols="5" />
       <DataTable
+        v-else
         v-model:filters="tableFilters"
         :value="journalRows"
         :loading="loading"
@@ -622,6 +625,8 @@ import {
   createManualEntryApi,
   getExportCsvUrl,
   getJournalGroupsApi,
+  listAccountsApi,
+  type AccountingAccount,
   type AccountingEntryGroupRead,
   type AccountingEntryRead,
   type EntrySourceType,
@@ -637,6 +642,8 @@ import AppNumberRangeFilter from '../components/ui/AppNumberRangeFilter.vue'
 import AppPageHeader from '../components/ui/AppPageHeader.vue'
 import AppPanel from '../components/ui/AppPanel.vue'
 import AppStatCard from '../components/ui/AppStatCard.vue'
+import AppAccountSelect from '../components/ui/AppAccountSelect.vue'
+import AppTableSkeleton from '../components/ui/AppTableSkeleton.vue'
 import {
   dateRangeFilter,
   inFilter,
@@ -662,6 +669,7 @@ const router = useRouter()
 const fiscalYearStore = useFiscalYearStore()
 
 const groups = ref<AccountingEntryGroupRead[]>([])
+const journalAccounts = ref<AccountingAccount[]>([])
 const fiscalYears = computed(() => fiscalYearStore.fiscalYears)
 const selectedFiscalYearId = computed({
   get: () => fiscalYearStore.selectedFiscalYearId,
@@ -843,6 +851,11 @@ function accountsSummary(group: AccountingEntryGroupRead): string {
   return `${group.account_numbers.slice(0, 3).join(', ')} +${group.account_numbers.length - 3}`
 }
 
+function onAccountFilterChange(value: string | null) {
+  filters.value.account_number = value ?? ''
+  void load()
+}
+
 function findEditableEntry(group: AccountingEntryGroupRead): AccountingEntryRead | null {
   return (
     group.lines.find((line) => line.editable && Number.parseFloat(line.debit) > 0) ||
@@ -977,7 +990,8 @@ watch(
 
 onMounted(async () => {
   await fiscalYearStore.initialize()
-  await load()
+  const [, accts] = await Promise.all([load(), listAccountsApi(undefined, false)])
+  journalAccounts.value = accts
 })
 </script>
 

--- a/frontend/src/views/AccountingLedgerView.vue
+++ b/frontend/src/views/AccountingLedgerView.vue
@@ -287,7 +287,11 @@ async function load() {
 
 function onAccountChange(value: string | null) {
   accountNumber.value = value
-  if (value) void load()
+  if (value) {
+    void load()
+  } else {
+    ledger.value = null
+  }
 }
 
 watch(

--- a/frontend/src/views/AccountingLedgerView.vue
+++ b/frontend/src/views/AccountingLedgerView.vue
@@ -10,15 +10,11 @@
         <div class="app-filter-grid">
           <div class="app-field app-field--span-2">
             <label class="app-field__label">{{ t('accounting.journal.filter_account') }}</label>
-            <Select
+            <AppAccountSelect
               v-model="accountNumber"
-              :options="accounts"
-              option-label="displayLabel"
-              option-value="number"
+              :accounts="accounts"
               :placeholder="t('accounting.ledger.select_account')"
-              filter
-              editable
-              @change="load"
+              @update:model-value="onAccountChange"
             />
           </div>
           <div class="app-field">
@@ -203,7 +199,7 @@ import Button from 'primevue/button'
 import Column from 'primevue/column'
 import DataTable from 'primevue/datatable'
 import InputText from 'primevue/inputtext'
-import Select from 'primevue/select'
+import AppAccountSelect from '../components/ui/AppAccountSelect.vue'
 import AppDateInput from '../components/ui/AppDateInput.vue'
 import AppDateRangeFilter from '../components/ui/AppDateRangeFilter.vue'
 import AppNumberRangeFilter from '../components/ui/AppNumberRangeFilter.vue'
@@ -211,7 +207,7 @@ import AppPage from '../components/ui/AppPage.vue'
 import AppPageHeader from '../components/ui/AppPageHeader.vue'
 import AppPanel from '../components/ui/AppPanel.vue'
 import AppStatCard from '../components/ui/AppStatCard.vue'
-import { getLedgerApi, listAccountsApi, type LedgerRead } from '../api/accounting'
+import { getLedgerApi, listAccountsApi, type AccountingAccount, type LedgerRead } from '../api/accounting'
 import {
   dateRangeFilter,
   numericRangeFilter,
@@ -219,20 +215,19 @@ import {
   useDataTableFilters,
 } from '../composables/useDataTableFilters'
 import { useFiscalYearStore } from '../stores/fiscalYear'
-import { formatFocusedAccountLabel } from '../utils/focusAccounts'
 import { formatAccountingAmount, formatDisplayDate } from '@/utils/format'
 
 const { t } = useI18n()
 const fiscalYearStore = useFiscalYearStore()
 
 const ledger = ref<LedgerRead | null>(null)
-const accounts = ref<Array<{ number: string; displayLabel: string }>>([])
+const accounts = ref<AccountingAccount[]>([])
 const fiscalYears = computed(() => fiscalYearStore.fiscalYears)
 const fiscalYearId = computed({
   get: () => fiscalYearStore.selectedFiscalYearId,
   set: (value: number | undefined) => fiscalYearStore.setSelectedFiscalYear(value),
 })
-const accountNumber = ref('')
+const accountNumber = ref<string | null>(null)
 const fromDate = ref('')
 const toDate = ref('')
 const loading = ref(false)
@@ -276,10 +271,11 @@ const emptyStateMessage = computed(() => {
 })
 
 async function load() {
-  if (!accountNumber.value || !fiscalYearStore.selectedFiscalYearId) return
+  const acctNum = accountNumber.value
+  if (!acctNum || !fiscalYearStore.selectedFiscalYearId) return
   loading.value = true
   try {
-    ledger.value = await getLedgerApi(accountNumber.value, {
+    ledger.value = await getLedgerApi(acctNum, {
       from_date: fromDate.value || undefined,
       to_date: toDate.value || undefined,
       fiscal_year_id: fiscalYearId.value,
@@ -287,6 +283,11 @@ async function load() {
   } finally {
     loading.value = false
   }
+}
+
+function onAccountChange(value: string | null) {
+  accountNumber.value = value
+  if (value) void load()
 }
 
 watch(
@@ -300,11 +301,7 @@ watch(
 onMounted(async () => {
   try {
     await fiscalYearStore.initialize()
-    const accts = await listAccountsApi(undefined, false)
-    accounts.value = accts.map((a) => ({
-      number: a.number,
-      displayLabel: formatFocusedAccountLabel(a.number, a.label, t),
-    }))
+    accounts.value = await listAccountsApi(undefined, false)
   } finally {
     initializing.value = false
   }

--- a/frontend/src/views/ClientInvoicesView.vue
+++ b/frontend/src/views/ClientInvoicesView.vue
@@ -119,7 +119,9 @@
         </div>
       </div>
 
+      <AppTableSkeleton v-if="loading && !invoices.length" :rows="8" :cols="5" />
       <DataTable
+        v-else
         v-model:filters="tableFilters"
         :value="invoiceRows"
         :loading="loading"
@@ -367,9 +369,7 @@
           </div>
         </div>
 
-        <div v-if="historyLoading" class="history-dialog__loading">
-          <ProgressSpinner style="width: 32px; height: 32px" />
-        </div>
+        <AppTableSkeleton v-if="historyLoading" :rows="5" :cols="3" />
         <div v-else-if="historyPayments.length === 0" class="app-empty-state">
           {{ t('invoices.no_payments') }}
         </div>
@@ -529,7 +529,6 @@ import DatePicker from 'primevue/datepicker'
 import Dialog from 'primevue/dialog'
 import InputNumber from 'primevue/inputnumber'
 import InputText from 'primevue/inputtext'
-import ProgressSpinner from 'primevue/progressspinner'
 import Select from 'primevue/select'
 import Tag from 'primevue/tag'
 import Textarea from 'primevue/textarea'
@@ -560,6 +559,7 @@ import AppPage from '../components/ui/AppPage.vue'
 import AppPageHeader from '../components/ui/AppPageHeader.vue'
 import AppPanel from '../components/ui/AppPanel.vue'
 import AppStatCard from '../components/ui/AppStatCard.vue'
+import AppTableSkeleton from '../components/ui/AppTableSkeleton.vue'
 import {
   dateRangeFilter,
   inFilter,
@@ -1079,12 +1079,6 @@ onMounted(async () => {
 
 .history-dialog__value--warn {
   color: var(--p-orange-500);
-}
-
-.history-dialog__loading {
-  display: flex;
-  justify-content: center;
-  padding: var(--app-space-5) 0;
 }
 
 @media (max-width: 767px) {

--- a/frontend/src/views/ContactDetailView.vue
+++ b/frontend/src/views/ContactDetailView.vue
@@ -7,7 +7,10 @@
     </AppPageHeader>
 
     <div v-if="loading" class="contact-detail-loading">
-      <ProgressSpinner />
+      <section class="app-stat-grid">
+        <Skeleton v-for="n in 3" :key="n" height="132px" border-radius="8px" />
+      </section>
+      <AppTableSkeleton :rows="10" :cols="4" style="margin-top: 1.5rem" />
     </div>
 
     <template v-else-if="history">
@@ -283,7 +286,7 @@ import Column from 'primevue/column'
 import ConfirmDialog from 'primevue/confirmdialog'
 import DataTable from 'primevue/datatable'
 import InputText from 'primevue/inputtext'
-import ProgressSpinner from 'primevue/progressspinner'
+import Skeleton from 'primevue/skeleton'
 import Tag from 'primevue/tag'
 import Toast from 'primevue/toast'
 import { useConfirm } from 'primevue/useconfirm'
@@ -295,6 +298,7 @@ import AppPage from '../components/ui/AppPage.vue'
 import AppPageHeader from '../components/ui/AppPageHeader.vue'
 import AppPanel from '../components/ui/AppPanel.vue'
 import AppStatCard from '../components/ui/AppStatCard.vue'
+import AppTableSkeleton from '../components/ui/AppTableSkeleton.vue'
 import { getContactHistoryApi, markCreanceDouteuse } from '../api/accounting'
 import type { ContactHistory } from '../api/accounting'
 import {
@@ -445,8 +449,8 @@ onMounted(loadHistory)
 <style scoped>
 .contact-detail-loading {
   display: flex;
-  justify-content: center;
-  padding: 4rem 0;
+  flex-direction: column;
+  gap: 0;
 }
 
 .contact-detail-actions {

--- a/frontend/src/views/ContactsView.vue
+++ b/frontend/src/views/ContactsView.vue
@@ -75,7 +75,9 @@
         </div>
       </div>
 
+      <AppTableSkeleton v-if="loading && !contacts.length" :rows="8" :cols="5" />
       <DataTable
+        v-else
         v-model:filters="tableFilters"
         :value="contactRows"
         :loading="loading"
@@ -225,6 +227,7 @@ import AppPage from '@/components/ui/AppPage.vue'
 import AppPageHeader from '@/components/ui/AppPageHeader.vue'
 import AppPanel from '@/components/ui/AppPanel.vue'
 import AppStatCard from '@/components/ui/AppStatCard.vue'
+import AppTableSkeleton from '@/components/ui/AppTableSkeleton.vue'
 import { deleteContactApi, listContactsApi, type Contact } from '@/api/contacts'
 import type { ContactType } from '@/api/types'
 import ContactForm from '@/components/ContactForm.vue'

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -2,9 +2,9 @@
   <AppPage width="wide">
     <AppPageHeader :eyebrow="t('ui.page.collection_eyebrow')" :title="t('dashboard.title')" />
 
-    <div v-if="loading" class="dashboard-loading">
-      <ProgressSpinner />
-    </div>
+    <section v-if="loading" class="app-stat-grid" aria-busy="true">
+      <Skeleton v-for="n in 7" :key="n" height="132px" border-radius="8px" />
+    </section>
 
     <template v-else>
       <section class="app-stat-grid">
@@ -133,7 +133,7 @@
 import { computed, onMounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import Message from 'primevue/message'
-import ProgressSpinner from 'primevue/progressspinner'
+import Skeleton from 'primevue/skeleton'
 import Select from 'primevue/select'
 import TrendLineChart, {
   type TrendLineChartSeries,
@@ -277,12 +277,6 @@ onMounted(async () => {
 .dashboard-panel-intro {
   margin: 0 0 var(--app-space-4);
   color: var(--p-text-muted-color);
-}
-
-.dashboard-loading {
-  display: flex;
-  justify-content: center;
-  padding: 4rem 0;
 }
 
 .dashboard-grid {

--- a/frontend/src/views/PaymentsView.vue
+++ b/frontend/src/views/PaymentsView.vue
@@ -64,7 +64,9 @@
         </div>
       </div>
 
+      <AppTableSkeleton v-if="loading && !payments.length" :rows="8" :cols="5" />
       <DataTable
+        v-else
         v-model:filters="tableFilters"
         :value="paymentRows"
         :loading="loading"
@@ -293,6 +295,7 @@ import AppNumberRangeFilter from '@/components/ui/AppNumberRangeFilter.vue'
 import AppPageHeader from '@/components/ui/AppPageHeader.vue'
 import AppPanel from '@/components/ui/AppPanel.vue'
 import AppStatCard from '@/components/ui/AppStatCard.vue'
+import AppTableSkeleton from '@/components/ui/AppTableSkeleton.vue'
 import { useFiscalYearStore } from '@/stores/fiscalYear'
 import { formatDisplayDate } from '@/utils/format'
 import { collectActiveFilterLabels } from '../composables/activeFilterLabels'


### PR DESCRIPTION
## Summary

Implements **Lot D — Polish UI** from the backlog: BL-071 (skeleton loaders) and BL-043 (account color combos).

---

## New components

### `AppTableSkeleton.vue`
Reusable skeleton loader component replacing `ProgressSpinner` in list views. Props: `rows` (default 8) and `cols` (default 4). Uses PrimeVue `Skeleton` cells arranged in a CSS grid.

### `AppAccountSelect.vue`
Searchable account dropdown with colored dot indicators for the 5 tracked accounts (member receivables, supplier payables, cash, current account, cheques to deposit). Wraps PrimeVue `Select` with custom `#option` and `#value` slots. Accepts `modelValue: string | null`.

---

## Changes

### BL-071 — Skeleton loaders
- **DashboardView**: 7 `<Skeleton height="132px">` placeholders in the KPI grid, replacing the centered `ProgressSpinner`
- **AccountingBilanView**: `AppTableSkeleton :rows="10" :cols="3"` instead of spinner
- **ContactDetailView**: skeleton stat-grid (3 cards) + `AppTableSkeleton` instead of spinner
- **ClientInvoicesView**: skeleton on main list (`loading && !invoices.length`) + skeleton in history payment dialog replacing spinner
- **ContactsView**, **PaymentsView**: skeleton on first load (`loading && !*.length`), `v-else` on DataTable
- **AccountingJournalView**: skeleton on first load (`loading && !groups.length`)

### BL-043 — Account color combos
- **AccountingJournalView**: account filter replaced from free-text `InputText` to `AppAccountSelect` — auto-reloads on selection/clear
- **AccountingLedgerView**: account `Select` (editable) replaced with `AppAccountSelect`; accounts loaded as raw `AccountingAccount[]`, mapping moved into component

### CSS (`main.css`)
Added global utility classes: `.app-table-skeleton`, `.app-table-skeleton__row`, `.account-select-option`, `.account-select-dot`, plus per-focus-account color variants.

---

## Tests
- `AccountingJournalView.spec.ts`: added `listAccountsApi` mock, stubbed `AppAccountSelect` and `AppTableSkeleton`
- `PaymentsView.spec.ts`: added extra microtask flush (2× `Promise.resolve`) to account for the `loading → loaded` async transition, stubbed `AppTableSkeleton`
- All 104 tests passing

---

## Breaking changes
None.

## Summary by Sourcery

Introduce reusable skeleton loading components and an account selection combo with color-coded accounting accounts, and apply them across key accounting and contact views.

New Features:
- Add AppTableSkeleton component for reusable table-like skeleton loaders used during initial data loading in list and detail views.
- Add AppAccountSelect component providing a searchable accounting account dropdown with color-coded focus account indicators.

Enhancements:
- Replace ProgressSpinner-based loading states with skeleton layouts in dashboard KPIs, accounting balance, contact detail, invoices, contacts, payments, and journal views for a smoother loading experience.
- Update accounting journal and ledger views to use AppAccountSelect for account filtering/selection, including automatic reload on changes and support for focus account coloring.
- Style skeleton tables and account select options with new global CSS utility classes and color tokens for focus accounts.
- Load raw AccountingAccount data in ledger and journal views and delegate label formatting and focus-account mapping to AppAccountSelect.
- Mark backlog items BL-071 and BL-043 and their containing Lot D as completed in the backlog documentation.

Tests:
- Extend AccountingJournalView and PaymentsView tests to mock new APIs/components and handle the asynchronous loading-to-loaded transition.