### PR TITLE
feat(ui): polish UI & contacts — version, profile link, tabs, email import (Lot I)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -124,7 +124,7 @@ Keep the following documents up to date with every significant change:
 
 ### Development cycle
 
-1. **Analyse and create tickets** — add work items to `doc/backlog.md` (format: `BL-NNN`, priorities P1–P3, dates, estimates, explicit status). Estimates represent **Copilot's own implementation time** (how long the AI agent takes to complete the work), not the user's time.
+1. **Analyse and create tickets** — add work items to `doc/backlog.md` (format: `BIZ-NNN` / `TEC-NNN` / `CHR-NNN` depending on category — see backlog legend, priorities P1–P3, dates, estimates, explicit status). Estimates represent **Copilot's own implementation time** (how long the AI agent takes to complete the work), not the user's time.
 2. **Feed the roadmap when relevant** — if a ticket represents a new feature, major initiative, innovative idea, or strategic shift, also add it to `doc/roadmap.md` under "Not yet planned".
 3. **Group tickets into lots** — related backlog items are bundled into named lots (e.g. *Lot A — Import Excel*, *Lot F — Tests*). Each lot is identified in the backlog.
 4. **Assign a target version** — agree on a version (`MAJOR.MINOR`, no patch level) per lot. **Every versioned lot must appear in the roadmap**: functional lots get a subsection with detail, technical lots get a one-line summary.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ Ce projet respecte le [Versionnage sémantique](https://semver.org/lang/fr/).
 
 ### Ajouté
 
+- `frontend/src/views/ContactsView.vue` : onglets Tous / Clients / Fournisseurs via `Tabs` PrimeVue — filtrage frontend (`les_deux` visible dans les deux onglets), remplacement du `Select` type par les onglets (BL-035)
+- `POST /api/contacts/import-emails` : endpoint d'import d'e-mails en masse pour enrichir les contacts existants par correspondance sur le nom (normalisation des accents, matching prenom+nom et nom seul) — schémas `ContactEmailImportRow` / `ContactEmailImportResult`, 9 nouveaux tests (BL-040)
+- `frontend/src/views/ContactsView.vue` : bouton « Importer e-mails » + dialogue avec zone de texte collée (`Nom, email` par ligne) + affichage du bilan (mis à jour / non trouvés / déjà renseignés) (BL-040)
+- `frontend/src/layouts/AppLayout.vue` : nom d'utilisateur (sidebar et topbar) cliquable via `RouterLink` vers `/profile` — suppression de l'entrée « Mon profil » du menu de navigation (BL-037)
+- `frontend/src/layouts/AppLayout.vue` : numéro de version discret en bas de la sidebar, injecté depuis `package.json` via `vite.config.ts` `define.__APP_VERSION__` (BL-038)
+
 - `frontend/src/tests/composables/useDarkMode.spec.ts` : tests unitaires Vitest pour le composable `useDarkMode` — toggle, persistance dans localStorage, classe CSS `dark-mode` (BL-079)
 - `frontend/src/tests/composables/useTableFilter.spec.ts` : tests unitaires Vitest pour `applyFilter` et `useTableFilter` — filtrage par sous-chaîne insensible à la casse, réactivité, cas limites null/undefined (BL-079)
 - `frontend/src/tests/composables/activeFilterLabels.spec.ts` : tests unitaires Vitest pour `findSelectedFilterLabel` et `collectActiveFilterLabels` — matching, valeurs nulles, types numériques (BL-079)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,89 +13,89 @@ Ce projet respecte le [Versionnage sémantique](https://semver.org/lang/fr/).
 
 ### Ajouté
 
-- `frontend/src/views/ContactsView.vue` : onglets Tous / Clients / Fournisseurs via `Tabs` PrimeVue — filtrage frontend (`les_deux` visible dans les deux onglets), remplacement du `Select` type par les onglets (BL-035)
-- `POST /api/contacts/import-emails` : endpoint d'import d'e-mails en masse pour enrichir les contacts existants par correspondance sur le nom (normalisation des accents, matching prenom+nom et nom seul) — schémas `ContactEmailImportRow` / `ContactEmailImportResult`, 9 nouveaux tests (BL-040)
-- `frontend/src/views/ContactsView.vue` : bouton « Importer e-mails » + dialogue avec zone de texte collée (`Nom, email` par ligne) + affichage du bilan (mis à jour / non trouvés / déjà renseignés) (BL-040)
-- `frontend/src/layouts/AppLayout.vue` : nom d'utilisateur (sidebar et topbar) cliquable via `RouterLink` vers `/profile` — suppression de l'entrée « Mon profil » du menu de navigation (BL-037)
-- `frontend/src/layouts/AppLayout.vue` : numéro de version discret en bas de la sidebar, injecté depuis `package.json` via `vite.config.ts` `define.__APP_VERSION__` (BL-038)
+- `frontend/src/views/ContactsView.vue` : onglets Tous / Clients / Fournisseurs via `Tabs` PrimeVue — filtrage frontend (`les_deux` visible dans les deux onglets), remplacement du `Select` type par les onglets (BIZ-035)
+- `POST /api/contacts/import-emails` : endpoint d'import d'e-mails en masse pour enrichir les contacts existants par correspondance sur le nom (normalisation des accents, matching prénom+nom et nom seul) — schémas `ContactEmailImportRow` / `ContactEmailImportResult`, 9 nouveaux tests (BIZ-040)
+- `frontend/src/views/ContactsView.vue` : bouton « Importer e-mails » + dialogue avec zone de texte collée (`Nom, email` par ligne) + affichage du bilan (mis à jour / non trouvés / déjà renseignés) (BIZ-040)
+- `frontend/src/layouts/AppLayout.vue` : nom d'utilisateur (sidebar et topbar) cliquable via `RouterLink` vers `/profile` — suppression de l'entrée « Mon profil » du menu de navigation (BIZ-037)
+- `frontend/src/layouts/AppLayout.vue` : numéro de version discret en bas de la sidebar, injecté depuis `package.json` via `vite.config.ts` `define.__APP_VERSION__` (CHR-038)
 
-- `frontend/src/tests/composables/useDarkMode.spec.ts` : tests unitaires Vitest pour le composable `useDarkMode` — toggle, persistance dans localStorage, classe CSS `dark-mode` (BL-079)
-- `frontend/src/tests/composables/useTableFilter.spec.ts` : tests unitaires Vitest pour `applyFilter` et `useTableFilter` — filtrage par sous-chaîne insensible à la casse, réactivité, cas limites null/undefined (BL-079)
-- `frontend/src/tests/composables/activeFilterLabels.spec.ts` : tests unitaires Vitest pour `findSelectedFilterLabel` et `collectActiveFilterLabels` — matching, valeurs nulles, types numériques (BL-079)
-- `frontend/e2e/smoke.spec.ts` : smoke test E2E Playwright couvrant login → changement de mot de passe obligatoire → dashboard → contacts → factures clients → paiements (BL-080)
-- `frontend/playwright.config.ts` : configuration Playwright avec webServer auto-start (backend Uvicorn + frontend Vite) et DB E2E dédiée (BL-080)
-- `tests/integration/test_accounting_rules_api.py` : tests d'intégration complets pour l'API des règles comptables — CRUD, seed, auth, rôles (BL-081)
-- `tests/integration/test_fiscal_year_api.py` : tests d'intégration pour les endpoints pre-close-checks, open-next, close 404, auth/rôles (BL-081)
-- `tests/integration/test_salary_api.py` : tests complémentaires — get by id, update, delete not found, accès trésorier (BL-081)
-- `tests/integration/test_dashboard_api.py` : test d'authentification pour le graphique ressources (BL-081)
+- `frontend/src/tests/composables/useDarkMode.spec.ts` : tests unitaires Vitest pour le composable `useDarkMode` — toggle, persistance dans localStorage, classe CSS `dark-mode` (TEC-079)
+- `frontend/src/tests/composables/useTableFilter.spec.ts` : tests unitaires Vitest pour `applyFilter` et `useTableFilter` — filtrage par sous-chaîne insensible à la casse, réactivité, cas limites null/undefined (TEC-079)
+- `frontend/src/tests/composables/activeFilterLabels.spec.ts` : tests unitaires Vitest pour `findSelectedFilterLabel` et `collectActiveFilterLabels` — matching, valeurs nulles, types numériques (TEC-079)
+- `frontend/e2e/smoke.spec.ts` : smoke test E2E Playwright couvrant login → changement de mot de passe obligatoire → dashboard → contacts → factures clients → paiements (TEC-080)
+- `frontend/playwright.config.ts` : configuration Playwright avec webServer auto-start (backend Uvicorn + frontend Vite) et DB E2E dédiée (TEC-080)
+- `tests/integration/test_accounting_rules_api.py` : tests d'intégration complets pour l'API des règles comptables — CRUD, seed, auth, rôles (TEC-081)
+- `tests/integration/test_fiscal_year_api.py` : tests d'intégration pour les endpoints pre-close-checks, open-next, close 404, auth/rôles (TEC-081)
+- `tests/integration/test_salary_api.py` : tests complémentaires — get by id, update, delete not found, accès trésorier (TEC-081)
+- `tests/integration/test_dashboard_api.py` : test d'authentification pour le graphique ressources (TEC-081)
 
-- `frontend/src/components/ui/AppTableSkeleton.vue` : composant de skeleton réutilisable (grille de cellules PrimeVue `Skeleton`, props `rows`/`cols` avec valeurs par défaut 8×4) remplaçant les `ProgressSpinner` dans toutes les vues de liste au premier chargement (BL-071)
-- `frontend/src/components/ui/AppAccountSelect.vue` : composant combo comptes comptables avec point coloré pour les 5 comptes de suivi (créances membres, fournisseurs, caisse, courant, chèques à déposer) via `AppAccountSelect` wrappant PrimeVue `Select` avec slots `#option` et `#value` (BL-043)
+- `frontend/src/components/ui/AppTableSkeleton.vue` : composant de skeleton réutilisable (grille de cellules PrimeVue `Skeleton`, props `rows`/`cols` avec valeurs par défaut 8×4) remplaçant les `ProgressSpinner` dans toutes les vues de liste au premier chargement (BIZ-071)
+- `frontend/src/components/ui/AppAccountSelect.vue` : composant combo comptes comptables avec point coloré pour les 5 comptes de suivi (créances membres, fournisseurs, caisse, courant, chèques à déposer) via `AppAccountSelect` wrappant PrimeVue `Select` avec slots `#option` et `#value` (BIZ-043)
 - `frontend/src/assets/main.css` : classes globales `.app-table-skeleton`, `.app-table-skeleton__row`, `.account-select-option`, `.account-select-dot` et variantes couleur par compte de suivi
 
 ### Modifié
 
-- `frontend/src/views/DashboardView.vue` : remplacement du `ProgressSpinner` central par 7 `<Skeleton height="132px">` dans la grille KPI au chargement — cohérence visuelle avec le layout final (BL-071)
-- `frontend/src/views/AccountingBilanView.vue` : remplacement du `ProgressSpinner` par `AppTableSkeleton :rows="10" :cols="3"` (BL-071)
-- `frontend/src/views/ContactDetailView.vue` : remplacement du `ProgressSpinner` par une grille de 3 `Skeleton` de stat + `AppTableSkeleton` (BL-071)
-- `frontend/src/views/ClientInvoicesView.vue` : skeleton sur la liste principale (`loading && !invoices.length`) et dans le dialogue historique (BL-071)
-- `frontend/src/views/ContactsView.vue` + `PaymentsView.vue` : skeleton sur liste principale au premier chargement (`loading && !*.length`) (BL-071)
-- `frontend/src/views/AccountingJournalView.vue` : skeleton liste + filtre compte remplacé par `AppAccountSelect` avec rechargement automatique à la sélection (BL-071, BL-043)
-- `frontend/src/views/AccountingLedgerView.vue` : select compte remplacé par `AppAccountSelect` avec points colorés (BL-043)
+- `frontend/src/views/DashboardView.vue` : remplacement du `ProgressSpinner` central par 7 `<Skeleton height="132px">` dans la grille KPI au chargement — cohérence visuelle avec le layout final (BIZ-071)
+- `frontend/src/views/AccountingBilanView.vue` : remplacement du `ProgressSpinner` par `AppTableSkeleton :rows="10" :cols="3"` (BIZ-071)
+- `frontend/src/views/ContactDetailView.vue` : remplacement du `ProgressSpinner` par une grille de 3 `Skeleton` de stat + `AppTableSkeleton` (BIZ-071)
+- `frontend/src/views/ClientInvoicesView.vue` : skeleton sur la liste principale (`loading && !invoices.length`) et dans le dialogue historique (BIZ-071)
+- `frontend/src/views/ContactsView.vue` + `PaymentsView.vue` : skeleton sur liste principale au premier chargement (`loading && !*.length`) (BIZ-071)
+- `frontend/src/views/AccountingJournalView.vue` : skeleton liste + filtre compte remplacé par `AppAccountSelect` avec rechargement automatique à la sélection (BIZ-071, BIZ-043)
+- `frontend/src/views/AccountingLedgerView.vue` : select compte remplacé par `AppAccountSelect` avec points colorés (BIZ-043)
 
-- `frontend/src/composables/useKeyboardShortcuts.ts` : composable Vue 3 gérant les raccourcis clavier Ctrl/Cmd+N (nouveau), Ctrl/Cmd+S (sauvegarder) et Escape (fermer) avec gestion du focus (Ctrl+N ignoré dans les champs de saisie) et nettoyage automatique au démontage (BL-073)
-- `frontend/src/components/ui/AppStatCard.vue` : prop optionnelle `to` (route Vue Router) rendant la carte KPI cliquable via `<RouterLink>` avec animation hover et focus-visible accessible (BL-075)
-- `frontend/src/views/DashboardView.vue` : tous les KPI (solde banque, caisse, factures impayées/en retard, chèques non déposés, exercice courant, résultat) sont désormais cliquables vers les vues filtrées correspondantes (BL-075)
-- `frontend/src/views/ClientInvoicesView.vue` + `PaymentsView.vue` : support des query params URL (`status=overdue`, `undeposited=1`) pour pré-filtrer les listes depuis le dashboard (BL-075)
-- `frontend/src/views/ClientInvoicesView.vue` + `ContactsView.vue` : intégration de `useKeyboardShortcuts` pour Ctrl+N / Ctrl+S / Escape dans les vues avec dialogue (BL-073)
-- `doc/user/migration.md` + `doc/user/migration.en.md` : guide de migration / montée de version bilingue FR + EN pour les déploiements Docker sur Synology NAS — couvre la préparation, la mise à jour, la vérification, le rollback et les bonnes pratiques (BL-083)
-- `frontend/src/assets/print.css` : styles `@media print` pour l'impression des vues comptables (journal, balance, grand livre, bilan, résultat) — masque la sidebar, les filtres et les boutons ; optimise les tables en noir et blanc A4 paysage pour impression AG (BL-076)
-- `backend/main.py` : middleware ASGI `UnhandledExceptionMiddleware` interceptant toutes les exceptions non gérées pour renvoyer un JSON structuré `{"detail": ..., "code": "INTERNAL_SERVER_ERROR"}` au lieu d'un 500 HTML avec stack trace — log complet côté serveur (BL-067)
-- `backend/main.py` : `/api/docs`, `/api/redoc` et `/api/openapi.json` désormais désactivés quand `debug=False` — réduit la surface d'attaque en production (BL-068)
-- `backend/services/backup_service.py` + `POST /api/settings/backup` : endpoint admin de sauvegarde SQLite utilisant `sqlite3.backup()` avec rotation automatique (5 derniers backups), téléchargement direct du fichier en réponse (BL-069)
-- `backend/schemas/auth.py` : politique de complexité de mot de passe — minimum 8 caractères, au moins une majuscule et un chiffre, appliquée sur la création utilisateur, le changement et le reset de mot de passe (BL-085)
+- `frontend/src/composables/useKeyboardShortcuts.ts` : composable Vue 3 gérant les raccourcis clavier Ctrl/Cmd+N (nouveau), Ctrl/Cmd+S (sauvegarder) et Escape (fermer) avec gestion du focus (Ctrl+N ignoré dans les champs de saisie) et nettoyage automatique au démontage (BIZ-073)
+- `frontend/src/components/ui/AppStatCard.vue` : prop optionnelle `to` (route Vue Router) rendant la carte KPI cliquable via `<RouterLink>` avec animation hover et focus-visible accessible (BIZ-075)
+- `frontend/src/views/DashboardView.vue` : tous les KPI (solde banque, caisse, factures impayées/en retard, chèques non déposés, exercice courant, résultat) sont désormais cliquables vers les vues filtrées correspondantes (BIZ-075)
+- `frontend/src/views/ClientInvoicesView.vue` + `PaymentsView.vue` : support des query params URL (`status=overdue`, `undeposited=1`) pour pré-filtrer les listes depuis le dashboard (BIZ-075)
+- `frontend/src/views/ClientInvoicesView.vue` + `ContactsView.vue` : intégration de `useKeyboardShortcuts` pour Ctrl+N / Ctrl+S / Escape dans les vues avec dialogue (BIZ-073)
+- `doc/user/migration.md` + `doc/user/migration.en.md` : guide de migration / montée de version bilingue FR + EN pour les déploiements Docker sur Synology NAS — couvre la préparation, la mise à jour, la vérification, le rollback et les bonnes pratiques (CHR-083)
+- `frontend/src/assets/print.css` : styles `@media print` pour l'impression des vues comptables (journal, balance, grand livre, bilan, résultat) — masque la sidebar, les filtres et les boutons ; optimise les tables en noir et blanc A4 paysage pour impression AG (BIZ-076)
+- `backend/main.py` : middleware ASGI `UnhandledExceptionMiddleware` interceptant toutes les exceptions non gérées pour renvoyer un JSON structuré `{"detail": ..., "code": "INTERNAL_SERVER_ERROR"}` au lieu d'un 500 HTML avec stack trace — log complet côté serveur (TEC-067)
+- `backend/main.py` : `/api/docs`, `/api/redoc` et `/api/openapi.json` désormais désactivés quand `debug=False` — réduit la surface d'attaque en production (TEC-068)
+- `backend/services/backup_service.py` + `POST /api/settings/backup` : endpoint admin de sauvegarde SQLite utilisant `sqlite3.backup()` avec rotation automatique (5 derniers backups), téléchargement direct du fichier en réponse (BIZ-069)
+- `backend/schemas/auth.py` : politique de complexité de mot de passe — minimum 8 caractères, au moins une majuscule et un chiffre, appliquée sur la création utilisateur, le changement et le reset de mot de passe (TEC-085)
 
 **Qualité / Sécurité (audit 2026-04-22)**
 
-- `backend/routers/auth.py` : le refresh token est désormais transmis via un cookie `HttpOnly`, `Secure`, `SameSite=Strict` au lieu du corps JSON — `/auth/login` et `/auth/refresh` posent le cookie, nouvel endpoint `POST /auth/logout` (204) l'efface (BL-046)
-- Frontend : `refreshApi()` et `logoutApi()` utilisent le cookie automatiquement (`withCredentials: true`), le store auth ne stocke plus le refresh token en `localStorage` (BL-046)
-- `entrypoint.sh` : script d'entrée Docker dédié avec `set -e` — les migrations Alembic échouent explicitement au lieu d'être masquées par le `&&` shell (BL-054)
-- `GET /api/health` : endpoint de health check léger (200, `{"status": "ok"}`) + `HEALTHCHECK` Docker + `healthcheck:` docker-compose pour la supervision Synology (BL-061)
-- `backend/models/user.py` : champ `must_change_password` obligeant l'utilisateur à changer son mot de passe avant d'accéder à l'application — activé au bootstrap admin, à la réinitialisation de mot de passe par un administrateur, et désactivé automatiquement après changement effectif (BL-053)
-- `backend/main.py` : middleware `MustChangePasswordMiddleware` bloquant (HTTP 403) toute requête API hors `/api/auth/` quand le JWT porte le flag `mcp=True` (BL-053)
-- Frontend : redirection automatique vers la page Profil avec bannière d'avertissement lorsque `must_change_password` est actif ; le router guard empêche la navigation vers d'autres pages (BL-053)
-- `backend/config.py` : `get_settings()` utilise désormais `@lru_cache` au lieu d'un pattern `global` mutable — plus idiomatique et thread-safe (BL-066)
-- `backend/main.py` : middleware `SecurityHeadersMiddleware` ajoutant `Content-Security-Policy`, `X-Content-Type-Options`, `X-Frame-Options`, `Strict-Transport-Security` et `Referrer-Policy` sur toutes les réponses (BL-047)
-- `backend/config.py` : paramètre `cors_allowed_origins` (liste, variable d'environnement `CORS_ALLOWED_ORIGINS`) permettant de configurer explicitement les origines CORS autorisées en production — wildcard `*` seulement en mode debug sans origines configurées (BL-055)
-- `frontend/public/dark-mode-init.js` : script d'initialisation du mode sombre extrait inline vers un fichier statique dédié pour respecter la politique `script-src 'self'` de la CSP (BL-047)
-- Endpoints de liste : paramètre `limit` désormais borné (`default=100`, `le=1000`) sur tous les routers de liste — caisse, banque, paiements, factures, contacts, salaires, écritures — pour limiter le volume de données retourné en une seule requête (BL-059)
-- `backend/models/types.py` : nouveau `TypeDecorator` `DecimalType` (wrapping `Numeric`) garantissant que SQLAlchemy renvoie toujours un `Decimal` pour les colonnes monétaires au lieu d'un `float` SQLite — élimine les quelque 60 casts `Decimal(str(obj.attr))` répartis dans les services (BL-057)
-- `backend/models/payment.py` : suppression de `__allow_unmapped__` et des attributs transients `invoice_number` / `invoice_type` — ces champs sont désormais calculés à la lecture dans `PaymentRead` via une requête ciblée sur `Invoice` (BL-065)
-- `backend/models/audit_log.py` : table `audit_logs` + service `record_audit` + enum `AuditAction` pour le journal d'audit structuré — traçabilité des connexions (succès/échec), déconnexions, changements de mot de passe, création/modification d'utilisateurs, réinitialisations de mot de passe admin, et opérations de reset base. Migration Alembic `0023` (BL-056)
-- Tests : +44 tests unitaires (812 → 856) pour les services critiques — `fiscal_year_service` (pre_close_checks, report à nouveau), `contact` (historique, créance douteuse), `dashboard_service` (KPIs, alertes, graphiques), `salary_service` (update, filtre par mois), `accounting_rule_service` (CRUD, preview, template). Couverture globale backend ~71 % (BL-049)
+- `backend/routers/auth.py` : le refresh token est désormais transmis via un cookie `HttpOnly`, `Secure`, `SameSite=Strict` au lieu du corps JSON — `/auth/login` et `/auth/refresh` posent le cookie, nouvel endpoint `POST /auth/logout` (204) l'efface (TEC-046)
+- Frontend : `refreshApi()` et `logoutApi()` utilisent le cookie automatiquement (`withCredentials: true`), le store auth ne stocke plus le refresh token en `localStorage` (TEC-046)
+- `entrypoint.sh` : script d'entrée Docker dédié avec `set -e` — les migrations Alembic échouent explicitement au lieu d'être masquées par le `&&` shell (CHR-054)
+- `GET /api/health` : endpoint de health check léger (200, `{"status": "ok"}`) + `HEALTHCHECK` Docker + `healthcheck:` docker-compose pour la supervision Synology (CHR-061)
+- `backend/models/user.py` : champ `must_change_password` obligeant l'utilisateur à changer son mot de passe avant d'accéder à l'application — activé au bootstrap admin, à la réinitialisation de mot de passe par un administrateur, et désactivé automatiquement après changement effectif (BIZ-053)
+- `backend/main.py` : middleware `MustChangePasswordMiddleware` bloquant (HTTP 403) toute requête API hors `/api/auth/` quand le JWT porte le flag `mcp=True` (BIZ-053)
+- Frontend : redirection automatique vers la page Profil avec bannière d'avertissement lorsque `must_change_password` est actif ; le router guard empêche la navigation vers d'autres pages (BIZ-053)
+- `backend/config.py` : `get_settings()` utilise désormais `@lru_cache` au lieu d'un pattern `global` mutable — plus idiomatique et thread-safe (TEC-066)
+- `backend/main.py` : middleware `SecurityHeadersMiddleware` ajoutant `Content-Security-Policy`, `X-Content-Type-Options`, `X-Frame-Options`, `Strict-Transport-Security` et `Referrer-Policy` sur toutes les réponses (TEC-047)
+- `backend/config.py` : paramètre `cors_allowed_origins` (liste, variable d'environnement `CORS_ALLOWED_ORIGINS`) permettant de configurer explicitement les origines CORS autorisées en production — wildcard `*` seulement en mode debug sans origines configurées (TEC-055)
+- `frontend/public/dark-mode-init.js` : script d'initialisation du mode sombre extrait inline vers un fichier statique dédié pour respecter la politique `script-src 'self'` de la CSP (TEC-047)
+- Endpoints de liste : paramètre `limit` désormais borné (`default=100`, `le=1000`) sur tous les routers de liste — caisse, banque, paiements, factures, contacts, salaires, écritures — pour limiter le volume de données retourné en une seule requête (TEC-059)
+- `backend/models/types.py` : nouveau `TypeDecorator` `DecimalType` (wrapping `Numeric`) garantissant que SQLAlchemy renvoie toujours un `Decimal` pour les colonnes monétaires au lieu d'un `float` SQLite — élimine les quelque 60 casts `Decimal(str(obj.attr))` répartis dans les services (TEC-057)
+- `backend/models/payment.py` : suppression de `__allow_unmapped__` et des attributs transients `invoice_number` / `invoice_type` — ces champs sont désormais calculés à la lecture dans `PaymentRead` via une requête ciblée sur `Invoice` (TEC-065)
+- `backend/models/audit_log.py` : table `audit_logs` + service `record_audit` + enum `AuditAction` pour le journal d'audit structuré — traçabilité des connexions (succès/échec), déconnexions, changements de mot de passe, création/modification d'utilisateurs, réinitialisations de mot de passe admin, et opérations de reset base. Migration Alembic `0023` (BIZ-056)
+- Tests : +44 tests unitaires (812 → 856) pour les services critiques — `fiscal_year_service` (pre_close_checks, report à nouveau), `contact` (historique, créance douteuse), `dashboard_service` (KPIs, alertes, graphiques), `salary_service` (update, filtre par mois), `accounting_rule_service` (CRUD, preview, template). Couverture globale backend ~71 % (TEC-049)
 
 ### Refactorisé
 
-- `frontend/src/views/SettingsView.vue` → 24 lignes (depuis 1 077 L) : extraction de `SettingsAssociationSmtpPanel`, `SettingsSystemOpeningPanel`, `SettingsDangerZonePanel` dans `src/components/settings/` (BL-077)
-- `frontend/src/views/BankView.vue` → 917 lignes (depuis 2 215 L) : extraction de 7 composants de dialogue dans `src/components/bank/` — `BankNewTransactionDialog`, `BankImportStatementDialog`, `BankClientPaymentDialog`, `BankLinkClientPaymentDialog`, `BankSupplierPaymentDialog`, `BankLinkSupplierPaymentDialog`, `BankNewDepositDialog` — chaque dialogue est auto-suffisant (chargement interne, émet `@saved`) (BL-077)
-- `frontend/src/views/ImportExcelView.vue` → 1 191 lignes (depuis 2 873 L) : extraction de `ImportExcelFormPanel`, `ImportExcelShortcutsPanel`, `ImportExcelPreviewPanel`, `ImportExcelResultPanel` dans `src/components/import/` — la vue orchestre, les composants gèrent l'affichage et les opérations locales (BL-077)
+- `frontend/src/views/SettingsView.vue` → 24 lignes (depuis 1 077 L) : extraction de `SettingsAssociationSmtpPanel`, `SettingsSystemOpeningPanel`, `SettingsDangerZonePanel` dans `src/components/settings/` (TEC-077)
+- `frontend/src/views/BankView.vue` → 917 lignes (depuis 2 215 L) : extraction de 7 composants de dialogue dans `src/components/bank/` — `BankNewTransactionDialog`, `BankImportStatementDialog`, `BankClientPaymentDialog`, `BankLinkClientPaymentDialog`, `BankSupplierPaymentDialog`, `BankLinkSupplierPaymentDialog`, `BankNewDepositDialog` — chaque dialogue est auto-suffisant (chargement interne, émet `@saved`) (TEC-077)
+- `frontend/src/views/ImportExcelView.vue` → 1 191 lignes (depuis 2 873 L) : extraction de `ImportExcelFormPanel`, `ImportExcelShortcutsPanel`, `ImportExcelPreviewPanel`, `ImportExcelResultPanel` dans `src/components/import/` — la vue orchestre, les composants gèrent l'affichage et les opérations locales (TEC-077)
 
 **Qualité / Sécurité (audit 2026-04-22)**
 
-- `backend/services/excel_import.py` : monolith de 5 567 lignes éclaté en package `backend/services/excel_import/` avec 16 sous-modules thématiques (`_constants`, `_salary`, `_invoices`, `_loaders`, `_comparison`, `_comparison_loaders`, `_comparison_domains`, `_entry_groups`, `_sheet_wrappers`, `_orchestrator`, `_import_contacts_invoices`, `_import_payments_salaries`, `_import_cash_bank`, `_import_entries`, `_preview_existing`, `_preview_sheets`) — refactoring purement structurel, interfaces publiques inchangées, zéro dépendance circulaire (BL-050)
-- `backend/services/excel_import/_exceptions.py` : introduction de `ImportFileOpenError` et `ImportSheetError` en remplacement des `except Exception` généralisés — `_ImportSheetFailure(RuntimeError)` remplacé par alias vers `ImportSheetError`, orchestrateur avec catch séparés par type, routeur avec mapping HTTP typé (BL-058)
+- `backend/services/excel_import.py` : monolith de 5 567 lignes éclaté en package `backend/services/excel_import/` avec 16 sous-modules thématiques (`_constants`, `_salary`, `_invoices`, `_loaders`, `_comparison`, `_comparison_loaders`, `_comparison_domains`, `_entry_groups`, `_sheet_wrappers`, `_orchestrator`, `_import_contacts_invoices`, `_import_payments_salaries`, `_import_cash_bank`, `_import_entries`, `_preview_existing`, `_preview_sheets`) — refactoring purement structurel, interfaces publiques inchangées, zéro dépendance circulaire (TEC-050)
+- `backend/services/excel_import/_exceptions.py` : introduction de `ImportFileOpenError` et `ImportSheetError` en remplacement des `except Exception` généralisés — `_ImportSheetFailure(RuntimeError)` remplacé par alias vers `ImportSheetError`, orchestrateur avec catch séparés par type, routeur avec mapping HTTP typé (TEC-058)
 
 ### Corrigé
 
 **Qualité / Sécurité (audit 2026-04-22)**
 
-- `frontend/src/stores/counter.ts` : suppression du fichier de scaffolding Vue non utilisé (BL-064)
-- `frontend/package.json` : version alignée sur `0.1.0` pour correspondre au backend (BL-062)
-- `backend/models/accounting_account.py` : remplacement des noms de personnes réelles dans le plan comptable par défaut par des libellés génériques (`Client litigieux 1`, `Client litigieux 2`) — conformité RGPD (BL-063)
-- `tests/integration/test_import_api.py` : adaptation du test `test_test_import_shortcuts_list_and_run_configured_file` pour utiliser `unittest.mock.patch` au lieu d'accéder directement au singleton `_settings` supprimé (BL-066)
-- `backend/routers/settings.py` : endpoint `POST /settings/reset-db` désormais protégé — retourne HTTP 403 si `settings.debug` est `False`, évitant une remise à zéro accidentelle en production (BL-052)
-- `backend/database.py` : suppression de `Base.metadata.create_all` de `init_db()` — le schéma est exclusivement géré par les migrations Alembic ; `init_db()` ne configure plus que les PRAGMAs SQLite (BL-060)
-- `backend/services/accounting_engine.py` : `_next_entry_number` utilise désormais `SELECT MAX(entry_number)` au lieu de `SELECT COUNT(*)` pour éviter les collisions de numéros après suppressions ou imports partiels (BL-051)
+- `frontend/src/stores/counter.ts` : suppression du fichier de scaffolding Vue non utilisé (CHR-064)
+- `frontend/package.json` : version alignée sur `0.1.0` pour correspondre au backend (CHR-062)
+- `backend/models/accounting_account.py` : remplacement des noms de personnes réelles dans le plan comptable par défaut par des libellés génériques (`Client litigieux 1`, `Client litigieux 2`) — conformité RGPD (TEC-063)
+- `tests/integration/test_import_api.py` : adaptation du test `test_test_import_shortcuts_list_and_run_configured_file` pour utiliser `unittest.mock.patch` au lieu d'accéder directement au singleton `_settings` supprimé (TEC-066)
+- `backend/routers/settings.py` : endpoint `POST /settings/reset-db` désormais protégé — retourne HTTP 403 si `settings.debug` est `False`, évitant une remise à zéro accidentelle en production (TEC-052)
+- `backend/database.py` : suppression de `Base.metadata.create_all` de `init_db()` — le schéma est exclusivement géré par les migrations Alembic ; `init_db()` ne configure plus que les PRAGMAs SQLite (TEC-060)
+- `backend/services/accounting_engine.py` : `_next_entry_number` utilise désormais `SELECT MAX(entry_number)` au lieu de `SELECT COUNT(*)` pour éviter les collisions de numéros après suppressions ou imports partiels (TEC-051)
 
 **Documentation projet**
 
@@ -190,7 +190,7 @@ Ce projet respecte le [Versionnage sémantique](https://semver.org/lang/fr/).
 - `excel_import.py` : support des feuilles Caisse (`caisse`/`cash`) et Banque (`banque`/`bank`/`relev`) dans l'import Excel de gestion ; déduplication des numéros de factures dans le même batch ; création automatique du contact si absent (plutôt que saut de ligne silencieux)
 - sécurité et robustesse revues après commentaires de PR : secret JWT obligatoire hors dev/test, conversion propre des erreurs d'édition manuelle en réponses HTTP, metadata Alembic complétée pour l'autogénération
 - factures clients mixtes `cs+a` : quand la feuille `Factures` expose des montants distincts `cours` et `adhésion`, l'import historique crée les lignes de facture correspondantes et la génération comptable ventile désormais les produits sur les comptes dédiés au lieu d'un seul produit global
-- import réversible BL-004 stabilisé : un paiement préparé peut maintenant se rapprocher d'une facture du même classeur déjà planifiée dans le run, même si l'ordre des onglets est défavorable, et l'exécution facture/paiement ne déclenche plus d'erreurs async sur les snapshots enregistrés
+- import réversible BIZ-004 stabilisé : un paiement préparé peut maintenant se rapprocher d'une facture du même classeur déjà planifiée dans le run, même si l'ordre des onglets est défavorable, et l'exécution facture/paiement ne déclenche plus d'erreurs async sur les snapshots enregistrés
 
 **Frontend — bugfixes interface**
 

--- a/backend/routers/contact.py
+++ b/backend/routers/contact.py
@@ -11,6 +11,8 @@ from backend.models.user import User, UserRole
 from backend.routers.auth import require_role
 from backend.schemas.contact import (
     ContactCreate,
+    ContactEmailImportResult,
+    ContactEmailImportRow,
     ContactHistory,
     ContactRead,
     ContactUpdate,
@@ -58,6 +60,16 @@ async def create_contact(
 ) -> ContactRead:
     """Create a new contact."""
     return await contact_service.create_contact(db, payload)  # type: ignore[return-value]
+
+
+@router.post("/import-emails", response_model=ContactEmailImportResult)
+async def import_contact_emails(
+    payload: list[ContactEmailImportRow],
+    db: Annotated[AsyncSession, Depends(get_db)],
+    _current_user: _WriteAccess,
+) -> ContactEmailImportResult:
+    """Bulk-import email addresses into existing contacts matched by name."""
+    return await contact_service.import_emails_from_rows(db, payload)
 
 
 @router.get("/{contact_id}", response_model=ContactRead)

--- a/backend/schemas/contact.py
+++ b/backend/schemas/contact.py
@@ -101,13 +101,18 @@ class ContactHistory(BaseModel):
 
 class ContactEmailImportRow(BaseModel):
     nom: str
-    email: str
+    email: EmailStr
 
     @field_validator("nom")
     @classmethod
     def nom_not_empty(cls, v: str) -> str:
         if not v.strip():
             raise ValueError("nom must not be empty")
+        return v.strip()
+
+    @field_validator("email", mode="before")
+    @classmethod
+    def email_strip(cls, v: str) -> str:
         return v.strip()
 
 

--- a/backend/schemas/contact.py
+++ b/backend/schemas/contact.py
@@ -97,3 +97,22 @@ class ContactHistory(BaseModel):
     total_invoiced: Decimal
     total_paid: Decimal
     total_due: Decimal
+
+
+class ContactEmailImportRow(BaseModel):
+    nom: str
+    email: str
+
+    @field_validator("nom")
+    @classmethod
+    def nom_not_empty(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("nom must not be empty")
+        return v.strip()
+
+
+class ContactEmailImportResult(BaseModel):
+    rows_processed: int
+    updated: int
+    not_found: int
+    already_has_email: int

--- a/backend/services/contact.py
+++ b/backend/services/contact.py
@@ -229,18 +229,24 @@ async def import_emails_from_rows(
     rows: list[ContactEmailImportRow],
 ) -> ContactEmailImportResult:
     """Bulk-enrich contacts with email addresses matched by name."""
-    result = await db.execute(select(Contact).where(Contact.is_active == True))  # noqa: E712
+    result = await db.execute(
+        select(Contact).where(Contact.is_active == True).order_by(Contact.id)  # noqa: E712
+    )
     all_contacts = list(result.scalars().all())
 
-    # Build lookup: normalized name → contact (last write wins for duplicates)
-    contact_by_key: dict[str, Contact] = {}
+    # Build lookup: normalized name → list of contacts.
+    # Keys with multiple matches are ambiguous and will be skipped to avoid
+    # updating the wrong contact.
+    contact_by_key: dict[str, list[Contact]] = {}
     for contact in all_contacts:
-        contact_by_key[_normalize_name(contact.nom)] = contact
+        keys = {_normalize_name(contact.nom)}
         if contact.prenom:
             full = f"{contact.nom} {contact.prenom}"
-            contact_by_key[_normalize_name(full)] = contact
             reversed_full = f"{contact.prenom} {contact.nom}"
-            contact_by_key[_normalize_name(reversed_full)] = contact
+            keys.add(_normalize_name(full))
+            keys.add(_normalize_name(reversed_full))
+        for key in keys:
+            contact_by_key.setdefault(key, []).append(contact)
 
     updated = 0
     not_found = 0
@@ -248,10 +254,11 @@ async def import_emails_from_rows(
 
     for row in rows:
         key = _normalize_name(row.nom)
-        found = contact_by_key.get(key)
-        if found is None:
+        matches = contact_by_key.get(key, [])
+        if len(matches) != 1:
             not_found += 1
             continue
+        found = matches[0]
         if found.email:
             already_has_email += 1
             continue

--- a/backend/services/contact.py
+++ b/backend/services/contact.py
@@ -1,5 +1,6 @@
 """Contact service — CRUD and search."""
 
+import unicodedata
 from datetime import date
 from decimal import Decimal
 
@@ -13,6 +14,8 @@ from backend.models.invoice import Invoice, InvoiceStatus
 from backend.models.payment import Payment
 from backend.schemas.contact import (
     ContactCreate,
+    ContactEmailImportResult,
+    ContactEmailImportRow,
     ContactHistory,
     ContactInvoiceSummary,
     ContactPaymentSummary,
@@ -212,3 +215,55 @@ async def mark_creance_douteuse(
     await db.refresh(debit_entry)
     await db.refresh(credit_entry)
     return debit_entry, credit_entry
+
+
+def _normalize_name(name: str) -> str:
+    """Normalize a name for fuzzy matching: lowercase, strip accents, collapse whitespace."""
+    nfkd = unicodedata.normalize("NFKD", name.lower().strip())
+    no_accents = "".join(c for c in nfkd if not unicodedata.combining(c))
+    return " ".join(no_accents.split())
+
+
+async def import_emails_from_rows(
+    db: AsyncSession,
+    rows: list[ContactEmailImportRow],
+) -> ContactEmailImportResult:
+    """Bulk-enrich contacts with email addresses matched by name."""
+    result = await db.execute(select(Contact).where(Contact.is_active == True))  # noqa: E712
+    all_contacts = list(result.scalars().all())
+
+    # Build lookup: normalized name → contact (last write wins for duplicates)
+    contact_by_key: dict[str, Contact] = {}
+    for contact in all_contacts:
+        contact_by_key[_normalize_name(contact.nom)] = contact
+        if contact.prenom:
+            full = f"{contact.nom} {contact.prenom}"
+            contact_by_key[_normalize_name(full)] = contact
+            reversed_full = f"{contact.prenom} {contact.nom}"
+            contact_by_key[_normalize_name(reversed_full)] = contact
+
+    updated = 0
+    not_found = 0
+    already_has_email = 0
+
+    for row in rows:
+        key = _normalize_name(row.nom)
+        found = contact_by_key.get(key)
+        if found is None:
+            not_found += 1
+            continue
+        if found.email:
+            already_has_email += 1
+            continue
+        found.email = row.email
+        updated += 1
+
+    if updated > 0:
+        await db.commit()
+
+    return ContactEmailImportResult(
+        rows_processed=len(rows),
+        updated=updated,
+        not_found=not_found,
+        already_has_email=already_has_email,
+    )

--- a/doc/backlog.md
+++ b/doc/backlog.md
@@ -13,7 +13,7 @@ Quand un sujet est livré, mettre à jour `CHANGELOG.md` et passer le ticket en 
 
 | ID | Titre | Prio | Est. | Créé | Démarré | Terminé |
 | --- | --- | --- | --- | --- | --- | --- |
-| BL-077 | Refactoring vues volumineuses | P2 | ~30 min | 2026-04-23 | 2026-04-24 | 2026-04-24 |
+| TEC-077 | Refactoring vues volumineuses | P2 | ~30 min | 2026-04-23 | 2026-04-24 | 2026-04-24 |
 
 > ✅ Lot G terminé — PR #43 mergée le 2026-04-24
 
@@ -21,93 +21,93 @@ Quand un sujet est livré, mettre à jour `CHANGELOG.md` et passer le ticket en 
 
 | ID | Titre | Prio | Est. | Créé | Démarré | Terminé |
 | --- | --- | --- | --- | --- | --- | --- |
-| BL-038 | Numéro de version dans l'UI | P3 | ~5 min | 2026-04-21 | 2026-04-24 | |
-| BL-037 | Profil via clic sur le nom | P3 | ~5 min | 2026-04-21 | 2026-04-24 | |
-| BL-035 | Onglets clients / fournisseurs | P2 | ~15 min | 2026-04-21 | 2026-04-24 | |
-| BL-040 | Import one-shot emails contacts | P2 | ~10 min | 2026-04-21 | 2026-04-24 | |
+| CHR-038 | Numéro de version dans l'UI | P3 | ~5 min | 2026-04-21 | 2026-04-24 | 2026-04-24 |
+| BIZ-037 | Profil via clic sur le nom | P3 | ~5 min | 2026-04-21 | 2026-04-24 | 2026-04-24 |
+| BIZ-035 | Onglets clients / fournisseurs | P2 | ~15 min | 2026-04-21 | 2026-04-24 | 2026-04-24 |
+| BIZ-040 | Import one-shot emails contacts | P2 | ~10 min | 2026-04-21 | 2026-04-24 | 2026-04-24 |
 
 ### Lot H — Architecture multi-compte (~45 min) — v0.6
 
 | ID | Titre | Prio | Est. | Créé | Démarré | Terminé |
 | --- | --- | --- | --- | --- | --- | --- |
-| BL-034 | Support multi-compte banque | P2 | ~45 min | 2026-04-21 | | |
+| BIZ-034 | Support multi-compte banque | P2 | ~45 min | 2026-04-21 | | |
 
 ## Hors lots
 
 | ID | Titre | Prio | Est. | Créé | Démarré | Terminé |
 | --- | --- | --- | --- | --- | --- | --- |
-| BL-019 | README et documentation technique | P1 | ~10 min | 2026-04-13 | 2026-04-21 | |
-| BL-021 | Manuel utilisateur illustré | P1 | ~20 min | 2026-04-13 | 2026-04-13 | |
-| BL-033 | Comparaison chèques inter-exercices | P1 | ~15 min | 2026-04-21 | | |
-| BL-039 | Revalidation scénarios facture / email | P1 | ~10 min | 2026-04-21 | | |
-| BL-020 | Documentation de contribution | P3 | ~5 min | 2026-04-13 | 2026-04-21 | |
-| BL-078 | Squelette i18n anglais | P3 | ~5 min | 2026-04-23 | | |
-| BL-082 | Descriptions Swagger enrichies | P3 | ~10 min | 2026-04-23 | | |
+| CHR-019 | README et documentation technique | P1 | ~10 min | 2026-04-13 | 2026-04-21 | |
+| CHR-021 | Manuel utilisateur illustré | P1 | ~20 min | 2026-04-13 | 2026-04-13 | |
+| BIZ-033 | Comparaison chèques inter-exercices | P1 | ~15 min | 2026-04-21 | | |
+| TEC-039 | Revalidation scénarios facture / email | P1 | ~10 min | 2026-04-21 | | |
+| CHR-020 | Documentation de contribution | P3 | ~5 min | 2026-04-13 | 2026-04-21 | |
+| CHR-078 | Squelette i18n anglais | P3 | ~5 min | 2026-04-23 | | |
+| CHR-082 | Descriptions Swagger enrichies | P3 | ~10 min | 2026-04-23 | | |
 
 ---
 
 ## Détails
 
-### BL-019 — README et documentation technique
+### CHR-019 — README et documentation technique
 
 README recentré FR+EN, `doc/dev/exploitation.md` couvre config/Docker/volumes/backups,
 guide d'installation FR+EN dans `doc/user/installation.md`, `.env.example` documenté.
 Reste à revalider en tests réels d'installation et de mise à jour.
 
-### BL-020 — Documentation de contribution
+### CHR-020 — Documentation de contribution
 
 `doc/dev/contribuer.md` centralise setup local, `dev.ps1`, checks backend/frontend,
 conventions et workflow Git. Reste à valider sur un vrai cycle setup → checks → PR.
 
-### BL-021 — Manuel utilisateur illustré
+### CHR-021 — Manuel utilisateur illustré
 
 Manuel FR pas à pas couvrant les parcours métier essentiels. Structure posée, socle
 textuel consolidé. Reste : enrichissement visuel (captures annotées homogènes).
 Séquence : lot 1 (connexion, contacts, facture, paiement) → lot 2 (achat, caisse,
 banque) → lot 3 (import Excel, comptabilité, FAQ) → lot 4 (captures, stabilisation).
 
-### BL-033 — Comparaison chèques inter-exercices
+### BIZ-033 — Comparaison chèques inter-exercices
 
 Un chèque reçu en N−1 mais remis en banque en N crée un écart trompeur dans les
 validations par exercice. Convention métier à expliciter, puis aligner comparaison
 d'import et documentation. Cf. `doc/dev/bl-026-validation-2025-working-notes.md`.
 
-### BL-034 — Support multi-compte banque
+### BIZ-034 — Support multi-compte banque
 
 Distinguer compte courant et compte épargne dans les données, imports et écrans.
 Décisions métier nécessaires avant implémentation.
 
-### BL-035 — Onglets clients / fournisseurs
+### BIZ-035 — Onglets clients / fournisseurs
 
 Séparer les contacts clients et fournisseurs dans deux onglets dédiés.
 
-### BL-037 — Profil via clic sur le nom
+### BIZ-037 — Profil via clic sur le nom
 
 Remplacer l'entrée menu « Mon profil » par un accès via clic sur le nom utilisateur.
 
-### BL-038 — Numéro de version dans l'UI
+### CHR-038 — Numéro de version dans l'UI
 
 Afficher un numéro de version discret mais visible dans l'interface.
 
-### BL-039 — Revalidation scénarios facture / email
+### TEC-039 — Revalidation scénarios facture / email
 
 Rejouer et fiabiliser les scénarios d'édition de facture client et d'envoi par e-mail
 avec validation explicite du comportement attendu.
 
-### BL-040 — Import one-shot emails contacts
+### BIZ-040 — Import one-shot emails contacts
 
 Import d'une liste d'adresses e-mail pour enrichir les contacts clients existants.
 
-### BL-077 — Refactoring vues volumineuses
+### TEC-077 — Refactoring vues volumineuses
 
 `ImportExcelView` (2 873 L), `BankView` (2 215 L), `SettingsView` (1 077 L) à éclater
 en sous-composants < 500 lignes.
 
-### BL-078 — Squelette i18n anglais
+### CHR-078 — Squelette i18n anglais
 
 Créer `en.ts` avec les clés structurelles pour préparer la localisation anglaise.
 
-### BL-082 — Descriptions Swagger enrichies
+### CHR-082 — Descriptions Swagger enrichies
 
 Ajouter `description=` et `response_description=` sur les endpoints principaux.
 
@@ -117,39 +117,39 @@ Ajouter `description=` et `response_description=` sur les endpoints principaux.
 
 | Lot | Nom | Version | Tickets | Terminé |
 | --- | --- | --- | --- | --- |
-| 1 | Quick wins P3 | v0.2 | BL-064, BL-062, BL-066, BL-063 | 2026-04-22 |
-| 2 | Tests au vert | v0.2 | BL-048 | 2026-04-22 |
-| 3 | Sécurité sans impact structurel | v0.2 | BL-047, BL-052, BL-055, BL-060, BL-051 | 2026-04-22 |
-| 4 | Qualité backend sans impact API | v0.2 | BL-065, BL-057, BL-059 | 2026-04-22 |
-| 5 | Sécurité auth (full-stack) | v0.2 | BL-045, BL-053, BL-046 | 2026-04-22 |
-| 6 | DevOps Docker | v0.2 | BL-054, BL-061 | 2026-04-22 |
-| 7 | Refactoring structurel | v0.2 | BL-050, BL-058 | 2026-04-22 |
-| 8 | Chantiers longs | v0.2 | BL-056, BL-049 | 2026-04-22 |
-| A | Backend rapide | v0.3 | BL-085 | 2026-04-23 |
-| B | UX quick wins | v0.3 | BL-070, BL-072, BL-074, BL-084, BL-042 | 2026-04-23 |
-| C | Dashboard interactif | v0.3 | BL-075, BL-073 | 2026-04-23 |
-| D | Polish UI | v0.3 | BL-071, BL-043 | 2026-04-23 |
-| F | Tests | v0.4 | BL-079, BL-080, BL-081 | 2026-04-24 |
+| 1 | Quick wins P3 | v0.2 | CHR-064, CHR-062, TEC-066, TEC-063 | 2026-04-22 |
+| 2 | Tests au vert | v0.2 | TEC-048 | 2026-04-22 |
+| 3 | Sécurité sans impact structurel | v0.2 | TEC-047, TEC-052, TEC-055, TEC-060, TEC-051 | 2026-04-22 |
+| 4 | Qualité backend sans impact API | v0.2 | TEC-065, TEC-057, TEC-059 | 2026-04-22 |
+| 5 | Sécurité auth (full-stack) | v0.2 | TEC-045, BIZ-053, TEC-046 | 2026-04-22 |
+| 6 | DevOps Docker | v0.2 | CHR-054, CHR-061 | 2026-04-22 |
+| 7 | Refactoring structurel | v0.2 | TEC-050, TEC-058 | 2026-04-22 |
+| 8 | Chantiers longs | v0.2 | BIZ-056, TEC-049 | 2026-04-22 |
+| A | Backend rapide | v0.3 | TEC-085 | 2026-04-23 |
+| B | UX quick wins | v0.3 | BIZ-070, BIZ-072, BIZ-074, BIZ-084, BIZ-042 | 2026-04-23 |
+| C | Dashboard interactif | v0.3 | BIZ-075, BIZ-073 | 2026-04-23 |
+| D | Polish UI | v0.3 | BIZ-071, BIZ-043 | 2026-04-23 |
+| F | Tests | v0.4 | TEC-079, TEC-080, TEC-081 | 2026-04-24 |
 
-Tickets fermés hors lots : BL-067, BL-068, BL-069, BL-076, BL-083, BL-036, BL-041.
-Tickets fermés pré-audit : BL-001 → BL-023.
+Tickets fermés hors lots : TEC-067, TEC-068, BIZ-069, BIZ-076, CHR-083, BIZ-036, BIZ-041.
+Tickets fermés pré-audit : CHR-001, CHR-002, BIZ-003 – BIZ-018, CHR-019 – CHR-021, BIZ-022 – BIZ-023.
 
 <details>
 <summary>Historique des estimations — lots techniques 1-8 (2026-04-22)</summary>
 
 Total estimé initial : ~40h — total révisé : ~55h.
-Principaux postes de dérapage : quality gates (~10 min/commit), tests d'intégration, migrations Alembic, refactoring BL-050.
+Principaux postes de dérapage : quality gates (~10 min/commit), tests d'intégration, migrations Alembic, refactoring TEC-050.
 
 ### Lot 1 — Quick wins P3 — ~45 min
 
 | Ticket | Estimation | Détail |
 | --- | --- | --- |
-| BL-064 | 5 min | Supprimer un fichier + vérifier qu'il n'est pas importé |
-| BL-062 | 5 min | Changer une string dans `package.json` |
-| BL-066 | 20 min | Remplacer le pattern `global` par `@lru_cache`, vérifier les tests |
-| BL-063 | 15 min | Remplacer 2 noms dans les fixtures + migration Alembic si nécessaire |
+| CHR-064 | 5 min | Supprimer un fichier + vérifier qu'il n'est pas importé |
+| CHR-062 | 5 min | Changer une string dans `package.json` |
+| TEC-066 | 20 min | Remplacer le pattern `global` par `@lru_cache`, vérifier les tests |
+| TEC-063 | 15 min | Remplacer 2 noms dans les fixtures + migration Alembic si nécessaire |
 
-### Lot 2 — Tests au vert (BL-048) — ~2h
+### Lot 2 — Tests au vert (TEC-048) — ~2h
 
 11 échecs dans `excel_import_parsers` / `excel_import_parsing` + 1 erreur API de test. Suite déjà au vert (739/739) après corrections antérieures.
 
@@ -157,361 +157,361 @@ Principaux postes de dérapage : quality gates (~10 min/commit), tests d'intégr
 
 | Ticket | Est. initiale | Est. révisée | Temps réel | Détail |
 | --- | --- | --- | --- | --- |
-| BL-047 | 30 min | 1h | ~1h15 | Middleware 5 en-têtes + test CSP PrimeVue |
-| BL-052 | 20 min | 30 min | ~40 min | Conditionner endpoint sur `settings.debug` |
-| BL-055 | 20 min | 30 min | ~25 min | Paramètre `cors_allowed_origins` |
-| BL-060 | 30 min | 45 min | ~30 min | Retirer `create_all` de `init_db()` |
-| BL-051 | 50 min | 1h15 | ~50 min | `MAX(entry_number)` + lock + migration |
+| TEC-047 | 30 min | 1h | ~1h15 | Middleware 5 en-têtes + test CSP PrimeVue |
+| TEC-052 | 20 min | 30 min | ~40 min | Conditionner endpoint sur `settings.debug` |
+| TEC-055 | 20 min | 30 min | ~25 min | Paramètre `cors_allowed_origins` |
+| TEC-060 | 30 min | 45 min | ~30 min | Retirer `create_all` de `init_db()` |
+| TEC-051 | 50 min | 1h15 | ~50 min | `MAX(entry_number)` + lock + migration |
 
 ### Lot 4 — Qualité backend sans impact API — ~6h
 
 | Ticket | Est. initiale | Est. révisée | Temps réel | Détail |
 | --- | --- | --- | --- | --- |
-| BL-065 | 1h | 1h30 | ~1h30 | Déplacer attributs transients vers `PaymentRead` |
-| BL-057 | 2h | 2h30 | ~3h30 | `TypeDecorator` Decimal + 63 occurrences |
-| BL-059 | 1h30 | 2h | ~45 min | `limit=100` / `max=1000` sur tous les endpoints |
+| TEC-065 | 1h | 1h30 | ~1h30 | Déplacer attributs transients vers `PaymentRead` |
+| TEC-057 | 2h | 2h30 | ~3h30 | `TypeDecorator` Decimal + 63 occurrences |
+| TEC-059 | 1h30 | 2h | ~45 min | `limit=100` / `max=1000` sur tous les endpoints |
 
 ### Lot 5 — Sécurité auth (full-stack) — ~10h
 
 | Ticket | Est. initiale | Est. révisée | Temps réel | Détail |
 | --- | --- | --- | --- | --- |
-| BL-045 | 1h | 1h30 | ~1h | `slowapi` rate limiting sur `/auth/login` |
-| BL-053 | 2h | 3h | ~1h30 | Migration `must_change_password` + guard |
-| BL-046 | 4h | 5h30 | — | Cookie `HttpOnly` + intercepteur Axios + `/auth/refresh` |
+| TEC-045 | 1h | 1h30 | ~1h | `slowapi` rate limiting sur `/auth/login` |
+| BIZ-053 | 2h | 3h | ~1h30 | Migration `must_change_password` + guard |
+| TEC-046 | 4h | 5h30 | — | Cookie `HttpOnly` + intercepteur Axios + `/auth/refresh` |
 
 ### Lot 6 — DevOps Docker — ~1h30
 
 | Ticket | Est. initiale | Est. révisée | Détail |
 | --- | --- | --- | --- |
-| BL-054 | 40 min | 50 min | `entrypoint.sh` avec gestion d'erreur |
-| BL-061 | 20 min | 20 min | `HEALTHCHECK` Docker + docker-compose |
+| CHR-054 | 40 min | 50 min | `entrypoint.sh` avec gestion d'erreur |
+| CHR-061 | 20 min | 20 min | `HEALTHCHECK` Docker + docker-compose |
 
 ### Lot 7 — Refactoring structurel — ~12h
 
 | Ticket | Est. initiale | Est. révisée | Détail |
 | --- | --- | --- | --- |
-| BL-050 | 6h | 9h | Éclater `excel_import.py` (5 038 L) en package |
-| BL-058 | 2h | 1h | Typer les `except Exception` |
+| TEC-050 | 6h | 9h | Éclater `excel_import.py` (5 038 L) en package |
+| TEC-058 | 2h | 1h | Typer les `except Exception` |
 
 ### Lot 8 — Chantiers longs
 
 | Ticket | Est. initiale | Est. révisée | Détail |
 | --- | --- | --- | --- |
-| BL-056 | 3-4h | 2h | Table d'audit + middleware + 4 types d'événements |
-| BL-049 | 10-15h | 12-20h | Palier 34 % → 60 % couverture de test |
+| BIZ-056 | 3-4h | 2h | Table d'audit + middleware + 4 types d'événements |
+| TEC-049 | 10-15h | 12-20h | Palier 34 % → 60 % couverture de test |
 
 </details>
 
 <details>
 <summary>Détails des sujets fermés — cliquer pour développer</summary>
 
-### BL-001 — Stabiliser la méthode de triage du backlog
+### CHR-001 — Stabiliser la méthode de triage du backlog
 
 - **Dates** : `created=2026-04-12`, `completed=2026-04-12`
 - **Livré** : backlog utilisé comme support versionné avec statuts, priorités et mises à jour récurrentes.
 
-### BL-002 — Documentation utilisateur import/reset
+### CHR-002 — Documentation utilisateur import/reset
 
 - **Dates** : `created=2026-04-12`, `completed=2026-04-12`
 - **Livré** : documentation rédigée dans `doc/user/import-excel-et-reinitialisation.md`.
 
-### BL-003 — Campagne de retest métier sur imports réels
+### BIZ-003 — Campagne de retest métier sur imports réels
 
 - **Dates** : `created=2026-04-12`, `completed=2026-04-12`
 - **Livré** : rejeu réel confirmé sans écart bloquant, procédure ajustée pour exercices/compteurs.
 
-### BL-004 — Historique d'import réversible
+### BIZ-004 — Historique d'import réversible
 
 - **Dates** : `created=2026-04-12`, `started=2026-04-20`, `completed=2026-04-20`
 - **Livré** : backend `runs`, `operations`, `effects` réversibles, API cycle `prepare → execute → undo/redo`, UI prévisualisation + historique. Stabilisation rapprochement paiement/facture intra-run.
 
-### BL-005 — Politique de coexistence import / écritures existantes
+### BIZ-005 — Politique de coexistence import / écritures existantes
 
 - **Dates** : `created=2026-04-12`, `started=2026-04-19`, `completed=2026-04-19`
-- **Livré** : politique explicitée dans `doc/dev/bl-005-politique-coexistence-imports.md`, trois diagnostics : `entry-existing`, `entry-covered-by-solde`, `entry-near-manual`.
+- **Livré** : politique explicitée dans `doc/dev/BIZ-005-politique-coexistence-imports.md`, trois diagnostics : `entry-existing`, `entry-covered-by-solde`, `entry-near-manual`.
 
-### BL-006 — Warnings de dépréciation FastAPI
+### CHR-006 — Warnings de dépréciation FastAPI
 
 - **Dates** : `created=2026-04-12`, `started=2026-04-21`, `completed=2026-04-21`
 - **Livré** : `HTTP_422_UNPROCESSABLE_ENTITY` → `HTTP_422_UNPROCESSABLE_CONTENT`, zéro warning.
 
-### BL-007 — Source de vérité backlog vs issues GitHub
+### CHR-007 — Source de vérité backlog vs issues GitHub
 
 - **Dates** : `created=2026-04-12`, `completed=2026-04-13`
 - **Livré** : convention actée — `doc/backlog.md` = source de vérité.
 
-### BL-008 — Import Excel comme validation itérative de convergence
+### BIZ-008 — Import Excel comme validation itérative de convergence
 
 - **Dates** : `created=2026-04-12`, `started=2026-04-18`, `completed=2026-04-18`
-- **Livré** : modes `convergence globale` et `validation moteur Gestion`, preview bidirectionnelle, script `scripts/run_excel_convergence_preview.py`. Documentation dans `doc/dev/bl-008-recette-convergence.md`.
+- **Livré** : modes `convergence globale` et `validation moteur Gestion`, preview bidirectionnelle, script `scripts/run_excel_convergence_preview.py`. Documentation dans `doc/dev/BIZ-008-recette-convergence.md`.
 - **Détail** : grille de contrôle par domaine (factures, paiements, banque, caisse, comptes pivots), politique d'écarts résiduels, périmètre asymétrique `Solde ↔ Excel` par exercice.
 
-### BL-009 — Enrichir le plan comptable par défaut
+### BIZ-009 — Enrichir le plan comptable par défaut
 
 - **Dates** : `created=2026-04-12`, `completed=2026-04-12`
 - **Livré** : seed enrichi avec comptes réels, sous-comptes historiques conservés inactifs.
 
-### BL-010 — Stratégie de clôture des exercices historiques
+### BIZ-010 — Stratégie de clôture des exercices historiques
 
 - **Dates** : `created=2026-04-12`, `completed=2026-04-12`
 - **Livré** : exercices historiques ouverts pendant reprise, clôture administrative sans écritures de clôture.
 
-### BL-011 — Exercice courant global
+### BIZ-011 — Exercice courant global
 
 - **Dates** : `created=2026-04-12`, `completed=2026-04-12`
 - **Livré** : store global d'exercice + sélecteur partagé + filtrage métier par défaut.
 
-### BL-012 — Liste des paiements : référence et édition
+### BIZ-012 — Liste des paiements : référence et édition
 
 - **Dates** : `created=2026-04-12`, `completed=2026-04-12`
 - **Livré** : colonne Référence + bouton d'édition par ligne + dialogue `PUT /payments/{id}`.
 
-### BL-013 — Journal de caisse : référence, détail et édition
+### BIZ-013 — Journal de caisse : référence, détail et édition
 
 - **Dates** : `created=2026-04-12`, `completed=2026-04-12`
 - **Livré** : référence visible, panneau de détail, édition directe, recalcul soldes après modification.
 
-### BL-014 — Journal comptable : lisibilité et navigation
+### BIZ-014 — Journal comptable : lisibilité et navigation
 
 - **Dates** : `created=2026-04-12`, `completed=2026-04-12`
 - **Livré** : libellés comptes, références métier, tiers, détail, édition manuelles, navigation factures.
 
-### BL-015 — Reset sélectif orienté reprise d'import
+### BIZ-015 — Reset sélectif orienté reprise d'import
 
 - **Dates** : `created=2026-04-13`, `started=2026-04-20`, `completed=2026-04-20`
 - **Livré** : reset sélectif par type d'import + exercice avec prévisualisation, UI dans Paramètres, suppression des dépendances métier dérivées.
 
-### BL-016 — Harmonisation i18n et microcopie UI
+### BIZ-016 — Harmonisation i18n et microcopie UI
 
 - **Dates** : `created=2026-04-13`, `started=2026-04-14`, `completed=2026-04-14`
 - **Livré** : clés i18n cohérentes sur Banque, Caisse, Salaires (compteurs, états vides, libellés).
 
-### BL-017 — Formats de dates et périodes en français
+### BIZ-017 — Formats de dates et périodes en français
 
 - **Dates** : `created=2026-04-13`, `started=2026-04-14`, `completed=2026-04-14`
 - **Livré** : helper partagé pour mois en français, appliqué sur Salaires et Dashboard mensuel.
 
-### BL-018 — Lisibilité des écrans de liste
+### BIZ-018 — Lisibilité des écrans de liste
 
 - **Dates** : `created=2026-04-13`, `started=2026-04-14`, `completed=2026-04-14`
 - **Livré** : socle DataTable partagé (filtres texte/dates/intervalles/multi-sélection, compteurs, tri, saisie date FR/ISO).
 
-### BL-022 — Gestion des utilisateurs, rôles et sécurité
+### BIZ-022 — Gestion des utilisateurs, rôles et sécurité
 
 - **Dates** : `created=2026-04-13`, `started=2026-04-13`, `completed=2026-04-19`
 - **Livré** : cycle de vie complet : rôles métier, administration comptes, profil, changement MDP, réinitialisation admin, invalidation jetons.
 
-### BL-023 — Matrice d'autorisations par rôle
+### BIZ-023 — Matrice d'autorisations par rôle
 
 - **Dates** : `created=2026-04-13`, `started=2026-04-14`, `completed=2026-04-14`
 - **Livré** : séparation Gestion/Comptabilité dans la navigation, guards frontend par domaine, renommage Gestionnaire/Comptable, permissions backend alignées.
 
-### BL-036 — Carte « restant en retard » cliquable
+### BIZ-036 — Carte « restant en retard » cliquable
 
 - **Dates** : `created=2026-04-21`, `completed=2026-04-23`
-- **Livré** : absorbé par BL-075 (KPI dashboard cliquables).
+- **Livré** : absorbé par BIZ-075 (KPI dashboard cliquables).
 
-### BL-041 — Carte « non remis » cliquable
+### BIZ-041 — Carte « non remis » cliquable
 
 - **Dates** : `created=2026-04-21`, `completed=2026-04-23`
-- **Livré** : absorbé par BL-075 (KPI dashboard cliquables).
+- **Livré** : absorbé par BIZ-075 (KPI dashboard cliquables).
 
-### BL-042 — Bouton reset filtres tables
+### BIZ-042 — Bouton reset filtres tables
 
 - **Dates** : `created=2026-04-21`, `completed=2026-04-23`
 - **Livré** : bouton reset sur tous les filtres de toutes les tables.
 
-### BL-043 — Combos comptes comptables couleur
+### BIZ-043 — Combos comptes comptables couleur
 
 - **Dates** : `created=2026-04-21`, `completed=2026-04-23`
 - **Livré** : combos affichant numéro, nom et couleur des comptes suivis.
 
-### BL-045 — Rate limiting `/auth/login`
+### TEC-045 — Rate limiting `/auth/login`
 
 - **Dates** : `created=2026-04-22`, `completed=2026-04-23`
 - **Livré** : middleware `slowapi` 5 req/min par IP, bypass configurable pour tests.
 
-### BL-046 — Refresh token cookie HttpOnly
+### TEC-046 — Refresh token cookie HttpOnly
 
 - **Dates** : `created=2026-04-22`, `completed=2026-04-22`
 - **Livré** : cookie `HttpOnly`/`Secure`/`SameSite=Strict`, endpoint `POST /auth/logout`, intercepteur Axios `withCredentials: true`, 6 tests dédiés.
 
-### BL-047 — En-têtes de sécurité HTTP
+### TEC-047 — En-têtes de sécurité HTTP
 
 - **Dates** : `created=2026-04-22`, `completed=2026-04-22`
 - **Livré** : middleware CSP, HSTS, X-Content-Type-Options, X-Frame-Options. `dark-mode-init.js` extrait pour CSP `script-src 'self'`.
 
-### BL-048 — Corriger les tests en échec
+### TEC-048 — Corriger les tests en échec
 
 - **Dates** : `created=2026-04-22`, `completed=2026-04-22`
-- **Livré** : suite 739/739 au vert. Test API adapté pour `@lru_cache` (BL-066).
+- **Livré** : suite 739/739 au vert. Test API adapté pour `@lru_cache` (TEC-066).
 
-### BL-049 — Remonter la couverture de test
+### TEC-049 — Remonter la couverture de test
 
 - **Dates** : `created=2026-04-22`, `completed=2026-04-22`
 - **Livré** : +44 tests (812 → 856), couverture 29% → 71%. Services critiques ≥ 90% : accounting_engine 92%, invoice 93%, payment 90%, fiscal_year ~95%, salary ~95%.
 
-### BL-050 — Refactorer `excel_import.py` en package
+### TEC-050 — Refactorer `excel_import.py` en package
 
 - **Dates** : `created=2026-04-22`, `completed=2026-04-22`
 - **Livré** : monolith 5 567 lignes éclaté en 16 sous-modules + `__init__.py` re-export. Aucune dépendance circulaire.
 
-### BL-051 — Numérotation des écritures thread-safe
+### TEC-051 — Numérotation des écritures thread-safe
 
 - **Dates** : `created=2026-04-22`, `completed=2026-04-22`
 - **Livré** : `COUNT(*)` → `MAX(entry_number)` + lock, migration, tests de concurrence.
 
-### BL-052 — Désactiver `reset-db` en production
+### TEC-052 — Désactiver `reset-db` en production
 
 - **Dates** : `created=2026-04-22`, `completed=2026-04-22`
 - **Livré** : endpoint conditionné à `settings.debug`.
 
-### BL-053 — Changement MDP obligatoire au premier login
+### BIZ-053 — Changement MDP obligatoire au premier login
 
 - **Dates** : `created=2026-04-22`, `completed=2026-04-23`
 - **Livré** : champ `must_change_password` (migration 0022), middleware 403, redirection frontend, 11 tests intégration + 2 tests frontend.
 
-### BL-054 — Séparer migrations du démarrage Uvicorn
+### CHR-054 — Séparer migrations du démarrage Uvicorn
 
 - **Dates** : `created=2026-04-22`, `completed=2026-04-22`
 - **Livré** : `entrypoint.sh` avec `set -e`, Dockerfile mis à jour avec `ENTRYPOINT`.
 
-### BL-055 — CORS configurable pour la production
+### TEC-055 — CORS configurable pour la production
 
 - **Dates** : `created=2026-04-22`, `completed=2026-04-22`
 - **Livré** : paramètre `cors_allowed_origins` dans les settings.
 
-### BL-056 — Journal d'audit structuré
+### BIZ-056 — Journal d'audit structuré
 
 - **Dates** : `created=2026-04-22`, `completed=2026-04-23`
 - **Livré** : modèle `AuditLog` + service `record_audit` + migration 0023. Événements : auth (login/logout/password), admin (user CRUD, reset_db, selective_reset). 14 tests.
 
-### BL-057 — TypeDecorator Decimal pour l'ORM
+### TEC-057 — TypeDecorator Decimal pour l'ORM
 
 - **Dates** : `created=2026-04-22`, `completed=2026-04-22`
 - **Livré** : `DecimalType(TypeDecorator)` sur toutes les colonnes monétaires, ~63 casts `Decimal(str())` retirés.
 
-### BL-058 — Typer les exceptions de l'import Excel
+### TEC-058 — Typer les exceptions de l'import Excel
 
 - **Dates** : `created=2026-04-22`, `completed=2026-04-22`
 - **Livré** : `ImportFileOpenError`, `ImportSheetError` dans `_exceptions.py`, mapping typé dans routeur. 10 tests ajoutés.
 
-### BL-059 — Pagination bornée par défaut
+### TEC-059 — Pagination bornée par défaut
 
 - **Dates** : `created=2026-04-22`, `completed=2026-04-22`
 - **Livré** : `limit=100` / `max=1000` sur tous les endpoints de liste. Frontend et tests adaptés.
 
-### BL-060 — Retirer `create_all` de `init_db()`
+### TEC-060 — Retirer `create_all` de `init_db()`
 
 - **Dates** : `created=2026-04-22`, `completed=2026-04-22`
 - **Livré** : `create_all` conservé uniquement dans `conftest.py`, Alembic seul en prod.
 
-### BL-061 — Docker HEALTHCHECK
+### CHR-061 — Docker HEALTHCHECK
 
 - **Dates** : `created=2026-04-22`, `completed=2026-04-22`
 - **Livré** : `GET /api/health` (200), `HEALTHCHECK` dans Dockerfile, `healthcheck:` dans docker-compose.
 
-### BL-062 — Synchroniser les versions frontend / backend
+### CHR-062 — Synchroniser les versions frontend / backend
 
 - **Dates** : `created=2026-04-22`, `completed=2026-04-22`
 - **Livré** : `frontend/package.json` aligné sur `0.1.0`.
 
-### BL-063 — Retirer les noms personnels du plan comptable (RGPD)
+### TEC-063 — Retirer les noms personnels du plan comptable (RGPD)
 
 - **Dates** : `created=2026-04-22`, `completed=2026-04-22`
 - **Livré** : noms remplacés par `Client litigieux 1/2`. Seed ne touche pas les données existantes.
 
-### BL-064 — Supprimer `stores/counter.ts`
+### CHR-064 — Supprimer `stores/counter.ts`
 
 - **Dates** : `created=2026-04-22`, `completed=2026-04-22`
 - **Livré** : fichier supprimé, aucune référence dans le code.
 
-### BL-065 — Éliminer `__allow_unmapped__` de Payment
+### TEC-065 — Éliminer `__allow_unmapped__` de Payment
 
 - **Dates** : `created=2026-04-22`, `completed=2026-04-22`
 - **Livré** : attributs transients déplacés vers `PaymentRead` via `_to_payment_read()`.
 
-### BL-066 — Settings singleton `@lru_cache`
+### TEC-066 — Settings singleton `@lru_cache`
 
 - **Dates** : `created=2026-04-22`, `completed=2026-04-22`
 - **Livré** : `@lru_cache(maxsize=1)` sur `get_settings()`, variable globale supprimée.
 
-### BL-067 — Gestionnaire d'erreurs global FastAPI
+### TEC-067 — Gestionnaire d'erreurs global FastAPI
 
 - **Dates** : `created=2026-04-23`, `completed=2026-04-23`
 - **Livré** : middleware `UnhandledExceptionMiddleware` → JSON 500 `{"detail": ..., "code": "INTERNAL_SERVER_ERROR"}`, log serveur. 5 tests.
 
-### BL-068 — Désactiver Swagger/ReDoc en production
+### TEC-068 — Désactiver Swagger/ReDoc en production
 
 - **Dates** : `created=2026-04-23`, `completed=2026-04-23`
 - **Livré** : `docs_url`, `redoc_url`, `openapi_url` conditionnés à `cfg.debug`.
 
-### BL-069 — Endpoint de sauvegarde SQLite
+### BIZ-069 — Endpoint de sauvegarde SQLite
 
 - **Dates** : `created=2026-04-23`, `completed=2026-04-23`
 - **Livré** : `POST /api/settings/backup` avec `sqlite3.backup()` + rotation 5 fichiers.
 
-### BL-070 — Page 404 dédiée
+### BIZ-070 — Page 404 dédiée
 
 - **Dates** : `created=2026-04-23`, `completed=2026-04-23`
 - **Livré** : `NotFoundView.vue` avec icône, titre i18n, bouton retour. Catch-all router remplacé.
 
-### BL-071 — Skeleton loaders
+### BIZ-071 — Skeleton loaders
 
 - **Dates** : `created=2026-04-23`, `completed=2026-04-23`
 - **Livré** : `<Skeleton>` PrimeVue sur les écrans de liste principaux.
 
-### BL-072 — Fil d'Ariane (Breadcrumb)
+### BIZ-072 — Fil d'Ariane (Breadcrumb)
 
 - **Dates** : `created=2026-04-23`, `completed=2026-04-23`
 - **Livré** : composable `useBreadcrumb` + `<Breadcrumb>` PrimeVue via meta routes `label`/`breadcrumbParent`.
 
-### BL-073 — Raccourcis clavier
+### BIZ-073 — Raccourcis clavier
 
 - **Dates** : `created=2026-04-23`, `completed=2026-04-23`
 - **Livré** : composable `useKeyboardShortcuts` (Ctrl+N, Ctrl+S, Escape).
 
-### BL-074 — Bandeau connexion perdue
+### BIZ-074 — Bandeau connexion perdue
 
 - **Dates** : `created=2026-04-23`, `completed=2026-04-23`
 - **Livré** : composable `useNetworkStatus` + `AppOfflineBanner.vue` (events online/offline + intercepteur Axios).
 
-### BL-075 — Dashboard KPI cliquables
+### BIZ-075 — Dashboard KPI cliquables
 
 - **Dates** : `created=2026-04-23`, `completed=2026-04-23`
-- **Livré** : KPI cliquables vers listes filtrées. Complète BL-036 et BL-041.
+- **Livré** : KPI cliquables vers listes filtrées. Complète BIZ-036 et BIZ-041.
 
-### BL-076 — Styles d'impression comptable
+### BIZ-076 — Styles d'impression comptable
 
 - **Dates** : `created=2026-04-23`, `completed=2026-04-23`
 - **Livré** : `@media print` sur journal, balance, grand livre, bilan, résultat. Sidebar/filtres/boutons masqués, en-tête imprimable.
 
-### BL-079 — Tests composables frontend
+### TEC-079 — Tests composables frontend
 
 - **Dates** : `created=2026-04-23`, `completed=2026-04-24`
 - **Livré** : 15 tests Vitest — `useDarkMode` (4), `useTableFilter` (8), `activeFilterLabels` (10). Suite 126/126 au vert.
 
-### BL-080 — Smoke test E2E Playwright
+### TEC-080 — Smoke test E2E Playwright
 
 - **Dates** : `created=2026-04-23`, `completed=2026-04-24`
 - **Livré** : `playwright.config.ts` (webServer auto-start, DB E2E dédiée). Smoke test : login → MDP obligatoire → dashboard → contacts → factures → paiements.
 
-### BL-081 — Tests d'intégration API manquants
+### TEC-081 — Tests d'intégration API manquants
 
 - **Dates** : `created=2026-04-23`, `completed=2026-04-24`
 - **Livré** : `test_accounting_rules_api.py` (11), `test_fiscal_year_api.py` (10), `test_salary_api.py` (+7), `test_dashboard_api.py` (+1). 52 tests intégration au vert.
 
-### BL-083 — Guide de migration Synology
+### CHR-083 — Guide de migration Synology
 
 - **Dates** : `created=2026-04-23`, `completed=2026-04-23`
 - **Livré** : guide FR+EN dans `doc/user/` couvrant mise à jour Docker, vérification post-migration, rollback.
 
-### BL-084 — Notification expiration session
+### BIZ-084 — Notification expiration session
 
 - **Dates** : `created=2026-04-23`, `completed=2026-05-03`
 - **Livré** : composable `useSessionExpiry` (décode expiry JWT, avertissement T−5 min) + `AppSessionWarning.vue` avec bouton « Prolonger la session ».
 
-### BL-085 — Politique de complexité MDP
+### TEC-085 — Politique de complexité MDP
 
 - **Dates** : `created=2026-04-23`, `completed=2026-04-23`
 - **Livré** : validateur `_validate_password_complexity` (8 chars, majuscule, chiffre). 14 tests unitaires.
@@ -521,6 +521,12 @@ Principaux postes de dérapage : quality gates (~10 min/commit), tests d'intégr
 ---
 
 ## Légende
+
+| Préfixe | Signification |
+| --- | --- |
+| BIZ-NNN | Fonctionnalité métier — valeur utilisateur directe |
+| TEC-NNN | Technique — qualité, refactoring, tests, sécurité technique |
+| CHR-NNN | Maintenance — outillage, documentation, CI, DevOps |
 
 | Priorité | Signification |
 | --- | --- |

--- a/doc/backlog.md
+++ b/doc/backlog.md
@@ -9,18 +9,22 @@ Quand un sujet est livré, mettre à jour `CHANGELOG.md` et passer le ticket en 
 
 ## Lots actifs
 
-### Lot E — Contacts & import (~25 min) — v0.5
-
-| ID | Titre | Prio | Est. | Créé | Démarré | Terminé |
-| --- | --- | --- | --- | --- | --- | --- |
-| BL-035 | Onglets clients / fournisseurs | P2 | ~15 min | 2026-04-21 | | |
-| BL-040 | Import one-shot emails contacts | P2 | ~10 min | 2026-04-21 | | |
-
 ### Lot G — Refactoring frontend (~30 min) — v0.5
 
 | ID | Titre | Prio | Est. | Créé | Démarré | Terminé |
 | --- | --- | --- | --- | --- | --- | --- |
 | BL-077 | Refactoring vues volumineuses | P2 | ~30 min | 2026-04-23 | 2026-04-24 | 2026-04-24 |
+
+> ✅ Lot G terminé — PR #43 mergée le 2026-04-24
+
+### Lot I — Polish UI & contacts (~35 min) — v0.5
+
+| ID | Titre | Prio | Est. | Créé | Démarré | Terminé |
+| --- | --- | --- | --- | --- | --- | --- |
+| BL-038 | Numéro de version dans l'UI | P3 | ~5 min | 2026-04-21 | 2026-04-24 | |
+| BL-037 | Profil via clic sur le nom | P3 | ~5 min | 2026-04-21 | 2026-04-24 | |
+| BL-035 | Onglets clients / fournisseurs | P2 | ~15 min | 2026-04-21 | 2026-04-24 | |
+| BL-040 | Import one-shot emails contacts | P2 | ~10 min | 2026-04-21 | 2026-04-24 | |
 
 ### Lot H — Architecture multi-compte (~45 min) — v0.6
 
@@ -37,8 +41,6 @@ Quand un sujet est livré, mettre à jour `CHANGELOG.md` et passer le ticket en 
 | BL-033 | Comparaison chèques inter-exercices | P1 | ~15 min | 2026-04-21 | | |
 | BL-039 | Revalidation scénarios facture / email | P1 | ~10 min | 2026-04-21 | | |
 | BL-020 | Documentation de contribution | P3 | ~5 min | 2026-04-13 | 2026-04-21 | |
-| BL-037 | Profil via clic sur le nom | P3 | ~5 min | 2026-04-21 | | |
-| BL-038 | Numéro de version dans l'UI | P3 | ~5 min | 2026-04-21 | | |
 | BL-078 | Squelette i18n anglais | P3 | ~5 min | 2026-04-23 | | |
 | BL-082 | Descriptions Swagger enrichies | P3 | ~10 min | 2026-04-23 | | |
 

--- a/doc/roadmap.md
+++ b/doc/roadmap.md
@@ -49,14 +49,14 @@ Completed 2026-04-22. Refactoring, security hardening, test coverage, DevOps.
 
 | Lot | Summary |
 | --- | --- |
-| 1 — Quick wins | Code cleanup (BL-064, BL-062, BL-066, BL-063) |
-| 2 — Tests au vert | Fix 11 failing tests (BL-048) |
-| 3 — Security | HTTP headers, CORS, DB schema, entry numbering (BL-047, BL-052, BL-055, BL-060, BL-051) |
-| 4 — Backend quality | Decimal TypeDecorator, pagination, DTO (BL-065, BL-057, BL-059) |
-| 5 — Auth security | Rate limit, HttpOnly cookie, forced pwd change (BL-045, BL-053, BL-046) |
-| 6 — DevOps | Entrypoint, healthcheck (BL-054, BL-061) |
-| 7 — Refactoring | Excel import split, typed exceptions (BL-050, BL-058) |
-| 8 — Long-running | Audit log, test coverage 29%→71% (BL-056, BL-049) |
+| 1 — Quick wins | Code cleanup (CHR-064, CHR-062, TEC-066, TEC-063) |
+| 2 — Tests au vert | Fix 11 failing tests (TEC-048) |
+| 3 — Security | HTTP headers, CORS, DB schema, entry numbering (TEC-047, TEC-052, TEC-055, TEC-060, TEC-051) |
+| 4 — Backend quality | Decimal TypeDecorator, pagination, DTO (TEC-065, TEC-057, TEC-059) |
+| 5 — Auth security | Rate limit, HttpOnly cookie, forced pwd change (TEC-045, BIZ-053, TEC-046) |
+| 6 — DevOps | Entrypoint, healthcheck (CHR-054, CHR-061) |
+| 7 — Refactoring | Excel import split, typed exceptions (TEC-050, TEC-058) |
+| 8 — Long-running | Audit log, test coverage 29%→71% (BIZ-056, TEC-049) |
 
 ---
 
@@ -66,12 +66,12 @@ Completed 2026-04-23. UX improvements and new features.
 
 | Lot | Summary |
 | --- | --- |
-| A — Backend rapide | Password complexity policy (BL-085) |
-| B — UX quick wins | 404 page, breadcrumb, offline banner, session expiry, filter reset (BL-070, BL-072, BL-074, BL-084, BL-042) |
-| C — Dashboard interactif | Clickable KPIs, keyboard shortcuts (BL-075, BL-073) |
-| D — Polish UI | Skeleton loaders, colored account combos (BL-071, BL-043) |
+| A — Backend rapide | Password complexity policy (TEC-085) |
+| B — UX quick wins | 404 page, breadcrumb, offline banner, session expiry, filter reset (BIZ-070, BIZ-072, BIZ-074, BIZ-084, BIZ-042) |
+| C — Dashboard interactif | Clickable KPIs, keyboard shortcuts (BIZ-075, BIZ-073) |
+| D — Polish UI | Skeleton loaders, colored account combos (BIZ-071, BIZ-043) |
 
-Standalone: error handler (BL-067), Swagger disabled in prod (BL-068), backup endpoint (BL-069), print styles (BL-076), migration guide (BL-083).
+Standalone: error handler (TEC-067), Swagger disabled in prod (TEC-068), backup endpoint (BIZ-069), print styles (BIZ-076), migration guide (CHR-083).
 
 ---
 
@@ -81,7 +81,7 @@ Completed 2026-04-24. Test coverage, quality gates, project process.
 
 | Lot | Summary |
 | --- | --- |
-| F — Tests | Composable tests, Playwright E2E smoke, integration API gaps (BL-079, BL-080, BL-081) |
+| F — Tests | Composable tests, Playwright E2E smoke, integration API gaps (TEC-079, TEC-080, TEC-081) |
 
 Also: backlog restructuring, copilot-instructions codification, all quality gates green.
 
@@ -98,13 +98,13 @@ des adresses e-mail par import ponctuel.
 
 | ID | Titre | Est. |
 | --- | --- | --- |
-| BL-035 | Onglets clients / fournisseurs | ~15 min |
-| BL-040 | Import one-shot emails contacts | ~10 min |
+| BIZ-035 | Onglets clients / fournisseurs | ~15 min |
+| BIZ-040 | Import one-shot emails contacts | ~10 min |
 
-**BL-035**: ajouter un `TabView` PrimeVue sur `ContactsView` avec onglets Clients /
+**BIZ-035**: ajouter un `TabView` PrimeVue sur `ContactsView` avec onglets Clients /
 Fournisseurs / Tous, filtré par `is_client` / `is_supplier`. Pas de changement backend.
 
-**BL-040**: endpoint `POST /contacts/import-emails` acceptant un CSV ou un copier-coller
+**BIZ-040**: endpoint `POST /contacts/import-emails` acceptant un CSV ou un copier-coller
 d'adresses pour enrichir les contacts existants par correspondance sur le nom.
 
 ### Lot G — Refactoring frontend (~30 min)
@@ -113,9 +113,9 @@ d'adresses pour enrichir les contacts existants par correspondance sur le nom.
 
 | ID | Titre | Est. |
 | --- | --- | --- |
-| BL-077 | Refactoring vues volumineuses | ~30 min |
+| TEC-077 | Refactoring vues volumineuses | ~30 min |
 
-**BL-077**: `ImportExcelView` (2 873 L) → panels preview/history/upload.
+**TEC-077**: `ImportExcelView` (2 873 L) → panels preview/history/upload.
 `BankView` (2 215 L) → panels journal/reconciliation/deposit.
 `SettingsView` (1 077 L) → tabs association/SMTP/admin.
 
@@ -123,20 +123,20 @@ d'adresses pour enrichir les contacts existants par correspondance sur le nom.
 
 | ID | Titre | Est. |
 | --- | --- | --- |
-| BL-019 | README et documentation technique | ~10 min |
-| BL-021 | Manuel utilisateur illustré | ~20 min |
-| BL-033 | Comparaison chèques inter-exercices | ~15 min |
-| BL-039 | Revalidation scénarios facture / email | ~10 min |
-| BL-020 | Documentation de contribution | ~5 min |
+| CHR-019 | README et documentation technique | ~10 min |
+| CHR-021 | Manuel utilisateur illustré | ~20 min |
+| BIZ-033 | Comparaison chèques inter-exercices | ~15 min |
+| TEC-039 | Revalidation scénarios facture / email | ~10 min |
+| CHR-020 | Documentation de contribution | ~5 min |
 
 ### P3 quick wins (v0.5)
 
 | ID | Titre | Est. |
 | --- | --- | --- |
-| BL-037 | Profil via clic sur le nom | ~5 min |
-| BL-038 | Numéro de version dans l'UI | ~5 min |
-| BL-078 | Squelette i18n anglais | ~5 min |
-| BL-082 | Descriptions Swagger enrichies | ~10 min |
+| BIZ-037 | Profil via clic sur le nom | ~5 min |
+| CHR-038 | Numéro de version dans l'UI | ~5 min |
+| CHR-078 | Squelette i18n anglais | ~5 min |
+| CHR-082 | Descriptions Swagger enrichies | ~10 min |
 
 ---
 
@@ -149,9 +149,9 @@ compte courant et compte épargne dans les données, imports et écrans.
 
 | ID | Titre | Est. |
 | --- | --- | --- |
-| BL-034 | Support multi-compte banque | ~45 min |
+| BIZ-034 | Support multi-compte banque | ~45 min |
 
-**BL-034**: modèle `BankAccount` (label, IBAN, type), migration, FK sur `BankTransaction`,
+**BIZ-034**: modèle `BankAccount` (label, IBAN, type), migration, FK sur `BankTransaction`,
 filtre par compte dans `BankView`, adaptation imports OFX/CSV.
 Prérequis : décisions métier sur la granularité (2 comptes fixes ou N comptes dynamiques).
 

--- a/frontend/env.d.ts
+++ b/frontend/env.d.ts
@@ -1,5 +1,7 @@
 /// <reference types="vite/client" />
 
+declare const __APP_VERSION__: string
+
 interface ImportMetaEnv {
 	readonly VITE_DEV_AUTO_LOGIN?: string
 	readonly VITE_DEV_AUTO_LOGIN_USERNAME?: string

--- a/frontend/src/api/contacts.ts
+++ b/frontend/src/api/contacts.ts
@@ -73,3 +73,20 @@ export async function updateContactApi(id: number, payload: ContactUpdate): Prom
 export async function deleteContactApi(id: number): Promise<void> {
   await apiClient.delete(`/api/contacts/${id}`)
 }
+
+export interface ContactEmailImportRow {
+  nom: string
+  email: string
+}
+
+export interface ContactEmailImportResult {
+  rows_processed: number
+  updated: number
+  not_found: number
+  already_has_email: number
+}
+
+export async function importContactEmailsApi(rows: ContactEmailImportRow[]): Promise<ContactEmailImportResult> {
+  const response = await apiClient.post<ContactEmailImportResult>('/api/contacts/import-emails', rows)
+  return response.data
+}

--- a/frontend/src/components/NavMenu.vue
+++ b/frontend/src/components/NavMenu.vue
@@ -44,7 +44,6 @@ type MenuItem = {
 
 const homeItems = computed<MenuItem[]>(() => [
   { to: '/dashboard', icon: 'pi-home', label: t('nav.dashboard') },
-  { to: '/profile', icon: 'pi-user', label: t('nav.profile') },
 ])
 
 const managementItems = computed<MenuItem[]>(() => {

--- a/frontend/src/i18n/fr.ts
+++ b/frontend/src/i18n/fr.ts
@@ -251,6 +251,18 @@ export default {
       'Ajoutez un contexte pratique pour les relances, la comptabilité ou l’organisation interne.',
     deleted: 'Contact supprimé.',
     confirm_delete: 'Supprimer le contact {nom} ?',
+    tabs: {
+      all: 'Tous',
+      clients: 'Clients',
+      suppliers: 'Fournisseurs',
+    },
+    import_emails: 'Importer e-mails',
+    import_emails_title: 'Importer des adresses e-mail',
+    import_emails_subtitle:
+      'Collez une liste de contacts (un par ligne, format : Nom, email@exemple.com). Les contacts existants sans e-mail seront mis à jour.',
+    import_emails_placeholder: 'Dupont Jean, jean.dupont@example.com\nMartin Pierre, pierre.martin@example.com',
+    import_emails_result: '{updated} mis à jour, {not_found} non trouvé(s), {already} déjà renseigné(s).',
+    import_emails_empty: 'Aucune ligne valide dans le texte collé.',
     metrics: {
       total: 'Contacts charges',
       clients: '{count} clients',

--- a/frontend/src/i18n/fr.ts
+++ b/frontend/src/i18n/fr.ts
@@ -263,6 +263,7 @@ export default {
     import_emails_placeholder: 'Dupont Jean, jean.dupont@example.com\nMartin Pierre, pierre.martin@example.com',
     import_emails_result: '{updated} mis à jour, {not_found} non trouvé(s), {already} déjà renseigné(s).',
     import_emails_empty: 'Aucune ligne valide dans le texte collé.',
+    import_emails_discarded: '{count} ligne(s) ignorée(s) car leur format était invalide.',
     metrics: {
       total: 'Contacts charges',
       clients: '{count} clients',

--- a/frontend/src/layouts/AppLayout.vue
+++ b/frontend/src/layouts/AppLayout.vue
@@ -24,7 +24,7 @@
         />
       </div>
       <div class="topbar-user">
-        <span class="topbar-username">{{ displayedUsername }}</span>
+        <RouterLink to="/profile" class="topbar-username">{{ displayedUsername }}</RouterLink>
         <Button
           :icon="isDark ? 'pi pi-sun' : 'pi pi-moon'"
           text
@@ -56,10 +56,10 @@
       <aside class="sidebar">
         <NavMenu />
         <div class="sidebar-footer">
-          <div class="sidebar-user">
+          <RouterLink to="/profile" class="sidebar-user">
             <span class="sidebar-username">{{ displayedUsername }}</span>
             <span class="sidebar-role">{{ displayedRoleLabel }}</span>
-          </div>
+          </RouterLink>
           <Button
             :icon="isDark ? 'pi pi-sun' : 'pi pi-moon'"
             text
@@ -75,6 +75,7 @@
             @click="handleLogout"
           />
         </div>
+        <span class="sidebar-version">v{{ appVersion }}</span>
       </aside>
 
       <!-- Main content -->
@@ -113,6 +114,7 @@ const { isDark, toggle: toggleDark } = useDarkMode()
 const { home: breadcrumbHome, items: breadcrumbItems } = useBreadcrumb()
 
 const sidebarVisible = ref(false)
+const appVersion = __APP_VERSION__
 const displayedUsername = computed(() => auth.user?.username ?? t('auth.me'))
 const displayedRoleLabel = computed(() =>
   auth.user?.role ? t(`user.role.${auth.user.role}`) : t('auth.session_active'),
@@ -242,6 +244,15 @@ onMounted(() => {
   display: flex;
   flex-direction: column;
   min-width: 0;
+  text-decoration: none;
+  color: inherit;
+  padding: 0.25rem 0.375rem;
+  border-radius: 0.375rem;
+  transition: background 0.15s;
+}
+
+.sidebar-user:hover {
+  background: v-bind(hoverBg);
 }
 
 .sidebar-username {
@@ -255,6 +266,14 @@ onMounted(() => {
 .sidebar-role {
   font-size: 0.75rem;
   color: var(--p-text-muted-color);
+}
+
+.sidebar-version {
+  font-size: 0.7rem;
+  color: var(--p-text-muted-color);
+  padding: 0.25rem 1rem 0.5rem;
+  display: block;
+  opacity: 0.6;
 }
 
 /* Main content */

--- a/frontend/src/tests/views/NavMenu.spec.ts
+++ b/frontend/src/tests/views/NavMenu.spec.ts
@@ -58,7 +58,6 @@ describe('NavMenu', () => {
     expect(text).not.toContain('nav.section_administration')
     expect(links).toEqual([
       'nav.dashboard',
-      'nav.profile',
       'nav.contacts',
       'nav.invoices_client',
       'nav.invoices_supplier',
@@ -91,7 +90,6 @@ describe('NavMenu', () => {
     expect(text).not.toContain('nav.section_administration')
     expect(links).toEqual([
       'nav.dashboard',
-      'nav.profile',
       'nav.contacts',
       'nav.invoices_client',
       'nav.invoices_supplier',
@@ -154,6 +152,6 @@ describe('NavMenu', () => {
     expect(text).not.toContain('nav.section_management')
     expect(text).not.toContain('nav.section_accounting')
     expect(text).not.toContain('nav.section_administration')
-    expect(links).toEqual(['nav.dashboard', 'nav.profile'])
+    expect(links).toEqual(['nav.dashboard'])
   })
 })

--- a/frontend/src/views/ContactsView.vue
+++ b/frontend/src/views/ContactsView.vue
@@ -197,6 +197,7 @@
       :header="t('contacts.import_emails_title')"
       modal
       class="app-dialog app-dialog--medium"
+      @hide="closeImportDialog"
     >
       <div class="contacts-import-form">
         <p class="app-field__hint">{{ t('contacts.import_emails_subtitle') }}</p>
@@ -213,7 +214,7 @@
           {{ t('contacts.import_emails_result', { updated: importResult.updated, not_found: importResult.not_found, already: importResult.already_has_email }) }}
         </Message>
         <div class="app-form-actions">
-          <Button :label="t('common.cancel')" severity="secondary" text @click="closeImportDialog" />
+          <Button :label="t('common.cancel')" severity="secondary" text :disabled="importLoading" @click="closeImportDialog" />
           <Button :label="t('contacts.import_emails')" icon="pi pi-check" :loading="importLoading" @click="runImport" />
         </div>
       </div>
@@ -369,23 +370,31 @@ function closeImportDialog(): void {
   importResult.value = null
 }
 
-function parseImportText(text: string): ContactEmailImportRow[] {
-  return text
+function parseImportText(text: string): { rows: ContactEmailImportRow[]; discardedCount: number } {
+  let discardedCount = 0
+  const rows = text
     .split('\n')
     .map((line) => line.trim())
     .filter(Boolean)
     .flatMap((line) => {
       const commaIdx = line.lastIndexOf(',')
-      if (commaIdx < 1) return []
+      if (commaIdx < 1) {
+        discardedCount += 1
+        return []
+      }
       const nom = line.slice(0, commaIdx).trim()
       const email = line.slice(commaIdx + 1).trim()
-      if (!nom || !email.includes('@')) return []
+      if (!nom || !email.includes('@')) {
+        discardedCount += 1
+        return []
+      }
       return [{ nom, email }]
     })
+  return { rows, discardedCount }
 }
 
 async function runImport(): Promise<void> {
-  const rows = parseImportText(importText.value)
+  const { rows, discardedCount } = parseImportText(importText.value)
   if (rows.length === 0) {
     toast.add({ severity: 'warn', summary: t('contacts.import_emails_empty'), life: 3000 })
     return
@@ -393,6 +402,9 @@ async function runImport(): Promise<void> {
   importLoading.value = true
   try {
     importResult.value = await importContactEmailsApi(rows)
+    if (discardedCount > 0) {
+      toast.add({ severity: 'warn', summary: t('contacts.import_emails_discarded', { count: discardedCount }), life: 4000 })
+    }
     void loadContacts()
   } catch {
     toast.add({ severity: 'error', summary: t('common.error.unknown'), life: 3000 })

--- a/frontend/src/views/ContactsView.vue
+++ b/frontend/src/views/ContactsView.vue
@@ -6,6 +6,7 @@
       :subtitle="t('contacts.subtitle')"
     >
       <template #actions>
+        <Button :label="t('contacts.import_emails')" icon="pi pi-envelope" severity="secondary" outlined @click="importDialogVisible = true" />
         <Button :label="t('contacts.new')" icon="pi pi-plus" @click="openCreateDialog" />
       </template>
     </AppPageHeader>
@@ -31,6 +32,14 @@
     </section>
 
     <AppPanel :title="t('contacts.workspace_title')" :subtitle="t('contacts.workspace_subtitle')">
+      <Tabs v-model:value="activeTab" class="contacts-tabs">
+        <TabList>
+          <Tab value="all">{{ t('contacts.tabs.all') }} ({{ contacts.length }})</Tab>
+          <Tab value="client">{{ t('contacts.tabs.clients') }} ({{ clientCount + mixedCount }})</Tab>
+          <Tab value="fournisseur">{{ t('contacts.tabs.suppliers') }} ({{ supplierCount + mixedCount }})</Tab>
+        </TabList>
+      </Tabs>
+
       <div class="app-toolbar">
         <div class="app-toolbar__meta">
           <p class="app-toolbar__hint">{{ t('contacts.filters_hint') }}</p>
@@ -58,18 +67,6 @@
               v-model="search"
               :placeholder="t('contacts.search_placeholder')"
               @input="debouncedLoad"
-            />
-          </div>
-          <div class="app-field">
-            <label class="app-field__label">{{ t('contacts.filter_type') }}</label>
-            <Select
-              v-model="typeFilter"
-              :options="typeOptions"
-              option-label="label"
-              option-value="value"
-              :placeholder="t('common.all')"
-              show-clear
-              @change="loadContacts"
             />
           </div>
         </div>
@@ -196,6 +193,33 @@
     </AppPanel>
 
     <Dialog
+      v-model:visible="importDialogVisible"
+      :header="t('contacts.import_emails_title')"
+      modal
+      class="app-dialog app-dialog--medium"
+    >
+      <div class="contacts-import-form">
+        <p class="app-field__hint">{{ t('contacts.import_emails_subtitle') }}</p>
+        <div class="app-field">
+          <Textarea
+            v-model="importText"
+            :placeholder="t('contacts.import_emails_placeholder')"
+            rows="8"
+            class="w-full"
+            style="font-family: monospace; font-size: 0.875rem"
+          />
+        </div>
+        <Message v-if="importResult" severity="success" :closable="false">
+          {{ t('contacts.import_emails_result', { updated: importResult.updated, not_found: importResult.not_found, already: importResult.already_has_email }) }}
+        </Message>
+        <div class="app-form-actions">
+          <Button :label="t('common.cancel')" severity="secondary" text @click="closeImportDialog" />
+          <Button :label="t('contacts.import_emails')" icon="pi pi-check" :loading="importLoading" @click="runImport" />
+        </div>
+      </div>
+    </Dialog>
+
+    <Dialog
       v-model:visible="dialogVisible"
       :header="editingContact ? t('contacts.edit') : t('contacts.new')"
       modal
@@ -215,8 +239,11 @@ import ConfirmDialog from 'primevue/confirmdialog'
 import DataTable from 'primevue/datatable'
 import Dialog from 'primevue/dialog'
 import InputText from 'primevue/inputtext'
-import Select from 'primevue/select'
+import Tab from 'primevue/tab'
+import TabList from 'primevue/tablist'
+import Tabs from 'primevue/tabs'
 import Tag from 'primevue/tag'
+import Textarea from 'primevue/textarea'
 import { useConfirm } from 'primevue/useconfirm'
 import { useToast } from 'primevue/usetoast'
 import { computed, onMounted, ref } from 'vue'
@@ -228,13 +255,12 @@ import AppPageHeader from '@/components/ui/AppPageHeader.vue'
 import AppPanel from '@/components/ui/AppPanel.vue'
 import AppStatCard from '@/components/ui/AppStatCard.vue'
 import AppTableSkeleton from '@/components/ui/AppTableSkeleton.vue'
-import { deleteContactApi, listContactsApi, type Contact } from '@/api/contacts'
-import type { ContactType } from '@/api/types'
+import { deleteContactApi, importContactEmailsApi, listContactsApi, type Contact } from '@/api/contacts'
+import type { ContactEmailImportRow } from '@/api/contacts'
 import ContactForm from '@/components/ContactForm.vue'
 import { useKeyboardShortcuts } from '@/composables/useKeyboardShortcuts'
 import {
   collectActiveFilterLabels,
-  findSelectedFilterLabel,
 } from '../composables/activeFilterLabels'
 import { inFilter, textFilter, useDataTableFilters } from '../composables/useDataTableFilters'
 
@@ -245,12 +271,22 @@ const toast = useToast()
 const contacts = ref<Contact[]>([])
 const loading = ref(false)
 const search = ref('')
-const typeFilter = ref<ContactType | undefined>(undefined)
+const activeTab = ref<'all' | 'client' | 'fournisseur'>('all')
 const dialogVisible = ref(false)
 const contactFormRef = ref<InstanceType<typeof ContactForm> | null>(null)
 const editingContact = ref<Contact | null>(null)
+const importDialogVisible = ref(false)
+const importText = ref('')
+const importLoading = ref(false)
+const importResult = ref<{ updated: number; not_found: number; already_has_email: number } | null>(null)
+
+const tabContacts = computed(() => {
+  if (activeTab.value === 'client') return contacts.value.filter((c) => c.type === 'client' || c.type === 'les_deux')
+  if (activeTab.value === 'fournisseur') return contacts.value.filter((c) => c.type === 'fournisseur' || c.type === 'les_deux')
+  return contacts.value
+})
 const contactRows = computed(() =>
-  contacts.value.map((contact) => ({
+  tabContacts.value.map((contact) => ({
     ...contact,
     type_label: t(`contacts.types.${contact.type}`),
   })),
@@ -282,14 +318,12 @@ const emailCount = computed(() => contacts.value.filter((contact) => Boolean(con
 const phoneCount = computed(
   () => contacts.value.filter((contact) => Boolean(contact.telephone)).length,
 )
-const activeFilterLabels = computed(() =>
-  collectActiveFilterLabels(findSelectedFilterLabel(typeOptions, typeFilter.value)),
-)
+const activeFilterLabels = computed(() => collectActiveFilterLabels())
 
 const typeOptions = [
-  { label: t('contacts.types.client'), value: 'client' as ContactType },
-  { label: t('contacts.types.fournisseur'), value: 'fournisseur' as ContactType },
-  { label: t('contacts.types.les_deux'), value: 'les_deux' as ContactType },
+  { label: t('contacts.types.client'), value: 'client' as const },
+  { label: t('contacts.types.fournisseur'), value: 'fournisseur' as const },
+  { label: t('contacts.types.les_deux'), value: 'les_deux' as const },
 ]
 
 function typeSeverity(type: ContactType): 'info' | 'success' | 'warn' {
@@ -306,13 +340,13 @@ function debouncedLoad(): void {
 }
 
 const hasAnyFilters = computed(
-  () => hasActiveFilters.value || Boolean(search.value) || typeFilter.value !== undefined,
+  () => hasActiveFilters.value || Boolean(search.value) || activeTab.value !== 'all',
 )
 
 function resetAllFilters(): void {
   resetFilters()
   search.value = ''
-  typeFilter.value = undefined
+  activeTab.value = 'all'
   void loadContacts()
 }
 
@@ -320,13 +354,50 @@ async function loadContacts(): Promise<void> {
   loading.value = true
   try {
     contacts.value = await listContactsApi({
-      type: typeFilter.value,
       search: search.value || undefined,
     })
   } catch {
     toast.add({ severity: 'error', summary: t('common.error.unknown'), life: 3000 })
   } finally {
     loading.value = false
+  }
+}
+
+function closeImportDialog(): void {
+  importDialogVisible.value = false
+  importText.value = ''
+  importResult.value = null
+}
+
+function parseImportText(text: string): ContactEmailImportRow[] {
+  return text
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .flatMap((line) => {
+      const commaIdx = line.lastIndexOf(',')
+      if (commaIdx < 1) return []
+      const nom = line.slice(0, commaIdx).trim()
+      const email = line.slice(commaIdx + 1).trim()
+      if (!nom || !email.includes('@')) return []
+      return [{ nom, email }]
+    })
+}
+
+async function runImport(): Promise<void> {
+  const rows = parseImportText(importText.value)
+  if (rows.length === 0) {
+    toast.add({ severity: 'warn', summary: t('contacts.import_emails_empty'), life: 3000 })
+    return
+  }
+  importLoading.value = true
+  try {
+    importResult.value = await importContactEmailsApi(rows)
+    void loadContacts()
+  } catch {
+    toast.add({ severity: 'error', summary: t('common.error.unknown'), life: 3000 })
+  } finally {
+    importLoading.value = false
   }
 }
 
@@ -384,5 +455,15 @@ onMounted(loadContacts)
 <style scoped>
 .contacts-table__actions {
   width: 8rem;
+}
+
+.contacts-tabs {
+  margin-bottom: var(--app-space-4);
+}
+
+.contacts-import-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--app-space-4);
 }
 </style>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -12,7 +12,9 @@ if (!isVitest) {
   plugins.push(vueDevTools())
 }
 
-const pkg = JSON.parse(readFileSync('./package.json', 'utf-8')) as { version: string }
+const pkg = JSON.parse(
+  readFileSync(new URL('./package.json', import.meta.url), 'utf-8'),
+) as { version: string }
 
 // https://vite.dev/config/
 export default defineConfig({

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,4 +1,5 @@
 import { fileURLToPath, URL } from 'node:url'
+import { readFileSync } from 'node:fs'
 
 import { defineConfig, type PluginOption } from 'vite'
 import vue from '@vitejs/plugin-vue'
@@ -11,9 +12,14 @@ if (!isVitest) {
   plugins.push(vueDevTools())
 }
 
+const pkg = JSON.parse(readFileSync('./package.json', 'utf-8')) as { version: string }
+
 // https://vite.dev/config/
 export default defineConfig({
   plugins,
+  define: {
+    __APP_VERSION__: JSON.stringify(pkg.version),
+  },
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url)),

--- a/tests/integration/test_contacts_api.py
+++ b/tests/integration/test_contacts_api.py
@@ -178,6 +178,48 @@ class TestUpdateContact:
         assert response.status_code == 404
 
 
+class TestImportContactEmails:
+    async def test_requires_auth(self, client: AsyncClient):
+        response = await client.post("/api/contacts/import-emails", json=[])
+        assert response.status_code == 401
+
+    async def test_updates_contact_without_email(self, client: AsyncClient, auth_headers: dict):
+        await client.post(
+            "/api/contacts/",
+            json={"type": "client", "nom": "Dupont", "prenom": "Jean"},
+            headers=auth_headers,
+        )
+        response = await client.post(
+            "/api/contacts/import-emails",
+            json=[{"nom": "Dupont Jean", "email": "jean@example.com"}],
+            headers=auth_headers,
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["updated"] == 1
+        assert data["not_found"] == 0
+        assert data["already_has_email"] == 0
+
+    async def test_not_found_returns_zero_updates(self, client: AsyncClient, auth_headers: dict):
+        response = await client.post(
+            "/api/contacts/import-emails",
+            json=[{"nom": "Inconnu Total", "email": "x@example.com"}],
+            headers=auth_headers,
+        )
+        assert response.status_code == 200
+        assert response.json()["not_found"] == 1
+        assert response.json()["updated"] == 0
+
+    async def test_empty_list_returns_zero(self, client: AsyncClient, auth_headers: dict):
+        response = await client.post(
+            "/api/contacts/import-emails",
+            json=[],
+            headers=auth_headers,
+        )
+        assert response.status_code == 200
+        assert response.json()["rows_processed"] == 0
+
+
 class TestDeleteContact:
     async def test_soft_delete(self, client: AsyncClient, auth_headers: dict):
         created = await client.post(

--- a/tests/unit/test_contact_service.py
+++ b/tests/unit/test_contact_service.py
@@ -9,12 +9,13 @@ from backend.models.contact import Contact, ContactType
 from backend.models.fiscal_year import FiscalYear, FiscalYearStatus
 from backend.models.invoice import Invoice, InvoiceStatus, InvoiceType
 from backend.models.payment import Payment, PaymentMethod
-from backend.schemas.contact import ContactCreate, ContactUpdate
+from backend.schemas.contact import ContactCreate, ContactEmailImportRow, ContactUpdate
 from backend.services.contact import (
     create_contact,
     delete_contact,
     get_contact,
     get_contact_history,
+    import_emails_from_rows,
     list_contacts,
     mark_creance_douteuse,
     update_contact,
@@ -290,3 +291,40 @@ class TestMarkCreanceDouteuse:
         assert credit_entry.credit == Decimal("300.00")
         assert credit_entry.debit == Decimal("0")
         assert f"411{contact.id:04d}" in credit_entry.account_number
+
+
+class TestImportEmailsFromRows:
+    async def test_updates_contact_without_email(self, db_session: AsyncSession):
+        contact = await create_contact(db_session, ContactCreate(type=ContactType.CLIENT, nom="Dupont", prenom="Jean"))
+        rows = [ContactEmailImportRow(nom="Dupont Jean", email="jean@example.com")]
+        result = await import_emails_from_rows(db_session, rows)
+        assert result.updated == 1
+        assert result.not_found == 0
+        assert result.already_has_email == 0
+        await db_session.refresh(contact)
+        assert contact.email == "jean@example.com"
+
+    async def test_skips_contact_with_existing_email(self, db_session: AsyncSession):
+        await create_contact(db_session, ContactCreate(type=ContactType.CLIENT, nom="Martin", email="existing@example.com"))
+        rows = [ContactEmailImportRow(nom="Martin", email="new@example.com")]
+        result = await import_emails_from_rows(db_session, rows)
+        assert result.updated == 0
+        assert result.already_has_email == 1
+
+    async def test_reports_not_found(self, db_session: AsyncSession):
+        rows = [ContactEmailImportRow(nom="Inconnu", email="x@example.com")]
+        result = await import_emails_from_rows(db_session, rows)
+        assert result.not_found == 1
+        assert result.updated == 0
+
+    async def test_matches_by_nom_only(self, db_session: AsyncSession):
+        await create_contact(db_session, ContactCreate(type=ContactType.CLIENT, nom="Leclerc"))
+        rows = [ContactEmailImportRow(nom="Leclerc", email="leclerc@example.com")]
+        result = await import_emails_from_rows(db_session, rows)
+        assert result.updated == 1
+
+    async def test_accent_normalization(self, db_session: AsyncSession):
+        await create_contact(db_session, ContactCreate(type=ContactType.CLIENT, nom="Éléonore"))
+        rows = [ContactEmailImportRow(nom="Eleonore", email="elo@example.com")]
+        result = await import_emails_from_rows(db_session, rows)
+        assert result.updated == 1


### PR DESCRIPTION
## Summary

Polish UI improvements and contacts enhancements — Lot I (BIZ-035, BIZ-037, CHR-038, BIZ-040).

## Changes

### Added
- **BIZ-035 — Contact tabs**: `ContactsView` now shows Tous / Clients / Fournisseurs tabs using PrimeVue `Tabs`. Filtering is done on the frontend; contacts with type `les_deux` appear in both Clients and Fournisseurs tabs. The `Select` type filter is removed.
- **BIZ-040 — Bulk email import**: New `POST /api/contacts/import-emails` endpoint accepting `[{nom, email}]` rows. Matching by normalized name (accent-insensitive, case-insensitive, supports `Prénom NOM` and `NOM Prénom` variants). Returns `{rows_processed, updated, not_found, already_has_email}`. Frontend: "Importer e-mails" button + paste dialog in `ContactsView`.
- **BIZ-037 — Profile via username click**: Username in sidebar and topbar is now a `RouterLink` to `/profile`. The "Mon profil" entry is removed from the navigation menu.
- **CHR-038 — App version in sidebar**: App version displayed discreetly at the bottom of the sidebar, injected from `package.json` via `vite.config.ts` `define.__APP_VERSION__`.

### Tests
- 5 new unit tests for `import_emails_from_rows` (accent normalization, skips contacts with existing email, not found, etc.)
- 4 new integration tests for `POST /api/contacts/import-emails`
- `NavMenu.spec.ts` updated (removed `nav.profile` from expected items)

## Quality Gates
- `ruff check` + `ruff format --check`: ✅
- `mypy` (strict on `services/`): ✅
- `pytest tests/`: ✅
- `eslint src/`: ✅
- `vue-tsc --noEmit`: ✅
- `vitest run`: ✅ (126/126)

## Summary by Sourcery

Polish the contacts UI and global layout by introducing contact-type tabs, bulk email import, clickable profile areas, and displaying the app version in the sidebar.

New Features:
- Add frontend tabs in the contacts view to switch between all contacts, clients, and suppliers, replacing the previous type filter.
- Introduce a bulk email import flow for contacts, with a backend endpoint and frontend dialog to paste name/email rows and update existing contacts.
- Make the username in the topbar and sidebar link to the profile page instead of relying on a dedicated navigation menu item.
- Expose the application version in the sidebar, sourced from the frontend build configuration.

Enhancements:
- Adjust contacts filtering indicators and reset logic to respect the new tab-based filtering instead of the removed type select.
- Simplify the contacts listing API usage by moving type-based filtering to the frontend.
- Polish sidebar user area styling, including hover feedback and layout tweaks around the clickable user block and version display.
- Update backlog and changelog documentation to reflect the new UI and contact-import work.

Build:
- Inject the app version from package.json into the frontend bundle via a global define in Vite config.

Documentation:
- Extend French i18n strings for the contacts page to cover tabs and the bulk email import workflow.

Tests:
- Add unit tests for the contact email bulk-import service, including matching and normalization edge cases.
- Add integration tests for the new /api/contacts/import-emails endpoint, covering auth, updates, and empty payloads.
- Update navigation menu tests to match the removal of the profile entry.