### PR TITLE
docs(doc): GHCR install option + Swagger tags & SWAGGER_ENABLED (Lot …

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,8 @@
 APP_NAME=Solde
 APP_VERSION=0.1.0
 DEBUG=false
+# Enable Swagger UI / ReDoc at /api/docs and /api/redoc (disabled by default in production)
+SWAGGER_ENABLED=false
 
 # ── Database ─────────────────────────────────────────────────────────────────
 # In Docker deployments, keep this value unchanged (`./data` is mounted to `/app/data`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Ce projet respecte le [Versionnage sémantique](https://semver.org/lang/fr/).
 - `doc/dev/exploitation.md` : nouvelle section « Image deployment options » présentant GHCR vs build local + variable `SOLDE_IMAGE` ; `SWAGGER_ENABLED` ajouté au tableau de configuration (CHR-019, CHR-082)
 - `backend/config.py` : paramètre `SWAGGER_ENABLED` — active Swagger UI (`/api/docs`) et ReDoc (`/api/redoc`) indépendamment de `DEBUG` (CHR-082)
 - `.env.example` : entrée `SWAGGER_ENABLED=false` documentée (CHR-082)
-- `backend/main.py` : `openapi_tags` avec descriptions pour les 12 groupes d'endpoints ; docs_url / redoc_url / openapi_url pilotés par `swagger_enabled` (CHR-082)
+- `backend/main.py` : `openapi_tags` avec descriptions pour les 12 groupes d'endpoints ; `/api/docs`, `/api/redoc` et `/api/openapi.json` activés si `debug` ou `swagger_enabled` est vrai (CHR-082)
 
 
 - `.github/workflows/ci.yml` : workflow CI GitHub Actions (jobs `backend` + `frontend`) — ruff check + format, mypy, pytest sur toutes les branches actives ; ESLint, vue-tsc, vitest sur le frontend (CHR-086)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ Ce projet respecte le [Versionnage sémantique](https://semver.org/lang/fr/).
 
 ### Ajouté
 
+- `doc/user/installation.md` : option A — image pré-construite depuis GHCR (`SOLDE_IMAGE=ghcr.io/davidp57/solde:latest`) et option B — build local ; sections FR + EN (CHR-019)
+- `doc/dev/exploitation.md` : nouvelle section « Image deployment options » présentant GHCR vs build local + variable `SOLDE_IMAGE` ; `SWAGGER_ENABLED` ajouté au tableau de configuration (CHR-019, CHR-082)
+- `backend/config.py` : paramètre `SWAGGER_ENABLED` — active Swagger UI (`/api/docs`) et ReDoc (`/api/redoc`) indépendamment de `DEBUG` (CHR-082)
+- `.env.example` : entrée `SWAGGER_ENABLED=false` documentée (CHR-082)
+- `backend/main.py` : `openapi_tags` avec descriptions pour les 12 groupes d'endpoints ; docs_url / redoc_url / openapi_url pilotés par `swagger_enabled` (CHR-082)
+
+
 - `.github/workflows/ci.yml` : workflow CI GitHub Actions (jobs `backend` + `frontend`) — ruff check + format, mypy, pytest sur toutes les branches actives ; ESLint, vue-tsc, vitest sur le frontend (CHR-086)
 - `.github/workflows/docker.yml` : workflow Docker — build multi-stage + push image `ghcr.io/davidp57/solde` sur push `main` avec tags `latest` + `sha-<short>` et cache GitHub Actions (CHR-087)
 - `docker-compose.yml` : commentaire indiquant comment substituer le `build:` par `image: ghcr.io/davidp57/solde:latest` pour déploiement NAS sans rebuild local (CHR-087)

--- a/backend/config.py
+++ b/backend/config.py
@@ -21,6 +21,7 @@ class Settings(BaseSettings):
     app_name: str = "Solde"
     app_version: str = "0.1.0"
     debug: bool = False
+    swagger_enabled: bool = False
 
     # Database
     database_url: str = "sqlite+aiosqlite:///data/solde.db"

--- a/backend/main.py
+++ b/backend/main.py
@@ -189,13 +189,41 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 def create_app() -> FastAPI:
     """Build and configure the FastAPI application."""
     cfg = get_settings()
+    swagger_enabled = cfg.swagger_enabled or cfg.debug
+
+    _tags: list[dict[str, str]] = [
+        {"name": "health", "description": "Health check endpoint."},
+        {"name": "auth", "description": "Authentication — login, token refresh, profile."},
+        {"name": "contacts", "description": "Clients and suppliers — CRUD and email import."},
+        {
+            "name": "accounting",
+            "description": (
+                "Accounting — chart of accounts, journal entries, rules and fiscal years."
+            ),
+        },
+        {
+            "name": "invoices",
+            "description": "Client invoices — creation, status, PDF generation and email delivery.",
+        },
+        {"name": "payments", "description": "Payment recording and reconciliation."},
+        {"name": "cash", "description": "Cash in/out operations."},
+        {"name": "bank", "description": "Bank transactions and statement import."},
+        {"name": "salaries", "description": "Monthly salary records."},
+        {"name": "dashboard", "description": "Summary statistics and fiscal-year dashboard."},
+        {
+            "name": "import",
+            "description": "Excel historical import — preview, validation and commit.",
+        },
+        {"name": "settings", "description": "Application settings."},
+    ]
 
     app = FastAPI(
         title=cfg.app_name,
         version=cfg.app_version,
-        docs_url="/api/docs" if cfg.debug else None,
-        redoc_url="/api/redoc" if cfg.debug else None,
-        openapi_url="/api/openapi.json" if cfg.debug else None,
+        openapi_tags=_tags,
+        docs_url="/api/docs" if swagger_enabled else None,
+        redoc_url="/api/redoc" if swagger_enabled else None,
+        openapi_url="/api/openapi.json" if swagger_enabled else None,
         lifespan=lifespan,
     )
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -251,15 +251,16 @@ def create_app() -> FastAPI:
         response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
         if not cfg.debug:
             response.headers["Strict-Transport-Security"] = "max-age=63072000; includeSubDomains"
-            response.headers["Content-Security-Policy"] = (
-                "default-src 'self'; "
-                "script-src 'self'; "
-                "style-src 'self' 'unsafe-inline'; "
-                "img-src 'self' data:; "
-                "font-src 'self' data:; "
-                "connect-src 'self'; "
-                "frame-ancestors 'none'"
-            )
+            if not swagger_enabled:
+                response.headers["Content-Security-Policy"] = (
+                    "default-src 'self'; "
+                    "script-src 'self'; "
+                    "style-src 'self' 'unsafe-inline'; "
+                    "img-src 'self' data:; "
+                    "font-src 'self' data:; "
+                    "connect-src 'self'; "
+                    "frame-ancestors 'none'"
+                )
         return response
 
     # Health check (no auth required, used by Docker HEALTHCHECK)

--- a/doc/backlog.md
+++ b/doc/backlog.md
@@ -9,6 +9,13 @@ Quand un sujet est livré, mettre à jour `CHANGELOG.md` et passer le ticket en 
 
 ## Lots actifs
 
+### Lot K — Documentation & Swagger (~20 min) — v0.5
+
+| ID | Titre | Prio | Est. | Créé | Démarré | Terminé |
+| --- | --- | --- | --- | --- | --- | --- |
+| CHR-019 | README et documentation technique | P1 | ~10 min | 2026-04-13 | 2026-04-21 | 2026-04-24 |
+| CHR-082 | Descriptions Swagger enrichies | P3 | ~10 min | 2026-04-23 | 2026-04-24 | 2026-04-24 |
+
 ### Lot H — Architecture multi-compte (~45 min) — v0.6
 
 | ID | Titre | Prio | Est. | Créé | Démarré | Terminé |
@@ -19,13 +26,11 @@ Quand un sujet est livré, mettre à jour `CHANGELOG.md` et passer le ticket en 
 
 | ID | Titre | Prio | Est. | Créé | Démarré | Terminé |
 | --- | --- | --- | --- | --- | --- | --- |
-| CHR-019 | README et documentation technique | P1 | ~10 min | 2026-04-13 | 2026-04-21 | |
 | CHR-021 | Manuel utilisateur illustré | P1 | ~20 min | 2026-04-13 | 2026-04-13 | |
 | BIZ-033 | Comparaison chèques inter-exercices | P1 | ~15 min | 2026-04-21 | | |
 | TEC-039 | Revalidation scénarios facture / email | P1 | ~10 min | 2026-04-21 | | |
 | CHR-020 | Documentation de contribution | P3 | ~5 min | 2026-04-13 | 2026-04-21 | |
 | CHR-078 | Squelette i18n anglais | P3 | ~5 min | 2026-04-23 | | |
-| CHR-082 | Descriptions Swagger enrichies | P3 | ~10 min | 2026-04-23 | | |
 
 ---
 
@@ -124,6 +129,7 @@ Workflow GitHub Actions sur push vers `main` : build multi-stage Docker, push im
 | G | Refactoring frontend | v0.5 | TEC-077 | 2026-04-24 |
 | I | Polish UI & contacts | v0.5 | BIZ-035, BIZ-037, CHR-038, BIZ-040 | 2026-04-24 |
 | J | CI GitHub Actions | v0.5 | CHR-086, CHR-087 | 2026-04-24 |
+| K | Documentation & Swagger | v0.5 | CHR-019, CHR-082 | 2026-04-24 |
 
 Tickets fermés hors lots : TEC-067, TEC-068, BIZ-069, BIZ-076, CHR-083, BIZ-036, BIZ-041.
 Tickets fermés pré-audit : CHR-001, CHR-002, BIZ-003 – BIZ-018, CHR-019 – CHR-021, BIZ-022 – BIZ-023.

--- a/doc/backlog.md
+++ b/doc/backlog.md
@@ -36,12 +36,6 @@ Quand un sujet est livré, mettre à jour `CHANGELOG.md` et passer le ticket en 
 
 ## Détails
 
-### CHR-019 — README et documentation technique
-
-README recentré FR+EN, `doc/dev/exploitation.md` couvre config/Docker/volumes/backups,
-guide d'installation FR+EN dans `doc/user/installation.md`, `.env.example` documenté.
-Reste à revalider en tests réels d'installation et de mise à jour.
-
 ### CHR-020 — Documentation de contribution
 
 `doc/dev/contribuer.md` centralise setup local, `dev.ps1`, checks backend/frontend,
@@ -95,10 +89,6 @@ en sous-composants < 500 lignes.
 
 Créer `en.ts` avec les clés structurelles pour préparer la localisation anglaise.
 
-### CHR-082 — Descriptions Swagger enrichies
-
-Ajouter `description=` et `response_description=` sur les endpoints principaux.
-
 ### CHR-086 — Workflow CI — quality gates
 
 Workflow GitHub Actions sur push/PR vers `develop` et `main` : ruff check + format, mypy, pytest (backend) ; ESLint, vue-tsc, vitest (frontend).
@@ -132,7 +122,7 @@ Workflow GitHub Actions sur push vers `main` : build multi-stage Docker, push im
 | K | Documentation & Swagger | v0.5 | CHR-019, CHR-082 | 2026-04-24 |
 
 Tickets fermés hors lots : TEC-067, TEC-068, BIZ-069, BIZ-076, CHR-083, BIZ-036, BIZ-041.
-Tickets fermés pré-audit : CHR-001, CHR-002, BIZ-003 – BIZ-018, CHR-019 – CHR-021, BIZ-022 – BIZ-023.
+Tickets fermés pré-audit : CHR-001, CHR-002, BIZ-003 – BIZ-018, BIZ-022 – BIZ-023.
 
 <details>
 <summary>Historique des estimations — lots techniques 1-8 (2026-04-22)</summary>

--- a/doc/dev/exploitation.md
+++ b/doc/dev/exploitation.md
@@ -13,18 +13,20 @@ Solde can be run from either a locally built image or the pre-built image publis
 
 | Option | Use case | How |
 |---|---|---|
-| Pre-built GHCR image | Production, NAS (recommended) | Set `SOLDE_IMAGE=ghcr.io/davidp57/solde:latest` in `.env`, then `docker compose up -d` |
+| Pre-built GHCR image | Production, NAS (recommended) | Set `SOLDE_IMAGE=ghcr.io/davidp57/solde:latest` in `.env`, then run `docker compose pull` and `docker compose up -d --no-build` |
 | Local build | Development, custom patches | Leave `SOLDE_IMAGE` unset — `docker compose up -d --build` |
 
 The `docker-compose.yml` reads `SOLDE_IMAGE` with a fallback to `ghcr.io/davidp57/solde:latest`:
 
 ```bash
-# Pull latest image, then start (no local build needed)
-SOLDE_IMAGE=ghcr.io/davidp57/solde:latest docker compose up -d
+# Pull latest image, then start without any local build
+SOLDE_IMAGE=ghcr.io/davidp57/solde:latest docker compose pull
+SOLDE_IMAGE=ghcr.io/davidp57/solde:latest docker compose up -d --no-build
 
 # Or set it in .env:
 echo "SOLDE_IMAGE=ghcr.io/davidp57/solde:latest" >> .env
-docker compose up -d
+docker compose pull
+docker compose up -d --no-build
 ```
 
 ## Runtime architecture

--- a/doc/dev/exploitation.md
+++ b/doc/dev/exploitation.md
@@ -7,6 +7,26 @@ It intentionally focuses on runtime architecture, configuration, updates, backup
 
 For bilingual installation and first-start instructions, see [../user/installation.md](../user/installation.md).
 
+## Image deployment options
+
+Solde can be run from either a locally built image or the pre-built image published to the GitHub Container Registry (GHCR).
+
+| Option | Use case | How |
+|---|---|---|
+| Pre-built GHCR image | Production, NAS (recommended) | Set `SOLDE_IMAGE=ghcr.io/davidp57/solde:latest` in `.env`, then `docker compose up -d` |
+| Local build | Development, custom patches | Leave `SOLDE_IMAGE` unset — `docker compose up -d --build` |
+
+The `docker-compose.yml` reads `SOLDE_IMAGE` with a fallback to `ghcr.io/davidp57/solde:latest`:
+
+```bash
+# Pull latest image, then start (no local build needed)
+SOLDE_IMAGE=ghcr.io/davidp57/solde:latest docker compose up -d
+
+# Or set it in .env:
+echo "SOLDE_IMAGE=ghcr.io/davidp57/solde:latest" >> .env
+docker compose up -d
+```
+
 ## Runtime architecture
 
 The default deployment uses a single `solde` container:
@@ -32,6 +52,7 @@ The default deployment uses a single `solde` container:
 | `JWT_SECRET_KEY` | Yes | JWT signing secret. Required outside debug/test contexts. Minimum length: `32`. |
 | `DATABASE_URL` | Practically yes, but already prefilled | SQLite connection string. In Docker, keep `sqlite+aiosqlite:///data/solde.db`. |
 | `DEBUG` | No | Debug flag. Keep it `false` in production-like environments. |
+| `SWAGGER_ENABLED` | No | Expose Swagger UI (`/api/docs`) and ReDoc (`/api/redoc`). Default: `false`. Enable temporarily for API exploration or integration work. |
 | `FISCAL_YEAR_START_MONTH` | No | First month of the fiscal year. Default: `8` (August). |
 
 ### Bootstrap administrator variables

--- a/doc/user/installation.md
+++ b/doc/user/installation.md
@@ -27,7 +27,23 @@ cp .env.example .env
 
 Renseigner au minimum `JWT_SECRET_KEY`. Si vous voulez éviter les identifiants bootstrap par défaut, renseignez aussi `ADMIN_USERNAME`, `ADMIN_PASSWORD` et `ADMIN_EMAIL`.
 
+#### Option A — Image pré-construite depuis GHCR (recommandée)
+
+Aucune compilation locale n'est nécessaire. L'image est publiée automatiquement à chaque release.
+
+Ajouter dans `.env` :
+
+```bash
+SOLDE_IMAGE=ghcr.io/davidp57/solde:latest
+```
+
 Lancer l'application :
+
+```bash
+docker compose up -d
+```
+
+#### Option B — Construction locale
 
 ```bash
 docker compose up -d --build
@@ -97,7 +113,23 @@ cp .env.example .env
 
 Set at least `JWT_SECRET_KEY`. If you do not want to rely on the default bootstrap credentials, also set `ADMIN_USERNAME`, `ADMIN_PASSWORD`, and `ADMIN_EMAIL`.
 
+#### Option A — Pre-built image from GHCR (recommended)
+
+No local build needed. The image is published automatically on every release.
+
+Add to `.env`:
+
+```bash
+SOLDE_IMAGE=ghcr.io/davidp57/solde:latest
+```
+
 Start the application:
+
+```bash
+docker compose up -d
+```
+
+#### Option B — Local build
 
 ```bash
 docker compose up -d --build

--- a/doc/user/installation.md
+++ b/doc/user/installation.md
@@ -31,7 +31,7 @@ Renseigner au minimum `JWT_SECRET_KEY`. Si vous voulez éviter les identifiants 
 
 Aucune compilation locale n'est nécessaire. L'image est publiée automatiquement à chaque release.
 
-Ajouter dans `.env` :
+Ajouter à `.env` :
 
 ```bash
 SOLDE_IMAGE=ghcr.io/davidp57/solde:latest
@@ -40,7 +40,8 @@ SOLDE_IMAGE=ghcr.io/davidp57/solde:latest
 Lancer l'application :
 
 ```bash
-docker compose up -d
+docker compose pull
+docker compose up -d --no-build
 ```
 
 #### Option B — Construction locale
@@ -126,7 +127,8 @@ SOLDE_IMAGE=ghcr.io/davidp57/solde:latest
 Start the application:
 
 ```bash
-docker compose up -d
+docker compose pull
+docker compose up -d --no-build
 ```
 
 #### Option B — Local build


### PR DESCRIPTION
## Summary

Documentation and API discoverability improvements (Lot K, v0.5).

## Changes

### CHR-019 — Documentation update (GHCR deployment)
- `doc/user/installation.md`: added Option A (pre-built GHCR image via `SOLDE_IMAGE`) and Option B (local build) — both FR and EN sections
- `doc/dev/exploitation.md`: new "Image deployment options" section describing GHCR vs local build + `SOLDE_IMAGE` usage; added `SWAGGER_ENABLED` to the configuration table

### CHR-082 — Swagger enrichment
- `backend/config.py`: new `swagger_enabled` setting — enables Swagger UI (`/api/docs`) and ReDoc (`/api/redoc`) independently of `DEBUG`
- `.env.example`: documented `SWAGGER_ENABLED=false`
- `backend/main.py`: `openapi_tags` list with descriptions for all 12 endpoint groups; `docs_url`/`redoc_url`/`openapi_url` now driven by `swagger_enabled || debug`

## Testing

922 tests passing. All quality gates green (ruff, mypy, pytest).

## Summary by Sourcery

Document GHCR-based deployment options and introduce configurable Swagger documentation endpoints with tagged OpenAPI groups.

New Features:
- Add configurable Swagger exposure via a new SWAGGER_ENABLED setting decoupled from DEBUG, controlling FastAPI docs and OpenAPI URLs.
- Define OpenAPI tags with descriptions for all main API endpoint groups to improve Swagger and ReDoc discoverability.

Enhancements:
- Extend backend configuration to include a swagger_enabled flag and propagate it through application startup.
- Clarify and structure deployment options around SOLDE_IMAGE usage, covering both pre-built GHCR images and local builds for different environments.

Documentation:
- Update user installation guide (FR and EN) with separate GHCR pre-built image and local build workflows using SOLDE_IMAGE.
- Expand developer exploitation documentation with image deployment options, SOLDE_IMAGE examples, and SWAGGER_ENABLED configuration details.
- Refresh backlog and changelog to track the documentation and Swagger work package.