### PR TITLE
perf(TEC-105): index due_date, fix N+1 list_payments, SQL dashboard filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Ce projet respecte le [Versionnage sémantique](https://semver.org/lang/fr/).
 
 ### Performances
 
-- TEC-105 : Fix N+1 dans `payment.list_payments()` — Invoice jointé dans la requête principale (1 query au lieu de N+1)
+- TEC-105 : Fix N+1 dans `payment.list_payments()` — Invoice jointe dans la requête principale (1 query au lieu de N+1)
 - TEC-105 : Dashboard — filtres `unpaid` et `overdue` déplacés en SQL (`WHERE total_amount > paid_amount`, `WHERE due_date < today`) au lieu d'un chargement en mémoire de toutes les factures
 - TEC-105 : Index SQL ajouté sur `invoices.due_date` (migration 0028) — accélère les requêtes de factures en retard
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Ce projet respecte le [Versionnage sémantique](https://semver.org/lang/fr/).
 
 ## [Non publié]
 
+### Performances
+
+- TEC-105 : Fix N+1 dans `payment.list_payments()` — Invoice jointé dans la requête principale (1 query au lieu de N+1)
+- TEC-105 : Dashboard — filtres `unpaid` et `overdue` déplacés en SQL (`WHERE total_amount > paid_amount`, `WHERE due_date < today`) au lieu d'un chargement en mémoire de toutes les factures
+- TEC-105 : Index SQL ajouté sur `invoices.due_date` (migration 0028) — accélère les requêtes de factures en retard
+
 ### Sécurité
 
 - TEC-091 : Logging serveur ajouté sur les routeurs `invoice`, `excel_import`, `settings` — les exceptions inattendues sont désormais tracées (`logger.exception`) avant relance

--- a/backend/alembic/versions/0028_add_invoice_due_date_index.py
+++ b/backend/alembic/versions/0028_add_invoice_due_date_index.py
@@ -5,13 +5,15 @@ Revises: 0027
 Create Date: 2026-04-25
 """
 
+from collections.abc import Sequence
+
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision = "0028"
-down_revision = "0027"
-branch_labels = None
-depends_on = None
+revision: str = "0028"
+down_revision: str | None = "0027"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:

--- a/backend/alembic/versions/0028_add_invoice_due_date_index.py
+++ b/backend/alembic/versions/0028_add_invoice_due_date_index.py
@@ -1,0 +1,22 @@
+"""Add index on invoices.due_date for overdue filter performance.
+
+Revision ID: 0028
+Revises: 0027
+Create Date: 2026-04-25
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0028"
+down_revision = "0027"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_index("ix_invoices_due_date", "invoices", ["due_date"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_invoices_due_date", table_name="invoices")

--- a/backend/models/invoice.py
+++ b/backend/models/invoice.py
@@ -116,7 +116,7 @@ class Invoice(Base):
     type: Mapped[InvoiceType] = mapped_column(String(20), nullable=False, index=True)
     contact_id: Mapped[int] = mapped_column(ForeignKey("contacts.id"), nullable=False, index=True)
     date: Mapped[_Date] = mapped_column(Date, nullable=False, index=True)
-    due_date: Mapped[_Date | None] = mapped_column(Date, nullable=True)
+    due_date: Mapped[_Date | None] = mapped_column(Date, nullable=True, index=True)
     label: Mapped[InvoiceLabel | None] = mapped_column(String(10), nullable=True)
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
     reference: Mapped[str | None] = mapped_column(String(100), nullable=True)

--- a/backend/services/dashboard_service.py
+++ b/backend/services/dashboard_service.py
@@ -22,9 +22,6 @@ async def get_dashboard(db: AsyncSession) -> dict[str, object]:
     """Return dashboard KPIs and alerts."""
     today = date.today()
 
-    def remaining_amount(invoice: Invoice) -> Decimal:
-        return invoice.total_amount - invoice.paid_amount
-
     # --- Bank balance (last transaction balance_after) ---
     bank_result = await db.execute(
         select(BankTransaction.balance_after)
@@ -41,26 +38,37 @@ async def get_dashboard(db: AsyncSession) -> dict[str, object]:
     )
     cash_balance = cash_result.scalar_one_or_none() or Decimal("0")
 
-    # --- Client invoices with a remaining amount (status can be stale after imports/edits) ---
-    client_invoices_result = await db.execute(
-        select(Invoice).where(
+    # --- Unpaid client invoices (total_amount > paid_amount, filtered in DB) ---
+    unpaid_result = await db.execute(
+        select(
+            func.count(Invoice.id),
+            func.coalesce(func.sum(Invoice.total_amount - Invoice.paid_amount), Decimal("0")),
+        ).where(
             Invoice.type == InvoiceType.CLIENT,
             Invoice.status != InvoiceStatus.DRAFT,
+            Invoice.total_amount > Invoice.paid_amount,
         )
     )
-    client_invoices = client_invoices_result.scalars().all()
-    unpaid_invoices = [invoice for invoice in client_invoices if remaining_amount(invoice) > 0]
-    unpaid_count = len(unpaid_invoices)
-    unpaid_total = sum(remaining_amount(inv) for inv in unpaid_invoices)
+    unpaid_row = unpaid_result.one()
+    unpaid_count: int = unpaid_row[0] or 0
+    unpaid_total: Decimal = unpaid_row[1] or Decimal("0")
 
-    # --- Overdue invoices (remaining amount > 0 with due_date < today) ---
-    overdue_invoices = [
-        invoice
-        for invoice in unpaid_invoices
-        if invoice.due_date is not None and invoice.due_date < today
-    ]
-    overdue_count = len(overdue_invoices)
-    overdue_total = sum(remaining_amount(inv) for inv in overdue_invoices)
+    # --- Overdue invoices (remaining amount > 0 with due_date < today, filtered in DB) ---
+    overdue_result = await db.execute(
+        select(
+            func.count(Invoice.id),
+            func.coalesce(func.sum(Invoice.total_amount - Invoice.paid_amount), Decimal("0")),
+        ).where(
+            Invoice.type == InvoiceType.CLIENT,
+            Invoice.status != InvoiceStatus.DRAFT,
+            Invoice.total_amount > Invoice.paid_amount,
+            Invoice.due_date.is_not(None),
+            Invoice.due_date < today,
+        )
+    )
+    overdue_row = overdue_result.one()
+    overdue_count: int = overdue_row[0] or 0
+    overdue_total: Decimal = overdue_row[1] or Decimal("0")
 
     # --- Undeposited payments (client chèques/espèces not yet deposited) ---
     undeposited_result = await db.execute(

--- a/backend/services/payment.py
+++ b/backend/services/payment.py
@@ -7,6 +7,7 @@ from decimal import Decimal
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import aliased
 
 from backend.models.cash import CashEntrySource, CashMovementType
 from backend.models.invoice import Invoice, InvoiceStatus, InvoiceType
@@ -172,13 +173,12 @@ async def list_payments(
     skip: int = 0,
     limit: int = 100,
 ) -> list[PaymentRead]:
-    query = select(Payment)
+    inv = aliased(Invoice)
+    query = select(Payment, inv.number, inv.type).join(inv, Payment.invoice_id == inv.id)
     if invoice_id is not None:
         query = query.where(Payment.invoice_id == invoice_id)
     if invoice_type is not None:
-        query = query.join(Invoice, Payment.invoice_id == Invoice.id).where(
-            Invoice.type == invoice_type
-        )
+        query = query.where(inv.type == invoice_type)
     if contact_id is not None:
         query = query.where(Payment.contact_id == contact_id)
     if from_date is not None:
@@ -187,11 +187,21 @@ async def list_payments(
         query = query.where(Payment.date <= to_date)
     if undeposited_only:
         query = query.where(Payment.deposited == False)  # noqa: E712
-    query = query.order_by(Payment.date.desc(), Payment.id.desc()).offset(skip)
-    query = query.limit(limit)
+    query = query.order_by(Payment.date.desc(), Payment.id.desc()).offset(skip).limit(limit)
     result = await db.execute(query)
-    payments_orm = list(result.scalars().all())
-    return [await _to_payment_read(db, p) for p in payments_orm]
+    rows = result.all()
+    out: list[PaymentRead] = []
+    for payment, inv_number, inv_type in rows:
+        read = PaymentRead.model_validate(payment)
+        out.append(
+            read.model_copy(
+                update={
+                    "invoice_number": inv_number,
+                    "invoice_type": InvoiceType(inv_type) if inv_type else None,
+                }
+            )
+        )
+    return out
 
 
 async def update_payment(db: AsyncSession, payment_id: int, payload: PaymentUpdate) -> PaymentRead:

--- a/backend/services/payment.py
+++ b/backend/services/payment.py
@@ -23,6 +23,16 @@ class PaymentDeleteError(ValueError):
     """Raised when a payment deletion is not allowed in the standard workflow."""
 
 
+def _build_payment_read(
+    payment: Payment,
+    invoice_number: str | None,
+    invoice_type: InvoiceType | None,
+) -> PaymentRead:
+    """Build a PaymentRead DTO from an ORM Payment and pre-fetched invoice metadata."""
+    read = PaymentRead.model_validate(payment)
+    return read.model_copy(update={"invoice_number": invoice_number, "invoice_type": invoice_type})
+
+
 async def _to_payment_read(db: AsyncSession, payment: Payment) -> PaymentRead:
     """Build a PaymentRead DTO enriched with invoice metadata."""
     result = await db.execute(
@@ -31,8 +41,7 @@ async def _to_payment_read(db: AsyncSession, payment: Payment) -> PaymentRead:
     row = result.one_or_none()
     invoice_number: str | None = row[0] if row else None
     invoice_type: InvoiceType | None = InvoiceType(row[1]) if row and row[1] else None
-    read = PaymentRead.model_validate(payment)
-    return read.model_copy(update={"invoice_number": invoice_number, "invoice_type": invoice_type})
+    return _build_payment_read(payment, invoice_number, invoice_type)
 
 
 async def _get_payment_orm(db: AsyncSession, payment_id: int) -> Payment | None:
@@ -190,18 +199,10 @@ async def list_payments(
     query = query.order_by(Payment.date.desc(), Payment.id.desc()).offset(skip).limit(limit)
     result = await db.execute(query)
     rows = result.all()
-    out: list[PaymentRead] = []
-    for payment, inv_number, inv_type in rows:
-        read = PaymentRead.model_validate(payment)
-        out.append(
-            read.model_copy(
-                update={
-                    "invoice_number": inv_number,
-                    "invoice_type": InvoiceType(inv_type) if inv_type else None,
-                }
-            )
-        )
-    return out
+    return [
+        _build_payment_read(payment, inv_number, InvoiceType(inv_type) if inv_type else None)
+        for payment, inv_number, inv_type in rows
+    ]
 
 
 async def update_payment(db: AsyncSession, payment_id: int, payload: PaymentUpdate) -> PaymentRead:

--- a/doc/backlog.md
+++ b/doc/backlog.md
@@ -55,7 +55,7 @@ Quand un sujet est livré, mettre à jour `CHANGELOG.md` et passer le ticket en 
 | --- | --- | --- | --- | --- | --- | --- |
 | BIZ-089 | Gestion des salaires — aide saisie, composantes CDD, vue coûts personnel | P1 | ~3h | 2026-04-25 | 2026-04-25 | 2026-04-25 |
 | BIZ-090 | Import Excel Gestion — champs CDD dans la feuille « Aide Salaires » | P1 | ~30 min | 2026-04-25 | 2026-04-25 | 2026-04-25 |
-| TEC-105 | Lenteur navigation et chargement des données | P2 | ~2h | 2026-04-25 | | |
+| TEC-105 | Lenteur navigation et chargement des données | P2 | ~2h | 2026-04-25 | 2026-04-25 | |
 | CHR-021 | Manuel utilisateur illustré | P1 | ~20 min | 2026-04-13 | 2026-04-13 | |
 | TEC-039 | Revalidation scénarios facture / email | P1 | ~10 min | 2026-04-21 | | |
 | CHR-020 | Documentation de contribution | P3 | ~5 min | 2026-04-13 | 2026-04-21 | |


### PR DESCRIPTION
## Summary

Three performance improvements targeting slow navigation and data loading (TEC-105).

## Changes

### 1. SQL index on `invoices.due_date` (migration 0028)
Added `index=True` on `Invoice.due_date` + Alembic migration `0028_add_invoice_due_date_index.py`. Speeds up the overdue-invoice filter run on every dashboard load.

### 2. Fix N+1 in `payment.list_payments()`
The previous implementation called `_to_payment_read()` for each payment, which issued a separate DB query to fetch `Invoice.number` and `Invoice.type`. Replaced with a single `SELECT … JOIN Invoice` query using `sqlalchemy.orm.aliased`. 100 payments → 1 query instead of 101.

### 3. Dashboard filters pushed to SQL
The dashboard previously loaded **all** non-draft client invoices into Python memory, then filtered unpaid/overdue with list comprehensions. Replaced with two SQL aggregate queries (`func.count` + `func.sum` + `WHERE` clauses). The unused local helper `remaining_amount()` was removed as dead code.

## Testing

- 935 backend tests passing
- 126 frontend tests passing
- ruff, mypy, eslint, vue-tsc all clean

## Summary by Sourcery

Improve performance of invoice-related views and dashboard KPIs by optimizing queries and adding a supporting index.

Bug Fixes:
- Eliminate the N+1 query pattern in payment listing by loading related invoice metadata in the main query.

Enhancements:
- Push unpaid and overdue invoice aggregations on the dashboard from in-memory filtering to SQL aggregate queries.
- Add a database index on invoice due_date to speed up overdue invoice lookups and dashboard filters.

Documentation:
- Document TEC-105 performance improvements in the changelog and mark the backlog ticket as delivered.