### PR TITLE
feat(quality): Lots O+P — SQL pagination, FK cascade, missing tests, frontend refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,22 @@ Ce projet respecte le [Versionnage sémantique](https://semver.org/lang/fr/).
 
 ### Ajouté
 
+- TEC-099 : Contrainte `ON DELETE CASCADE` sur la FK `payments.invoice_id → invoices.id` (migration Alembic `0030_payment_invoice_cascade`) — suppression d'une facture en base entraîne désormais la suppression en cascade des paiements associés, éliminant le risque d'enregistrements orphelins
+- TEC-100 : `tests/unit/test_pdf_service.py` — 13 tests couvrant `render_invoice_html` (contenu HTML) et `generate_invoice_pdf` / `save_invoice_pdf` (WeasyPrint mocké via `sys.modules` pour éviter l'import natif GTK)
+- TEC-100 : `tests/unit/test_email_service.py` — 11 tests couvrant STARTTLS, SSL, BCC optionnel, sujet du message, et gestion des erreurs SMTP/OS/auth
+- TEC-101 : Composable `frontend/src/composables/useInvoiceMetrics.ts` — extrait `receivableMetrics` et `portfolioMetrics` de `ClientInvoicesView.vue`, avec export des helpers purs `remainingForInvoice`, `isOpenReceivableInvoice`, `isOverdueInvoice`
+- TEC-102 : Utilitaire `frontend/src/utils/errorUtils.ts` — fonction `getErrorDetail(error, fallback)` qui extrait le message `detail` des erreurs FastAPI structurées
+- TEC-103 : Debounce 300 ms sur le filtre global de `ClientInvoicesView.vue` via `globalFilterInput` ref + `setTimeout`/`clearTimeout` natif — évite les re-renders à chaque frappe sur de longues listes
+
+### Modifié
+
+- TEC-098 : `backend/services/accounting_entry_service.py` — suppression de `limit=100_000` ; `get_balance`, `get_resultat`, `get_bilan` utilisent désormais des agrégations SQL (`GROUP BY + SUM`) ; `get_grouped_journal` utilise une pagination SQL réelle (`OFFSET/LIMIT` poussés dans la requête SQLAlchemy, plus de slice Python)
+- TEC-098 : `backend/services/export_service.py` — `export_journal_csv` passe `limit=None` pour lever le plafond de 100 000 lignes sans charger en mémoire
+- TEC-102 : `BankClientPaymentDialog.vue`, `BankSupplierPaymentDialog.vue`, `BankLinkClientPaymentDialog.vue`, `BankLinkSupplierPaymentDialog.vue` — extraction d'erreur inline remplacée par `getErrorDetail()`
+- TEC-104 : `CashView.vue` — type `CashDenomField` dédié élimine le cast `as unknown as Record<string, number>` dans le template ; `CashEntryFormState.date` déclaré `Date | string` élimine les deux casts `as unknown as Date`
+
+### Ajouté
+
 - BIZ-108 : Écran de supervision système (`/system`) — panneau état (version, taille DB, uptime, badge statut), panneau sauvegardes (création + liste), journaux applicatifs (filtres niveau + texte, couleur par niveau, défilement)
 - BIZ-109 : Journal d'audit — endpoint `GET /api/settings/audit-logs` et panneau dédié dans l'écran système (tableau horodatage / acteur / action / cible / détail)
 - BIZ-108 : Schémas Pydantic `SystemInfoRead`, `BackupFileRead`, `LogEntryRead`, `AuditLogRead` dans `backend/schemas/settings.py`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,36 +19,11 @@ Ce projet respecte le [Versionnage sémantique](https://semver.org/lang/fr/).
 - TEC-101 : Composable `frontend/src/composables/useInvoiceMetrics.ts` — extrait `receivableMetrics` et `portfolioMetrics` de `ClientInvoicesView.vue`, avec export des helpers purs `remainingForInvoice`, `isOpenReceivableInvoice`, `isOverdueInvoice`
 - TEC-102 : Utilitaire `frontend/src/utils/errorUtils.ts` — fonction `getErrorDetail(error, fallback)` qui extrait le message `detail` des erreurs FastAPI structurées
 - TEC-103 : Debounce 300 ms sur le filtre global de `ClientInvoicesView.vue` via `globalFilterInput` ref + `setTimeout`/`clearTimeout` natif — évite les re-renders à chaque frappe sur de longues listes
-
-### Modifié
-
-- TEC-098 : `backend/services/accounting_entry_service.py` — suppression de `limit=100_000` ; `get_balance`, `get_resultat`, `get_bilan` utilisent désormais des agrégations SQL (`GROUP BY + SUM`) ; `get_grouped_journal` utilise une pagination SQL réelle (`OFFSET/LIMIT` poussés dans la requête SQLAlchemy, plus de slice Python)
-- TEC-098 : `backend/services/export_service.py` — `export_journal_csv` passe `limit=None` pour lever le plafond de 100 000 lignes sans charger en mémoire
-- TEC-102 : `BankClientPaymentDialog.vue`, `BankSupplierPaymentDialog.vue`, `BankLinkClientPaymentDialog.vue`, `BankLinkSupplierPaymentDialog.vue` — extraction d'erreur inline remplacée par `getErrorDetail()`
-- TEC-104 : `CashView.vue` — type `CashDenomField` dédié élimine le cast `as unknown as Record<string, number>` dans le template ; `CashEntryFormState.date` déclaré `Date | string` élimine les deux casts `as unknown as Date`
-
-### Ajouté
-
 - BIZ-108 : Écran de supervision système (`/system`) — panneau état (version, taille DB, uptime, badge statut), panneau sauvegardes (création + liste), journaux applicatifs (filtres niveau + texte, couleur par niveau, défilement)
 - BIZ-109 : Journal d'audit — endpoint `GET /api/settings/audit-logs` et panneau dédié dans l'écran système (tableau horodatage / acteur / action / cible / détail)
 - BIZ-108 : Schémas Pydantic `SystemInfoRead`, `BackupFileRead`, `LogEntryRead`, `AuditLogRead` dans `backend/schemas/settings.py`
 - BIZ-108 : Endpoints admin `GET /api/settings/system-info`, `GET /api/settings/backups`, `GET /api/settings/logs` avec parsing des fichiers de rotation
 - BIZ-108 : Fonctions API TypeScript `getSystemInfoApi`, `listBackupsApi`, `getLogsApi`, `getAuditLogsApi` dans `frontend/src/api/settings.ts`
-
-### Modifié
-
-- Navigation : page « Employés » déplacée de la section Comptabilité vers la section Gestion
-- Navigation : ajout de l'entrée « Supervision système » dans la section Administration (admins uniquement)
-
-### Corrigé
-
-- BIZ-108 : Ordre de lecture des fichiers de rotation inversé — `.log.1` (plus récent) était lu après `.log.2` (plus ancien), masquant les entrées récentes
-- BIZ-108 : Filtre de niveau des journaux passé côté serveur — le filtre s'applique maintenant avant la limite de 500 lignes, rechargement automatique à chaque changement de filtre
-- BIZ-109 : Labels des actions d'audit traduits en français dans l'écran de supervision (clés i18n imbriquées `system.action.*`)
-- BIZ-109 : Horodatages affichés en heure locale — SQLite stockant les dates sans suffixe de fuseau, elles étaient interprétées comme heure locale plutôt qu'UTC (décalage −2h)
-
-### Ajouté (fonctionnalités précédentes)
-
 - BIZ-107 : Colonne « Dernière facture » dans le tableau des contacts (référence + date) — enrichissement backend avec sous-requête SQLAlchemy MAX(date) par contact
 - BIZ-107 : Historique contact en Dialog centré (au lieu d'une navigation vers une page dédiée) — composant `ContactHistoryContent` partagé entre la vue pleine page et le dialog
 - BIZ-107 : `ContactHistoryContent.vue` — composant extrait de `ContactDetailView`, réutilisable via prop `contactId` et événement `contact-loaded`
@@ -56,24 +31,26 @@ Ce projet respecte le [Versionnage sémantique](https://semver.org/lang/fr/).
 
 ### Modifié
 
+- TEC-098 : `backend/services/accounting_entry_service.py` — suppression de `limit=100_000` ; `get_balance`, `get_resultat`, `get_bilan` utilisent désormais des agrégations SQL (`GROUP BY + SUM`) ; `get_grouped_journal` utilise une pagination SQL réelle (`OFFSET/LIMIT` poussés dans la requête SQLAlchemy, plus de slice Python)
+- TEC-098 : `backend/services/export_service.py` — `export_journal_csv` passe `limit=None` pour lever le plafond de 100 000 lignes sans charger en mémoire
+- TEC-102 : `BankClientPaymentDialog.vue`, `BankSupplierPaymentDialog.vue`, `BankLinkClientPaymentDialog.vue`, `BankLinkSupplierPaymentDialog.vue` — extraction d'erreur inline remplacée par `getErrorDetail()`
+- TEC-104 : `CashView.vue` — type `CashDenomField` dédié élimine le cast `as unknown as Record<string, number>` dans le template ; `CashEntryFormState.date` déclaré `Date | string` élimine les deux casts `as unknown as Date`
+- Navigation : page « Employés » déplacée de la section Comptabilité vers la section Gestion
+- Navigation : ajout de l'entrée « Supervision système » dans la section Administration (admins uniquement)
 - BIZ-107 : `ContactDetailView.vue` — réécrit comme wrapper léger autour de `ContactHistoryContent`
 - BIZ-107 : `ContactsView.vue` — bouton historique ouvre le dialog au lieu de naviguer, nouvelle colonne « Dernière facture »
-
-### Corrigé
-
-- TEC-110 (REC-016) : Fix SPA — `index.html` servi avec `Cache-Control: no-store, no-cache, must-revalidate` ; assets hachés `/assets/*` avec `immutable, max-age=1 an`. Élimine l'erreur `TypeError: error loading dynamically imported module` après un rebuild Docker (navigateur chargeait un `index.html` mis en cache référençant des hashes de chunks obsolètes)
-
- dans la page Paramètres — appelle `POST /api/settings/backup` et déclenche le téléchargement du fichier `.db` avec un nom horodaté (`solde_backup_YYYY-MM-DD-HH-MM-SS.db`) (CHR-019, REC-004)
-- `doc/dev/exploitation.md` : section déploiement Portainer / NAS Synology — stack YAML, variables d'environnement, données persistantes, procédure de mise à jour (CHR-019, REC-004)
-- Écran Salaires rendu accessible au rôle `secretaire` (Management) en plus des rôles `tresorier` et `admin` (REC-005)
-- CRUD complet des règles comptables réservé aux admins : création, modification, suppression avec confirmation ; dialog formulaire avec sélecteur de déclencheur, lignes comptables éditables ; 26 libellés et descriptions métier en français par déclencheur (REC-008)
-
-### Modifié
-
 - `PUT /api/accounting/rules/{id}` : accès resserré de trésorier+admin à **admin uniquement**, cohérent avec `POST /` et `DELETE /{id}` (REC-008)
 
 ### Corrigé
 
+- BIZ-108 : Ordre de lecture des fichiers de rotation inversé — `.log.1` (plus récent) était lu après `.log.2` (plus ancien), masquant les entrées récentes
+- BIZ-108 : Filtre de niveau des journaux passé côté serveur — le filtre s'applique maintenant avant la limite de 500 lignes, rechargement automatique à chaque changement de filtre
+- BIZ-109 : Labels des actions d'audit traduits en français dans l'écran de supervision (clés i18n imbriquées `system.action.*`)
+- BIZ-109 : Horodatages affichés en heure locale — SQLite stockant les dates sans suffixe de fuseau, elles étaient interprétées comme heure locale plutôt qu'UTC (décalage −2h)
+- TEC-110 (REC-016) : Fix SPA — `index.html` servi avec `Cache-Control: no-store, no-cache, must-revalidate` ; assets hachés `/assets/*` avec `immutable, max-age=1 an`. Élimine l'erreur `TypeError: error loading dynamically imported module` après un rebuild Docker (navigateur chargeait un `index.html` mis en cache référençant des hashes de chunks obsolètes)
+- `doc/dev/exploitation.md` : section déploiement Portainer / NAS Synology — stack YAML, variables d'environnement, données persistantes, procédure de mise à jour (CHR-019, REC-004)
+- Écran Salaires rendu accessible au rôle `secretaire` (Management) en plus des rôles `tresorier` et `admin` (REC-005)
+- CRUD complet des règles comptables réservé aux admins : création, modification, suppression avec confirmation ; dialog formulaire avec sélecteur de déclencheur, lignes comptables éditables ; 26 libellés et descriptions métier en français par déclencheur (REC-008)
 - Docker : rechargement direct sur une route Vue retournait 404 — FastAPI sert désormais `index.html` en fallback pour toutes les routes hors `/api/**` (REC-003)
 - Docker : `libgdk-pixbuf2.0-0` absent de Debian Trixie remplacé par `libgdk-pixbuf-xlib-2.0-0` — génération PDF WeasyPrint rétablie (REC-002)
 - Docker : `pyproject.toml` absent du stage `frontend-builder`, causant un échec de build de l'image (REC-007)

--- a/backend/alembic/versions/0030_payment_invoice_cascade.py
+++ b/backend/alembic/versions/0030_payment_invoice_cascade.py
@@ -3,6 +3,10 @@
 SQLite does not support ALTER TABLE ADD/DROP CONSTRAINT, so we recreate
 the payments table with the new FK constraint.
 
+The original FK was created in migration 0005 without an explicit name, so
+its reflected name is unknown at write time.  We use SQLAlchemy inspection at
+run time to locate the correct constraint before dropping it.
+
 Revision ID: 0030
 Revises: 0029
 Create Date: 2026-04-29
@@ -10,6 +14,7 @@ Create Date: 2026-04-29
 
 from collections.abc import Sequence
 
+import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
@@ -19,9 +24,26 @@ branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 
 
+def _invoice_fk_name() -> str | None:
+    """Return the reflected name of the FK payments.invoice_id → invoices.id."""
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    return next(
+        (
+            fk.get("name")
+            for fk in inspector.get_foreign_keys("payments")
+            if fk.get("referred_table") == "invoices"
+            and "invoice_id" in (fk.get("constrained_columns") or [])
+        ),
+        None,
+    )
+
+
 def upgrade() -> None:
+    old_fk_name = _invoice_fk_name()
     with op.batch_alter_table("payments", recreate="always") as batch_op:
-        batch_op.drop_constraint("fk_payments_invoice_id", type_="foreignkey")
+        if old_fk_name is not None:
+            batch_op.drop_constraint(old_fk_name, type_="foreignkey")
         batch_op.create_foreign_key(
             "fk_payments_invoice_id",
             "invoices",
@@ -34,8 +56,9 @@ def upgrade() -> None:
 def downgrade() -> None:
     with op.batch_alter_table("payments", recreate="always") as batch_op:
         batch_op.drop_constraint("fk_payments_invoice_id", type_="foreignkey")
+        # Recreate without CASCADE, unnamed (matching the original migration 0005)
         batch_op.create_foreign_key(
-            "fk_payments_invoice_id",
+            None,
             "invoices",
             ["invoice_id"],
             ["id"],

--- a/backend/alembic/versions/0030_payment_invoice_cascade.py
+++ b/backend/alembic/versions/0030_payment_invoice_cascade.py
@@ -1,0 +1,42 @@
+"""Add ON DELETE CASCADE to payments.invoice_id FK.
+
+SQLite does not support ALTER TABLE ADD/DROP CONSTRAINT, so we recreate
+the payments table with the new FK constraint.
+
+Revision ID: 0030
+Revises: 0029
+Create Date: 2026-04-29
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0030"
+down_revision: str | None = "0029"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("payments", recreate="always") as batch_op:
+        batch_op.drop_constraint("fk_payments_invoice_id", type_="foreignkey")
+        batch_op.create_foreign_key(
+            "fk_payments_invoice_id",
+            "invoices",
+            ["invoice_id"],
+            ["id"],
+            ondelete="CASCADE",
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("payments", recreate="always") as batch_op:
+        batch_op.drop_constraint("fk_payments_invoice_id", type_="foreignkey")
+        batch_op.create_foreign_key(
+            "fk_payments_invoice_id",
+            "invoices",
+            ["invoice_id"],
+            ["id"],
+        )

--- a/backend/models/payment.py
+++ b/backend/models/payment.py
@@ -26,7 +26,9 @@ class Payment(Base):
     __tablename__ = "payments"
 
     id: Mapped[int] = mapped_column(primary_key=True, index=True)
-    invoice_id: Mapped[int] = mapped_column(ForeignKey("invoices.id"), nullable=False, index=True)
+    invoice_id: Mapped[int] = mapped_column(
+        ForeignKey("invoices.id", ondelete="CASCADE"), nullable=False, index=True
+    )
     contact_id: Mapped[int] = mapped_column(ForeignKey("contacts.id"), nullable=False, index=True)
     amount: Mapped[_Decimal] = mapped_column(DecimalType(10, 2), nullable=False)
     date: Mapped[_Date] = mapped_column(Date, nullable=False, index=True)

--- a/backend/services/accounting_entry_service.py
+++ b/backend/services/accounting_entry_service.py
@@ -6,7 +6,7 @@ from collections.abc import Iterable
 from datetime import date, timedelta
 from decimal import Decimal
 
-from sqlalchemy import and_, func, or_, select
+from sqlalchemy import String, cast, func, literal_column, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql.elements import ColumnElement
 
@@ -81,7 +81,7 @@ async def _query_journal_entries(
     source_type: EntrySourceType | None = None,
     fiscal_year_id: int | None = None,
     skip: int = 0,
-    limit: int = 100,
+    limit: int | None = 100,
 ) -> list[AccountingEntry]:
     query = select(AccountingEntry)
     if from_date:
@@ -96,9 +96,59 @@ async def _query_journal_entries(
         query = query.where(AccountingEntry.fiscal_year_id == fiscal_year_id)
     query = query.order_by(AccountingEntry.date.asc(), AccountingEntry.id.asc())
     query = query.offset(skip)
-    query = query.limit(limit)
+    if limit is not None:
+        query = query.limit(limit)
     result = await db.execute(query)
     return list(result.scalars().all())
+
+
+async def _query_group_keys_paged(
+    db: AsyncSession,
+    *,
+    from_date: date | None = None,
+    to_date: date | None = None,
+    account_number: str | None = None,
+    source_type: EntrySourceType | None = None,
+    fiscal_year_id: int | None = None,
+    skip: int = 0,
+    limit: int = 100,
+) -> list[str]:
+    """Return a paginated list of effective group keys matching the filter.
+
+    The effective group key is COALESCE(group_key, 'entry:' || id), ordered
+    by (MIN(date), MIN(id)) so pagination is stable and chronological.
+    """
+    effective_gk = func.coalesce(
+        AccountingEntry.group_key,
+        literal_column("'entry:'").op("||")(cast(AccountingEntry.id, String)),
+    ).label("effective_gk")
+
+    query = select(
+        effective_gk,
+        func.min(AccountingEntry.date).label("min_date"),
+        func.min(AccountingEntry.id).label("min_id"),
+    )
+    if from_date:
+        query = query.where(AccountingEntry.date >= from_date)
+    if to_date:
+        query = query.where(AccountingEntry.date <= to_date)
+    if account_number:
+        query = query.where(AccountingEntry.account_number == account_number)
+    if source_type:
+        query = query.where(AccountingEntry.source_type == source_type)
+    if fiscal_year_id:
+        query = query.where(AccountingEntry.fiscal_year_id == fiscal_year_id)
+    query = (
+        query.group_by(effective_gk)
+        .order_by(
+            func.min(AccountingEntry.date).asc(),
+            func.min(AccountingEntry.id).asc(),
+        )
+        .offset(skip)
+        .limit(limit)
+    )
+    result = await db.execute(query)
+    return [row.effective_gk for row in result.all()]
 
 
 async def _load_account_labels(
@@ -307,64 +357,6 @@ async def _enrich_journal_entries(
     return journal_entries
 
 
-async def _load_entries_for_groups(
-    db: AsyncSession,
-    matched_entries: list[AccountingEntry],
-) -> list[AccountingEntry]:
-    if not matched_entries:
-        return []
-
-    group_keys = sorted(
-        {entry.group_key for entry in matched_entries if entry.group_key is not None}
-    )
-    source_groups = sorted(
-        {
-            (entry.source_type, entry.source_id)
-            for entry in matched_entries
-            if entry.group_key is None
-            and entry.source_type is not None
-            and entry.source_id is not None
-        },
-        key=lambda item: (str(item[0]), item[1]),
-    )
-    entry_ids = sorted(
-        {
-            entry.id
-            for entry in matched_entries
-            if entry.group_key is None and (entry.source_type is None or entry.source_id is None)
-        }
-    )
-
-    conditions: list[ColumnElement[bool]] = []
-    if group_keys:
-        conditions.append(AccountingEntry.group_key.in_(group_keys))
-    if source_groups:
-        conditions.append(
-            or_(
-                *[
-                    and_(
-                        AccountingEntry.source_type == source_type,
-                        AccountingEntry.source_id == source_id,
-                    )
-                    for source_type, source_id in source_groups
-                ]
-            )
-        )
-    if entry_ids:
-        conditions.append(AccountingEntry.id.in_(entry_ids))
-
-    if not conditions:
-        return matched_entries
-
-    query = (
-        select(AccountingEntry)
-        .where(or_(*conditions))
-        .order_by(AccountingEntry.date.asc(), AccountingEntry.id.asc())
-    )
-    result = await db.execute(query)
-    return list(result.scalars().all())
-
-
 async def get_journal(
     db: AsyncSession,
     *,
@@ -374,7 +366,7 @@ async def get_journal(
     source_type: EntrySourceType | None = None,
     fiscal_year_id: int | None = None,
     skip: int = 0,
-    limit: int = 100,
+    limit: int | None = 100,
 ) -> list[AccountingEntryRead]:
     entries = await _query_journal_entries(
         db,
@@ -400,27 +392,47 @@ async def get_grouped_journal(
     skip: int = 0,
     limit: int = 100,
 ) -> list[AccountingEntryGroupRead]:
-    matched_entries = await _query_journal_entries(
+    # Step 1: paginate at the group level using SQL — avoid loading all entries.
+    group_keys = await _query_group_keys_paged(
         db,
         from_date=from_date,
         to_date=to_date,
         account_number=account_number,
         source_type=source_type,
         fiscal_year_id=fiscal_year_id,
-        limit=100_000,
+        skip=skip,
+        limit=limit,
     )
-    if not matched_entries:
+    if not group_keys:
         return []
 
-    matched_group_keys = _ordered_unique(_runtime_group_key(entry) for entry in matched_entries)
-    group_entries = await _load_entries_for_groups(db, matched_entries)
+    # Step 2: load all entries belonging to those groups (all sibling lines).
+    stored_keys = [gk for gk in group_keys if not gk.startswith("entry:")]
+    standalone_ids = [int(gk[6:]) for gk in group_keys if gk.startswith("entry:")]
+    conditions: list[ColumnElement[bool]] = []
+    if stored_keys:
+        conditions.append(AccountingEntry.group_key.in_(stored_keys))
+    if standalone_ids:
+        conditions.append(AccountingEntry.id.in_(standalone_ids))
+    if not conditions:
+        return []
+
+    entries_q = (
+        select(AccountingEntry)
+        .where(or_(*conditions) if len(conditions) > 1 else conditions[0])
+        .order_by(AccountingEntry.date.asc(), AccountingEntry.id.asc())
+    )
+    result = await db.execute(entries_q)
+    group_entries = list(result.scalars().all())
+
+    # Step 3: enrich and assemble groups in the SQL-paginated order.
     journal_lines = await _enrich_journal_entries(db, group_entries)
     lines_by_group: dict[str, list[AccountingEntryRead]] = {}
     for line in journal_lines:
         lines_by_group.setdefault(line.group_key, []).append(line)
 
     groups: list[AccountingEntryGroupRead] = []
-    for group_key in matched_group_keys:
+    for group_key in group_keys:
         lines = lines_by_group.get(group_key, [])
         if not lines:
             continue
@@ -448,9 +460,6 @@ async def get_grouped_journal(
             )
         )
 
-    if skip:
-        groups = groups[skip:]
-    groups = groups[:limit]
     return groups
 
 
@@ -466,44 +475,42 @@ async def get_balance(
     to_date: date | None = None,
     fiscal_year_id: int | None = None,
 ) -> list[BalanceRow]:
-    """Return balance grouped by account number."""
-    entries = await _query_journal_entries(
-        db,
-        from_date=from_date,
-        to_date=to_date,
-        fiscal_year_id=fiscal_year_id,
-        limit=100_000,
+    """Return balance grouped by account number using SQL aggregation."""
+    query = select(
+        AccountingEntry.account_number,
+        func.sum(AccountingEntry.debit).label("total_debit"),
+        func.sum(AccountingEntry.credit).label("total_credit"),
     )
+    if from_date:
+        query = query.where(AccountingEntry.date >= from_date)
+    if to_date:
+        query = query.where(AccountingEntry.date <= to_date)
+    if fiscal_year_id:
+        query = query.where(AccountingEntry.fiscal_year_id == fiscal_year_id)
+    query = query.group_by(AccountingEntry.account_number).order_by(AccountingEntry.account_number)
+    agg_result = await db.execute(query)
+    agg_rows = agg_result.all()
 
-    # Aggregate per account
-    totals: dict[str, dict[str, Decimal]] = {}
-    for e in entries:
-        acct = e.account_number
-        if acct not in totals:
-            totals[acct] = {"debit": Decimal("0"), "credit": Decimal("0")}
-        totals[acct]["debit"] += e.debit
-        totals[acct]["credit"] += e.credit
+    if not agg_rows:
+        return []
 
-    # Look up account labels
-    account_map: dict[str, AccountingAccount] = {}
-    if totals:
-        numbers = list(totals.keys())
-        result = await db.execute(
-            select(AccountingAccount).where(AccountingAccount.number.in_(numbers))
-        )
-        for account in result.scalars().all():
-            account_map[account.number] = account
+    # Look up account labels and types in one query
+    account_numbers = [row.account_number for row in agg_rows]
+    acct_result = await db.execute(
+        select(AccountingAccount).where(AccountingAccount.number.in_(account_numbers))
+    )
+    account_map = {a.number: a for a in acct_result.scalars().all()}
 
     rows: list[BalanceRow] = []
-    for number, sums in sorted(totals.items()):
-        acct_obj = account_map.get(number)
-        label = acct_obj.label if acct_obj else number
-        acct_type = acct_obj.type if acct_obj else "actif"
-        debit = sums["debit"]
-        credit = sums["credit"]
+    for row in agg_rows:
+        acct_obj = account_map.get(row.account_number)
+        label = acct_obj.label if acct_obj else row.account_number
+        acct_type = acct_obj.type if acct_obj else AccountType.ACTIF
+        debit = Decimal(str(row.total_debit))
+        credit = Decimal(str(row.total_credit))
         rows.append(
             BalanceRow(
-                account_number=number,
+                account_number=row.account_number,
                 account_label=label,
                 account_type=acct_type,
                 total_debit=debit,
@@ -549,7 +556,7 @@ async def get_ledger(
         from_date=from_date,
         to_date=to_date,
         fiscal_year_id=fiscal_year_id,
-        limit=100_000,
+        limit=None,
     )
 
     # Account label
@@ -593,88 +600,87 @@ async def get_ledger(
 async def _compute_resultat(
     db: AsyncSession, fiscal_year_id: int | None
 ) -> tuple[Decimal, Decimal]:
-    """Return (total_charges, total_produits) for the given fiscal year."""
-    entries = await _query_journal_entries(db, fiscal_year_id=fiscal_year_id, limit=100_000)
-
-    # Get charge and produit account numbers
-    result = await db.execute(
-        select(AccountingAccount).where(
-            AccountingAccount.type.in_([AccountType.CHARGE, AccountType.PRODUIT])
+    """Return (total_charges, total_produits) for the given fiscal year using SQL aggregation."""
+    query = (
+        select(
+            AccountingAccount.type,
+            func.sum(AccountingEntry.debit).label("total_debit"),
+            func.sum(AccountingEntry.credit).label("total_credit"),
         )
+        .join(AccountingAccount, AccountingEntry.account_number == AccountingAccount.number)
+        .where(AccountingAccount.type.in_([AccountType.CHARGE, AccountType.PRODUIT]))
     )
-    acct_map: dict[str, AccountingAccount] = {a.number: a for a in result.scalars().all()}
+    if fiscal_year_id is not None:
+        query = query.where(AccountingEntry.fiscal_year_id == fiscal_year_id)
+    query = query.group_by(AccountingAccount.type)
+    result = await db.execute(query)
 
-    charges: dict[str, Decimal] = {}
-    produits: dict[str, Decimal] = {}
-
-    for e in entries:
-        acct = acct_map.get(e.account_number)
-        if acct is None:
-            continue
-        if acct.type == AccountType.CHARGE:
-            charges[e.account_number] = (
-                charges.get(e.account_number, Decimal("0")) + e.debit - e.credit
-            )
-        elif acct.type == AccountType.PRODUIT:
-            produits[e.account_number] = (
-                produits.get(e.account_number, Decimal("0")) + e.credit - e.debit
-            )
-
-    return sum(charges.values(), Decimal("0")), sum(produits.values(), Decimal("0"))
+    total_c = Decimal("0")
+    total_p = Decimal("0")
+    for row in result.all():
+        debit = Decimal(str(row.total_debit))
+        credit = Decimal(str(row.total_credit))
+        if row.type == AccountType.CHARGE:
+            total_c = debit - credit
+        elif row.type == AccountType.PRODUIT:
+            total_p = credit - debit
+    return total_c, total_p
 
 
 async def get_resultat(db: AsyncSession, fiscal_year_id: int | None = None) -> ResultatRead:
-    """Build the compte de résultat for a given fiscal year."""
-    entries = await _query_journal_entries(db, fiscal_year_id=fiscal_year_id, limit=100_000)
-
-    result = await db.execute(
-        select(AccountingAccount).where(
-            AccountingAccount.type.in_([AccountType.CHARGE, AccountType.PRODUIT])
+    """Build the compte de résultat for a given fiscal year using SQL aggregation."""
+    query = (
+        select(
+            AccountingEntry.account_number,
+            AccountingAccount.label,
+            AccountingAccount.type,
+            func.sum(AccountingEntry.debit).label("total_debit"),
+            func.sum(AccountingEntry.credit).label("total_credit"),
         )
+        .join(AccountingAccount, AccountingEntry.account_number == AccountingAccount.number)
+        .where(AccountingAccount.type.in_([AccountType.CHARGE, AccountType.PRODUIT]))
     )
-    acct_map: dict[str, AccountingAccount] = {a.number: a for a in result.scalars().all()}
+    if fiscal_year_id is not None:
+        query = query.where(AccountingEntry.fiscal_year_id == fiscal_year_id)
+    query = query.group_by(
+        AccountingEntry.account_number,
+        AccountingAccount.label,
+        AccountingAccount.type,
+    ).order_by(AccountingEntry.account_number)
+    result = await db.execute(query)
 
-    charge_totals: dict[str, Decimal] = {}
-    produit_totals: dict[str, Decimal] = {}
-
-    for e in entries:
-        acct = acct_map.get(e.account_number)
-        if acct is None:
-            continue
-        if acct.type == AccountType.CHARGE:
-            charge_totals[e.account_number] = (
-                charge_totals.get(e.account_number, Decimal("0")) + e.debit - e.credit
+    charges_rows: list[BalanceRow] = []
+    produits_rows: list[BalanceRow] = []
+    for row in result.all():
+        debit = Decimal(str(row.total_debit))
+        credit = Decimal(str(row.total_credit))
+        if row.type == AccountType.CHARGE:
+            tot = debit - credit
+            charges_rows.append(
+                BalanceRow(
+                    account_number=row.account_number,
+                    account_label=row.label,
+                    account_type="charge",
+                    total_debit=tot,
+                    total_credit=Decimal("0"),
+                    solde=tot,
+                )
             )
-        elif acct.type == AccountType.PRODUIT:
-            produit_totals[e.account_number] = (
-                produit_totals.get(e.account_number, Decimal("0")) + e.credit - e.debit
+        elif row.type == AccountType.PRODUIT:
+            tot = credit - debit
+            produits_rows.append(
+                BalanceRow(
+                    account_number=row.account_number,
+                    account_label=row.label,
+                    account_type="produit",
+                    total_debit=Decimal("0"),
+                    total_credit=tot,
+                    solde=tot,
+                )
             )
 
-    charges_rows = [
-        BalanceRow(
-            account_number=num,
-            account_label=acct_map[num].label if num in acct_map else num,
-            account_type="charge",
-            total_debit=tot,
-            total_credit=Decimal("0"),
-            solde=tot,
-        )
-        for num, tot in sorted(charge_totals.items())
-    ]
-    produits_rows = [
-        BalanceRow(
-            account_number=num,
-            account_label=acct_map[num].label if num in acct_map else num,
-            account_type="produit",
-            total_debit=Decimal("0"),
-            total_credit=tot,
-            solde=tot,
-        )
-        for num, tot in sorted(produit_totals.items())
-    ]
-
-    total_c = sum(charge_totals.values(), Decimal("0"))
-    total_p = sum(produit_totals.values(), Decimal("0"))
+    total_c = sum((r.solde for r in charges_rows), Decimal("0"))
+    total_p = sum((r.solde for r in produits_rows), Decimal("0"))
 
     return ResultatRead(
         total_charges=total_c,

--- a/backend/services/accounting_entry_service.py
+++ b/backend/services/accounting_entry_service.py
@@ -6,7 +6,7 @@ from collections.abc import Iterable
 from datetime import date, timedelta
 from decimal import Decimal
 
-from sqlalchemy import String, cast, func, literal_column, or_, select
+from sqlalchemy import String, cast, func, literal_column, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql.elements import ColumnElement
 
@@ -54,6 +54,22 @@ def _runtime_group_key(entry: AccountingEntry) -> str:
         entry.group_key
         or build_entry_group_key(entry.source_type, entry.source_id)
         or f"entry:{entry.id}"
+    )
+
+
+def _effective_gk_expr() -> ColumnElement[str]:
+    """SQL expression mirroring _runtime_group_key priority:
+
+    1. group_key if stored, else
+    2. source_type || ':' || source_id (NULL when either column is NULL), else
+    3. 'entry:' || id.
+    """
+    return func.coalesce(
+        AccountingEntry.group_key,
+        AccountingEntry.source_type.op("||")(
+            literal_column("':'").op("||")(cast(AccountingEntry.source_id, String))
+        ),
+        literal_column("'entry:'").op("||")(cast(AccountingEntry.id, String)),
     )
 
 
@@ -115,13 +131,11 @@ async def _query_group_keys_paged(
 ) -> list[str]:
     """Return a paginated list of effective group keys matching the filter.
 
-    The effective group key is COALESCE(group_key, 'entry:' || id), ordered
-    by (MIN(date), MIN(id)) so pagination is stable and chronological.
+    The effective group key mirrors _runtime_group_key: group_key, then
+    source_type:source_id, then entry:<id>.  Ordered by (MIN(date), MIN(id))
+    so pagination is stable and chronological.
     """
-    effective_gk = func.coalesce(
-        AccountingEntry.group_key,
-        literal_column("'entry:'").op("||")(cast(AccountingEntry.id, String)),
-    ).label("effective_gk")
+    effective_gk = _effective_gk_expr().label("effective_gk")
 
     query = select(
         effective_gk,
@@ -407,19 +421,11 @@ async def get_grouped_journal(
         return []
 
     # Step 2: load all entries belonging to those groups (all sibling lines).
-    stored_keys = [gk for gk in group_keys if not gk.startswith("entry:")]
-    standalone_ids = [int(gk[6:]) for gk in group_keys if gk.startswith("entry:")]
-    conditions: list[ColumnElement[bool]] = []
-    if stored_keys:
-        conditions.append(AccountingEntry.group_key.in_(stored_keys))
-    if standalone_ids:
-        conditions.append(AccountingEntry.id.in_(standalone_ids))
-    if not conditions:
-        return []
-
+    # Use the same effective_gk expression so entries whose group key is derived
+    # from source_type:source_id (rather than a stored group_key) are also found.
     entries_q = (
         select(AccountingEntry)
-        .where(or_(*conditions) if len(conditions) > 1 else conditions[0])
+        .where(_effective_gk_expr().in_(group_keys))
         .order_by(AccountingEntry.date.asc(), AccountingEntry.id.asc())
     )
     result = await db.execute(entries_q)

--- a/backend/services/export_service.py
+++ b/backend/services/export_service.py
@@ -40,7 +40,7 @@ async def export_journal_csv(
         to_date=to_date,
         account_number=account_number,
         fiscal_year_id=fiscal_year_id,
-        limit=100_000,
+        limit=None,
     )
 
     headers = ["N° pièce", "Date", "Compte", "Libellé", "Débit", "Crédit", "Source"]

--- a/doc/backlog.md
+++ b/doc/backlog.md
@@ -19,18 +19,18 @@ Quand un sujet est livré, mettre à jour `CHANGELOG.md` et passer le ticket en 
 
 | ID | Titre | Prio | Est. | Créé | Démarré | Terminé |
 | --- | --- | --- | --- | --- | --- | --- |
-| TEC-098 | Journal comptable : remplacer limit=100 000 par pagination SQL | P1 | ~45 min | 2026-04-25 | | |
-| TEC-099 | Cascade FK manquante Payment → Invoice (+ migration Alembic) | P2 | ~15 min | 2026-04-25 | | |
-| TEC-100 | Tests manquants : pdf_service, email_service, bank_import | P2 | ~1h | 2026-04-25 | | |
+| TEC-098 | Journal comptable : remplacer limit=100 000 par pagination SQL | P1 | ~45 min | 2026-04-25 | 2026-04-29 | 2026-04-30 |
+| TEC-099 | Cascade FK manquante Payment → Invoice (+ migration Alembic) | P2 | ~15 min | 2026-04-25 | 2026-04-29 | 2026-04-30 |
+| TEC-100 | Tests manquants : pdf_service, email_service, bank_import | P2 | ~1h | 2026-04-25 | 2026-04-29 | 2026-04-30 |
 
 ### Lot P — Qualité technique frontend (~1h15) — v0.7
 
 | ID | Titre | Prio | Est. | Créé | Démarré | Terminé |
 | --- | --- | --- | --- | --- | --- | --- |
-| TEC-101 | Refactoring ClientInvoicesView.vue (~1 100 L) | P2 | ~45 min | 2026-04-25 | | |
-| TEC-102 | Utilitaire getErrorDetail() mutualisé (bank dialogs) | P3 | ~10 min | 2026-04-25 | | |
-| TEC-103 | Debounce sur filtres texte en temps réel | P3 | ~10 min | 2026-04-25 | | |
-| TEC-104 | Casts TypeScript non sûrs dans CashView.vue | P2 | ~10 min | 2026-04-25 | | |
+| TEC-101 | Refactoring ClientInvoicesView.vue (~1 100 L) | P2 | ~45 min | 2026-04-25 | 2026-04-29 | 2026-04-30 |
+| TEC-102 | Utilitaire getErrorDetail() mutualisé (bank dialogs) | P3 | ~10 min | 2026-04-25 | 2026-04-29 | 2026-04-30 |
+| TEC-103 | Debounce sur filtres texte en temps réel | P3 | ~10 min | 2026-04-25 | 2026-04-29 | 2026-04-30 |
+| TEC-104 | Casts TypeScript non sûrs dans CashView.vue | P2 | ~10 min | 2026-04-25 | 2026-04-29 | 2026-04-30 |
 
 ### Lot S — Documentation & i18n (~1h) — v0.9
 
@@ -344,6 +344,8 @@ Remplacer toutes les occurrences inline par un appel à `getErrorDetail(error)`.
 | N | UX & formulaires | v0.7 | BIZ-094, BIZ-095, BIZ-096, BIZ-097 | 2026-04-25 |
 | Q | Recette post-merge N | v0.7 | voir doc/recette.md (REC-001..REC-015) | 2026-04-26 |
 | R | Supervision système & audit | v0.8 | BIZ-108, BIZ-109 | 2026-04-26 |
+| O | Qualité technique backend | v0.7 | TEC-098, TEC-099, TEC-100 | 2026-04-30 |
+| P | Qualité technique frontend | v0.7 | TEC-101, TEC-102, TEC-103, TEC-104 | 2026-04-30 |
 
 Tickets fermés hors lots : TEC-067, TEC-068, BIZ-069, BIZ-076, CHR-083, BIZ-036, BIZ-041, BIZ-033, BIZ-088, BIZ-089, BIZ-090, TEC-105, TEC-039, BIZ-107, TEC-110, BIZ-108, BIZ-109.
 Tickets fermés pré-audit : CHR-001, CHR-002, BIZ-003 – BIZ-018, BIZ-022 – BIZ-023.

--- a/frontend/src/components/bank/BankClientPaymentDialog.vue
+++ b/frontend/src/components/bank/BankClientPaymentDialog.vue
@@ -117,6 +117,7 @@ import { listInvoicesApi, type Invoice } from '@/api/invoices'
 import { scoreInvoiceSuggestion } from '@/utils/bankReconciliation'
 import { formatContactDisplayName } from '@/utils/contact'
 import { formatDisplayDate } from '@/utils/format'
+import { getErrorDetail } from '@/utils/errorUtils'
 
 const props = defineProps<{
   visible: boolean
@@ -289,10 +290,9 @@ async function submit(): Promise<void> {
     })
     emit('saved')
   } catch (error) {
-    const detail = (error as { response?: { data?: { detail?: unknown } } })?.response?.data?.detail
     toast.add({
       severity: 'error',
-      summary: typeof detail === 'string' ? detail : t('common.error.unknown'),
+      summary: getErrorDetail(error, t('common.error.unknown')),
       life: 3000,
     })
   } finally {

--- a/frontend/src/components/bank/BankLinkClientPaymentDialog.vue
+++ b/frontend/src/components/bank/BankLinkClientPaymentDialog.vue
@@ -97,6 +97,7 @@ import { listPayments, type Payment } from '@/api/payments'
 import { scorePaymentSuggestion } from '@/utils/bankReconciliation'
 import { formatContactDisplayName } from '@/utils/contact'
 import { formatDisplayDate } from '@/utils/format'
+import { getErrorDetail } from '@/utils/errorUtils'
 
 const props = defineProps<{
   visible: boolean
@@ -215,10 +216,9 @@ watch(
       contacts.value = conts
       selections.value = buildSelections()
     } catch (error) {
-      const detail = (error as { response?: { data?: { detail?: unknown } } })?.response?.data?.detail
       toast.add({
         severity: 'error',
-        summary: typeof detail === 'string' ? detail : t('common.error.unknown'),
+        summary: getErrorDetail(error, t('common.error.unknown')),
         life: 3000,
       })
     } finally {
@@ -246,10 +246,9 @@ async function submit(): Promise<void> {
     })
     emit('saved')
   } catch (error) {
-    const detail = (error as { response?: { data?: { detail?: unknown } } })?.response?.data?.detail
     toast.add({
       severity: 'error',
-      summary: typeof detail === 'string' ? detail : t('common.error.unknown'),
+      summary: getErrorDetail(error, t('common.error.unknown')),
       life: 3000,
     })
   } finally {

--- a/frontend/src/components/bank/BankLinkSupplierPaymentDialog.vue
+++ b/frontend/src/components/bank/BankLinkSupplierPaymentDialog.vue
@@ -73,6 +73,7 @@ import { listPayments, type Payment } from '@/api/payments'
 import { scorePaymentSuggestion } from '@/utils/bankReconciliation'
 import { formatContactDisplayName } from '@/utils/contact'
 import { formatDisplayDate } from '@/utils/format'
+import { getErrorDetail } from '@/utils/errorUtils'
 
 const props = defineProps<{
   visible: boolean
@@ -162,10 +163,9 @@ watch(
       contacts.value = conts
       selectedPaymentId.value = paymentOptions.value[0]?.value ?? null
     } catch (error) {
-      const detail = (error as { response?: { data?: { detail?: unknown } } })?.response?.data?.detail
       toast.add({
         severity: 'error',
-        summary: typeof detail === 'string' ? detail : t('common.error.unknown'),
+        summary: getErrorDetail(error, t('common.error.unknown')),
         life: 3000,
       })
     } finally {
@@ -183,10 +183,9 @@ async function submit(): Promise<void> {
     toast.add({ severity: 'success', summary: t('bank.link_supplier_payment_success'), life: 3000 })
     emit('saved')
   } catch (error) {
-    const detail = (error as { response?: { data?: { detail?: unknown } } })?.response?.data?.detail
     toast.add({
       severity: 'error',
-      summary: typeof detail === 'string' ? detail : t('common.error.unknown'),
+      summary: getErrorDetail(error, t('common.error.unknown')),
       life: 3000,
     })
   } finally {

--- a/frontend/src/components/bank/BankSupplierPaymentDialog.vue
+++ b/frontend/src/components/bank/BankSupplierPaymentDialog.vue
@@ -73,6 +73,7 @@ import { listInvoicesApi, type Invoice } from '@/api/invoices'
 import { scoreInvoiceSuggestion } from '@/utils/bankReconciliation'
 import { formatContactDisplayName } from '@/utils/contact'
 import { formatDisplayDate } from '@/utils/format'
+import { getErrorDetail } from '@/utils/errorUtils'
 
 const props = defineProps<{
   visible: boolean
@@ -163,10 +164,9 @@ watch(
       contacts.value = cont
       selectedInvoiceId.value = invoiceOptions.value[0]?.value ?? null
     } catch (error) {
-      const detail = (error as { response?: { data?: { detail?: unknown } } })?.response?.data?.detail
       toast.add({
         severity: 'error',
-        summary: typeof detail === 'string' ? detail : t('common.error.unknown'),
+        summary: getErrorDetail(error, t('common.error.unknown')),
         life: 3000,
       })
     } finally {
@@ -184,10 +184,9 @@ async function submit(): Promise<void> {
     toast.add({ severity: 'success', summary: t('bank.create_supplier_payment_success'), life: 3000 })
     emit('saved')
   } catch (error) {
-    const detail = (error as { response?: { data?: { detail?: unknown } } })?.response?.data?.detail
     toast.add({
       severity: 'error',
-      summary: typeof detail === 'string' ? detail : t('common.error.unknown'),
+      summary: getErrorDetail(error, t('common.error.unknown')),
       life: 3000,
     })
   } finally {

--- a/frontend/src/composables/useInvoiceMetrics.ts
+++ b/frontend/src/composables/useInvoiceMetrics.ts
@@ -1,0 +1,103 @@
+import { computed, type Ref } from 'vue'
+import type { Invoice } from '../api/invoices'
+import { useFiscalYearStore } from '../stores/fiscalYear'
+
+// ---------------------------------------------------------------------------
+// Pure helpers — exported so callers can reuse without re-importing
+// ---------------------------------------------------------------------------
+
+export function remainingForInvoice(invoice: Invoice): number {
+  return Math.max(0, parseFloat(invoice.total_amount) - parseFloat(invoice.paid_amount))
+}
+
+export function isOpenReceivableInvoice(invoice: Invoice): boolean {
+  return invoice.status !== 'draft' && remainingForInvoice(invoice) > 0
+}
+
+export function isOverdueInvoice(invoice: Invoice): boolean {
+  return Boolean(
+    invoice.status !== 'draft' &&
+      invoice.due_date &&
+      remainingForInvoice(invoice) > 0 &&
+      invoice.due_date < new Date().toISOString().slice(0, 10),
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Composable
+// ---------------------------------------------------------------------------
+
+/**
+ * Computes receivable and portfolio metrics from reactive invoice lists.
+ *
+ * @param allInvoices  - All client invoices (unfiltered).
+ * @param displayedInvoices - Currently visible invoices after DataTable filtering.
+ */
+export function useInvoiceMetrics(
+  allInvoices: Readonly<Ref<Invoice[]>>,
+  displayedInvoices: Readonly<Ref<Invoice[]>>,
+) {
+  const fiscalYearStore = useFiscalYearStore()
+
+  const receivableMetrics = computed(() => {
+    const openReceivables = allInvoices.value.filter(isOpenReceivableInvoice)
+    const fiscalYear = fiscalYearStore.selectedFiscalYear
+    const exerciseReceivables = fiscalYear
+      ? openReceivables.filter(
+          (invoice) =>
+            invoice.date >= fiscalYear.start_date && invoice.date <= fiscalYear.end_date,
+        )
+      : openReceivables
+    const historicalReceivables = fiscalYear
+      ? openReceivables.filter((invoice) => invoice.date < fiscalYear.start_date)
+      : []
+
+    return {
+      exerciseAmount: exerciseReceivables.reduce(
+        (sum, invoice) => sum + remainingForInvoice(invoice),
+        0,
+      ),
+      exerciseCount: exerciseReceivables.length,
+      totalAmount: openReceivables.reduce(
+        (sum, invoice) => sum + remainingForInvoice(invoice),
+        0,
+      ),
+      totalCount: openReceivables.length,
+      historicalAmount: historicalReceivables.reduce(
+        (sum, invoice) => sum + remainingForInvoice(invoice),
+        0,
+      ),
+      historicalCount: historicalReceivables.length,
+    }
+  })
+
+  const portfolioMetrics = computed(() => {
+    const visible = displayedInvoices.value
+    const totalAmount = visible.reduce(
+      (sum, invoice) => sum + parseFloat(invoice.total_amount),
+      0,
+    )
+    const paidAmount = visible.reduce(
+      (sum, invoice) => sum + parseFloat(invoice.paid_amount),
+      0,
+    )
+    const overdueInvoices = visible.filter(isOverdueInvoice)
+    const overdueAmount = overdueInvoices.reduce(
+      (sum, invoice) => sum + remainingForInvoice(invoice),
+      0,
+    )
+    const partialCount = visible.filter((invoice) => invoice.status === 'partial').length
+
+    return {
+      visibleCount: visible.length,
+      totalAmount,
+      paidAmount,
+      overdueAmount,
+      overdueCount: overdueInvoices.length,
+      partialCount,
+      averageAmount: visible.length > 0 ? totalAmount / visible.length : 0,
+    }
+  })
+
+  return { receivableMetrics, portfolioMetrics }
+}

--- a/frontend/src/utils/errorUtils.ts
+++ b/frontend/src/utils/errorUtils.ts
@@ -4,9 +4,11 @@
  * The FastAPI backend returns structured error responses with the shape:
  *   { response: { data: { detail: string | object } } }
  *
- * Falls back to a generic message when the error has no recognised shape.
+ * Falls back to a caller-provided translated message when the error has no
+ * recognised shape.  The fallback is required so callers are forced to pass
+ * an already-translated string and cannot accidentally embed hard-coded UI text.
  */
-export function getErrorDetail(error: unknown, fallback = 'Erreur inconnue'): string {
+export function getErrorDetail(error: unknown, fallback: string): string {
   if (error !== null && typeof error === 'object' && 'response' in error) {
     const response = (error as { response?: unknown }).response
     if (response !== null && typeof response === 'object' && 'data' in response) {

--- a/frontend/src/utils/errorUtils.ts
+++ b/frontend/src/utils/errorUtils.ts
@@ -1,0 +1,29 @@
+/**
+ * Extracts a human-readable error detail string from an Axios-style error object.
+ *
+ * The FastAPI backend returns structured error responses with the shape:
+ *   { response: { data: { detail: string | object } } }
+ *
+ * Falls back to a generic message when the error has no recognised shape.
+ */
+export function getErrorDetail(error: unknown, fallback = 'Erreur inconnue'): string {
+  if (error !== null && typeof error === 'object' && 'response' in error) {
+    const response = (error as { response?: unknown }).response
+    if (response !== null && typeof response === 'object' && 'data' in response) {
+      const data = (response as { data?: unknown }).data
+      if (data !== null && typeof data === 'object' && 'detail' in data) {
+        const detail = (data as { detail?: unknown }).detail
+        if (typeof detail === 'string') return detail
+        if (Array.isArray(detail) && detail.length > 0) {
+          const first = detail[0]
+          if (typeof first === 'object' && first !== null && 'msg' in first) {
+            return String((first as { msg: unknown }).msg)
+          }
+          return String(first)
+        }
+        if (detail !== null && detail !== undefined) return String(detail)
+      }
+    }
+  }
+  return fallback
+}

--- a/frontend/src/views/CashView.vue
+++ b/frontend/src/views/CashView.vue
@@ -484,7 +484,7 @@
               <div class="app-field">
                 <label class="app-field__label">{{ denom.label }}</label>
                 <InputNumber
-                  v-model="(countForm as unknown as Record<string, number>)[denom.field]"
+                  v-model="countForm[denom.field]"
                   :min="0"
                 />
               </div>
@@ -726,7 +726,22 @@ function resetActiveFilters() {
   resetCountFilters()
 }
 
-const denominations = [
+type CashDenomField =
+  | 'count_100'
+  | 'count_50'
+  | 'count_20'
+  | 'count_10'
+  | 'count_5'
+  | 'count_2'
+  | 'count_1'
+  | 'count_cents_50'
+  | 'count_cents_20'
+  | 'count_cents_10'
+  | 'count_cents_5'
+  | 'count_cents_2'
+  | 'count_cents_1'
+
+const denominations: Array<{ field: CashDenomField; label: string }> = [
   { field: 'count_100', label: '100 €' },
   { field: 'count_50', label: '50 €' },
   { field: 'count_20', label: '20 €' },
@@ -743,7 +758,7 @@ const denominations = [
 ]
 
 interface CashEntryFormState {
-  date: Date
+  date: Date | string
   type: 'in' | 'out'
   amount: number
   reference: string
@@ -888,7 +903,7 @@ async function submitEntry() {
   try {
     if (editingEntry.value) {
       await updateCashEntry(editingEntry.value.id, {
-        date: toIsoDate(entryForm.value.date as unknown as Date),
+        date: toIsoDate(entryForm.value.date),
         type: entryForm.value.type,
         amount: String(entryForm.value.amount),
         reference: normalizeOptionalField(entryForm.value.reference),
@@ -897,7 +912,7 @@ async function submitEntry() {
       toast.add({ severity: 'success', summary: t('cash.entry_updated'), life: 3000 })
     } else {
       await addCashEntry({
-        date: toIsoDate(entryForm.value.date as unknown as Date),
+        date: toIsoDate(entryForm.value.date),
         type: entryForm.value.type,
         amount: String(entryForm.value.amount),
         reference: normalizeOptionalField(entryForm.value.reference),

--- a/frontend/src/views/ClientInvoicesView.vue
+++ b/frontend/src/views/ClientInvoicesView.vue
@@ -94,7 +94,7 @@
               severity="secondary"
               text
               :title="t('common.reset_filters')"
-              @click="resetFilters"
+              @click="resetAllFilters"
             />
           </div>
         </div>
@@ -114,7 +114,7 @@
           </div>
           <div class="app-field app-field--span-2">
             <label class="app-field__label">{{ t('common.filter_placeholder') }}</label>
-            <InputText v-model="globalFilter" :placeholder="t('common.filter_placeholder')" />
+            <InputText v-model="globalFilterInput" :placeholder="t('common.filter_placeholder')" />
           </div>
         </div>
       </div>
@@ -547,7 +547,7 @@ import Tag from 'primevue/tag'
 import Textarea from 'primevue/textarea'
 import { useConfirm } from 'primevue/useconfirm'
 import { useToast } from 'primevue/usetoast'
-import { computed, onMounted, nextTick, ref, watch } from 'vue'
+import { computed, onMounted, onUnmounted, nextTick, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 
@@ -585,6 +585,11 @@ import {
   collectActiveFilterLabels,
   findSelectedFilterLabel,
 } from '../composables/activeFilterLabels'
+import {
+  useInvoiceMetrics,
+  remainingForInvoice,
+  isOverdueInvoice,
+} from '../composables/useInvoiceMetrics'
 import { useFiscalYearStore } from '../stores/fiscalYear'
 import { formatContactDisplayName } from '../utils/contact'
 import { formatDisplayDate } from '@/utils/format'
@@ -666,6 +671,25 @@ const {
   total_amount_value: numericRangeFilter(),
   status: inFilter(),
 })
+
+// Debounced input: avoids filtering on every keystroke
+const globalFilterInput = ref(globalFilter.value)
+let _filterDebounce: ReturnType<typeof setTimeout> | null = null
+watch(globalFilterInput, (val) => {
+  if (_filterDebounce) clearTimeout(_filterDebounce)
+  _filterDebounce = setTimeout(() => {
+    globalFilter.value = val
+  }, 300)
+})
+onUnmounted(() => {
+  if (_filterDebounce) clearTimeout(_filterDebounce)
+})
+
+function resetAllFilters(): void {
+  globalFilterInput.value = ''
+  globalFilter.value = ''
+  resetFilters()
+}
 const { filters: historyTableFilters } = useDataTableFilters(historyPaymentRows, {
   global: textFilter(''),
   date: dateRangeFilter(),
@@ -686,51 +710,7 @@ const paymentRemaining = computed(() => {
 
 const selectedFiscalYearLabel = computed(() => fiscalYearStore.selectedFiscalYear?.name ?? null)
 
-const receivableMetrics = computed(() => {
-  const openReceivables = allClientInvoices.value.filter(isOpenReceivableInvoice)
-  const fiscalYear = fiscalYearStore.selectedFiscalYear
-  const exerciseReceivables = fiscalYear
-    ? openReceivables.filter(
-        (invoice) => invoice.date >= fiscalYear.start_date && invoice.date <= fiscalYear.end_date,
-      )
-    : openReceivables
-  const historicalReceivables = fiscalYear
-    ? openReceivables.filter((invoice) => invoice.date < fiscalYear.start_date)
-    : []
-
-  return {
-    exerciseAmount: exerciseReceivables.reduce((sum, invoice) => sum + remainingForInvoice(invoice), 0),
-    exerciseCount: exerciseReceivables.length,
-    totalAmount: openReceivables.reduce((sum, invoice) => sum + remainingForInvoice(invoice), 0),
-    totalCount: openReceivables.length,
-    historicalAmount: historicalReceivables.reduce(
-      (sum, invoice) => sum + remainingForInvoice(invoice),
-      0,
-    ),
-    historicalCount: historicalReceivables.length,
-  }
-})
-
-const portfolioMetrics = computed(() => {
-  const visible = displayedInvoices.value
-  const totalAmount = visible.reduce((sum, invoice) => sum + parseFloat(invoice.total_amount), 0)
-  const paidAmount = visible.reduce((sum, invoice) => sum + parseFloat(invoice.paid_amount), 0)
-  const overdueInvoices = visible.filter(isOverdueInvoice)
-  const overdueAmount = overdueInvoices.reduce((sum, invoice) => {
-    return sum + remainingForInvoice(invoice)
-  }, 0)
-  const partialCount = visible.filter((invoice) => invoice.status === 'partial').length
-
-  return {
-    visibleCount: visible.length,
-    totalAmount,
-    paidAmount,
-    overdueAmount,
-    overdueCount: overdueInvoices.length,
-    partialCount,
-    averageAmount: visible.length > 0 ? totalAmount / visible.length : 0,
-  }
-})
+const { receivableMetrics, portfolioMetrics } = useInvoiceMetrics(allClientInvoices, displayedInvoices)
 
 const activeFilterLabels = computed(() =>
   collectActiveFilterLabels(
@@ -769,23 +749,6 @@ function formatAmount(val: string | number) {
 function toIsoDate(value: Date | string): string {
   if (typeof value === 'string') return value
   return value.toISOString().slice(0, 10)
-}
-
-function remainingForInvoice(invoice: Invoice): number {
-  return Math.max(0, parseFloat(invoice.total_amount) - parseFloat(invoice.paid_amount))
-}
-
-function isOpenReceivableInvoice(invoice: Invoice): boolean {
-  return invoice.status !== 'draft' && remainingForInvoice(invoice) > 0
-}
-
-function isOverdueInvoice(invoice: Invoice): boolean {
-  return Boolean(
-    invoice.status !== 'draft' &&
-      invoice.due_date &&
-      remainingForInvoice(invoice) > 0 &&
-      invoice.due_date < new Date().toISOString().slice(0, 10),
-  )
 }
 
 function canRecordPayment(invoice: Invoice | null): boolean {

--- a/tests/unit/test_email_service.py
+++ b/tests/unit/test_email_service.py
@@ -1,0 +1,194 @@
+"""Unit tests for email_service — mocks smtplib to avoid real SMTP connections."""
+
+from __future__ import annotations
+
+import smtplib
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from backend.services.email_service import (
+    EmailSendError,
+    send_invoice_email,
+)
+
+# ---------------------------------------------------------------------------
+# Shared test fixtures
+# ---------------------------------------------------------------------------
+
+_COMMON_KWARGS: dict = {
+    "smtp_host": "smtp.example.com",
+    "smtp_port": 587,
+    "smtp_user": "user@example.com",
+    "smtp_password": "secret",
+    "smtp_from_email": "factures@asso.fr",
+    "smtp_use_tls": True,
+    "recipient_email": "client@example.com",
+    "invoice_number": "2024-001",
+    "association_name": "Association Test",
+    "pdf_bytes": b"%PDF-fake",
+}
+
+
+# ---------------------------------------------------------------------------
+# Successful sends
+# ---------------------------------------------------------------------------
+
+
+def test_send_invoice_email_starttls_success() -> None:
+    mock_server = MagicMock()
+    with patch("smtplib.SMTP") as mock_smtp_cls:
+        mock_smtp_cls.return_value.__enter__ = MagicMock(return_value=mock_server)
+        mock_smtp_cls.return_value.__exit__ = MagicMock(return_value=False)
+        send_invoice_email(**_COMMON_KWARGS)
+
+    mock_smtp_cls.assert_called_once_with("smtp.example.com", 587, timeout=30)
+
+
+def test_send_invoice_email_ssl_success() -> None:
+    kwargs = {**_COMMON_KWARGS, "smtp_use_tls": False, "smtp_port": 465}
+    mock_server = MagicMock()
+    with patch("smtplib.SMTP_SSL") as mock_smtp_ssl_cls:
+        mock_smtp_ssl_cls.return_value.__enter__ = MagicMock(return_value=mock_server)
+        mock_smtp_ssl_cls.return_value.__exit__ = MagicMock(return_value=False)
+        send_invoice_email(**kwargs)
+
+    mock_smtp_ssl_cls.assert_called_once_with("smtp.example.com", 465, timeout=30)
+
+
+def test_send_invoice_email_with_bcc() -> None:
+    """BCC field must be set in the message headers when provided."""
+    sent_messages: list = []
+
+    class _FakeSMTP:
+        def __enter__(self) -> _FakeSMTP:
+            return self
+
+        def __exit__(self, *args: object) -> bool:
+            return False
+
+        def ehlo(self) -> None:
+            pass
+
+        def starttls(self, **kwargs: object) -> None:
+            pass
+
+        def login(self, user: str, password: str) -> None:
+            pass
+
+        def send_message(self, msg: object) -> None:
+            sent_messages.append(msg)
+
+    with patch("smtplib.SMTP", return_value=_FakeSMTP()):
+        send_invoice_email(**{**_COMMON_KWARGS, "bcc": "archivage@asso.fr"})
+
+    assert sent_messages, "send_message was not called"
+    assert sent_messages[0]["Bcc"] == "archivage@asso.fr"
+
+
+def test_send_invoice_email_without_bcc() -> None:
+    """Bcc header must be absent when bcc is None."""
+    sent_messages: list = []
+
+    class _FakeSMTP:
+        def __enter__(self) -> _FakeSMTP:
+            return self
+
+        def __exit__(self, *args: object) -> bool:
+            return False
+
+        def ehlo(self) -> None:
+            pass
+
+        def starttls(self, **kwargs: object) -> None:
+            pass
+
+        def login(self, user: str, password: str) -> None:
+            pass
+
+        def send_message(self, msg: object) -> None:
+            sent_messages.append(msg)
+
+    with patch("smtplib.SMTP", return_value=_FakeSMTP()):
+        send_invoice_email(**{**_COMMON_KWARGS, "bcc": None})
+
+    assert sent_messages
+    assert sent_messages[0]["Bcc"] is None
+
+
+def test_send_invoice_email_message_subject() -> None:
+    """Subject line must contain the invoice number and association name."""
+    sent_messages: list = []
+
+    class _FakeSMTP:
+        def __enter__(self) -> _FakeSMTP:
+            return self
+
+        def __exit__(self, *args: object) -> bool:
+            return False
+
+        def ehlo(self) -> None:
+            pass
+
+        def starttls(self, **kwargs: object) -> None:
+            pass
+
+        def login(self, user: str, password: str) -> None:
+            pass
+
+        def send_message(self, msg: object) -> None:
+            sent_messages.append(msg)
+
+    with patch("smtplib.SMTP", return_value=_FakeSMTP()):
+        send_invoice_email(**_COMMON_KWARGS)
+
+    assert sent_messages
+    subject = sent_messages[0]["Subject"]
+    assert "2024-001" in subject
+    assert "Association Test" in subject
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+
+def test_send_invoice_email_raises_email_send_error_on_smtp_exception() -> None:
+    with patch("smtplib.SMTP") as mock_smtp_cls:
+        mock_smtp_cls.return_value.__enter__ = MagicMock(
+            side_effect=smtplib.SMTPConnectError(421, "Service unavailable")
+        )
+        mock_smtp_cls.return_value.__exit__ = MagicMock(return_value=False)
+        with pytest.raises(EmailSendError):
+            send_invoice_email(**_COMMON_KWARGS)
+
+
+def test_send_invoice_email_raises_email_send_error_on_os_error() -> None:
+    with patch("smtplib.SMTP") as mock_smtp_cls:
+        mock_smtp_cls.side_effect = OSError("Connection refused")
+        with pytest.raises(EmailSendError):
+            send_invoice_email(**_COMMON_KWARGS)
+
+
+def test_send_invoice_email_raises_email_send_error_on_auth_failure() -> None:
+    class _FakeSMTP:
+        def __enter__(self) -> _FakeSMTP:
+            return self
+
+        def __exit__(self, *args: object) -> bool:
+            return False
+
+        def ehlo(self) -> None:
+            pass
+
+        def starttls(self, **kwargs: object) -> None:
+            pass
+
+        def login(self, user: str, password: str) -> None:
+            raise smtplib.SMTPAuthenticationError(535, b"Authentication failed")
+
+        def send_message(self, msg: object) -> None:
+            pass
+
+    with patch("smtplib.SMTP", return_value=_FakeSMTP()), pytest.raises(EmailSendError):
+        send_invoice_email(**_COMMON_KWARGS)

--- a/tests/unit/test_pdf_service.py
+++ b/tests/unit/test_pdf_service.py
@@ -5,10 +5,9 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import date
 from decimal import Decimal
+from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
-
-import pytest
 
 from backend.services.pdf_service import (
     generate_invoice_pdf,
@@ -160,24 +159,25 @@ def test_generate_invoice_pdf_returns_bytes() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_save_invoice_pdf_creates_file(tmp_path: pytest.TempPathFactory) -> None:
+def test_save_invoice_pdf_creates_file(tmp_path: Path) -> None:
     pdf_bytes = b"%PDF-1.4 fake content"
     output_dir = str(tmp_path / "pdfs")
     result_path = save_invoice_pdf("2024-001", pdf_bytes, output_dir=output_dir)
-
-    from pathlib import Path
 
     assert Path(result_path).exists()
     assert Path(result_path).read_bytes() == pdf_bytes
 
 
-def test_save_invoice_pdf_sanitises_slash_in_number(tmp_path: pytest.TempPathFactory) -> None:
+def test_save_invoice_pdf_sanitises_slash_in_number(tmp_path: Path) -> None:
     output_dir = str(tmp_path / "pdfs")
     result_path = save_invoice_pdf("2024/001", b"pdf", output_dir=output_dir)
-    assert "/" not in result_path.split("pdfs")[-1] or result_path.endswith("2024-001.pdf")
+    filename = Path(result_path).name
+    assert "/" not in filename
+    assert "\\" not in filename
+    assert filename == "facture_2024-001.pdf"
 
 
-def test_save_invoice_pdf_returns_path_string(tmp_path: pytest.TempPathFactory) -> None:
+def test_save_invoice_pdf_returns_path_string(tmp_path: Path) -> None:
     output_dir = str(tmp_path / "pdfs")
     result = save_invoice_pdf("INV-999", b"bytes", output_dir=output_dir)
     assert isinstance(result, str)

--- a/tests/unit/test_pdf_service.py
+++ b/tests/unit/test_pdf_service.py
@@ -1,0 +1,184 @@
+"""Unit tests for pdf_service — mocks WeasyPrint to avoid the heavy import."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date
+from decimal import Decimal
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from backend.services.pdf_service import (
+    generate_invoice_pdf,
+    render_invoice_html,
+    save_invoice_pdf,
+)
+
+# ---------------------------------------------------------------------------
+# Minimal stubs matching the Jinja2 template expectations
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _InvoiceLine:
+    description: str = "Cours de mathématiques"
+    quantity: int = 4
+    unit_price: Decimal = Decimal("25.00")
+    amount: Decimal = Decimal("100.00")
+    vat_rate: Decimal = Decimal("0.00")
+    total: Decimal = Decimal("100.00")
+    hours: int | None = None
+
+
+@dataclass
+class _FakeInvoice:
+    number: str = "2024-001"
+    reference: str | None = "REF-2024-001"
+    description: str = "Soutien scolaire"
+    date: date = field(default_factory=lambda: date(2024, 3, 1))
+    due_date: date | None = field(default_factory=lambda: date(2024, 3, 31))
+    total_amount: Decimal = Decimal("100.00")
+    total_ht: Decimal = Decimal("100.00")
+    total_ttc: Decimal = Decimal("100.00")
+    total_vat: Decimal = Decimal("0.00")
+    notes: str | None = None
+    lines: list[Any] = field(default_factory=lambda: [_InvoiceLine()])
+
+
+@dataclass
+class _FakeSettings:
+    association_name: str = "Association Éducation Plus"
+    association_address: str | None = "10 rue de la Paix, 75001 Paris"
+    association_siret: str | None = "12345678900001"
+    association_logo_path: str | None = None
+    email: str | None = "contact@edu-plus.fr"
+    phone: str | None = "01 23 45 67 89"
+    footer_text: str | None = "Merci pour votre confiance."
+    iban: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# render_invoice_html
+# ---------------------------------------------------------------------------
+
+
+def test_render_invoice_html_contains_invoice_number() -> None:
+    html = render_invoice_html(_FakeInvoice(), "Alice Martin", _FakeSettings())
+    assert "2024-001" in html
+
+
+def test_render_invoice_html_contains_contact_name() -> None:
+    html = render_invoice_html(_FakeInvoice(), "Alice Martin", _FakeSettings())
+    assert "Alice Martin" in html
+
+
+def test_render_invoice_html_contains_amount() -> None:
+    html = render_invoice_html(_FakeInvoice(), "Alice Martin", _FakeSettings())
+    # The template renders the total_ttc amount
+    assert "100" in html
+
+
+def test_render_invoice_html_contains_association_name() -> None:
+    html = render_invoice_html(_FakeInvoice(), "Bob Dupont", _FakeSettings())
+    assert "Association Éducation Plus" in html
+
+
+def test_render_invoice_html_returns_string() -> None:
+    result = render_invoice_html(_FakeInvoice(), "Alice Martin", _FakeSettings())
+    assert isinstance(result, str)
+    assert len(result) > 0
+
+
+def test_render_invoice_html_contains_reference() -> None:
+    invoice = _FakeInvoice(reference="REF-TEST")
+    html = render_invoice_html(invoice, "Alice Martin", _FakeSettings())
+    assert "REF-TEST" in html
+
+
+def test_render_invoice_html_contains_line_description() -> None:
+    invoice = _FakeInvoice()
+    html = render_invoice_html(invoice, "Alice Martin", _FakeSettings())
+    assert "mathématiques" in html
+
+
+# ---------------------------------------------------------------------------
+# generate_invoice_pdf — WeasyPrint mocked via sys.modules to avoid
+# loading native GTK libraries that may not be present on dev machines.
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_weasyprint(pdf_bytes: bytes = b"%PDF-1.4 fake") -> MagicMock:
+    """Return a fake weasyprint module where HTML().write_pdf() returns pdf_bytes."""
+    mock_wp = MagicMock()
+    mock_html_instance = MagicMock()
+    mock_html_instance.write_pdf.return_value = pdf_bytes
+    mock_wp.HTML.return_value = mock_html_instance
+    return mock_wp
+
+
+def test_generate_invoice_pdf_calls_weasyprint() -> None:
+    import sys
+
+    fake_wp = _make_fake_weasyprint(b"%PDF-1.4 fake")
+    with patch.dict(sys.modules, {"weasyprint": fake_wp}):
+        result = generate_invoice_pdf(_FakeInvoice(), "Alice Martin", _FakeSettings())
+
+    assert result == b"%PDF-1.4 fake"
+    fake_wp.HTML.return_value.write_pdf.assert_called_once()
+
+
+def test_generate_invoice_pdf_passes_html_content() -> None:
+    import sys
+
+    fake_wp = _make_fake_weasyprint()
+    with patch.dict(sys.modules, {"weasyprint": fake_wp}):
+        generate_invoice_pdf(_FakeInvoice(), "Alice Martin", _FakeSettings())
+
+    call_kwargs = fake_wp.HTML.call_args
+    assert call_kwargs is not None
+    html_string = call_kwargs.kwargs.get("string") or (
+        call_kwargs.args[0] if call_kwargs.args else None
+    )
+    assert html_string is not None
+    assert "2024-001" in html_string
+
+
+def test_generate_invoice_pdf_returns_bytes() -> None:
+    import sys
+
+    fake_wp = _make_fake_weasyprint(b"%PDF-1.4")
+    with patch.dict(sys.modules, {"weasyprint": fake_wp}):
+        result = generate_invoice_pdf(_FakeInvoice(), "Alice Martin", _FakeSettings())
+
+    assert isinstance(result, bytes)
+
+
+# ---------------------------------------------------------------------------
+# save_invoice_pdf
+# ---------------------------------------------------------------------------
+
+
+def test_save_invoice_pdf_creates_file(tmp_path: pytest.TempPathFactory) -> None:
+    pdf_bytes = b"%PDF-1.4 fake content"
+    output_dir = str(tmp_path / "pdfs")
+    result_path = save_invoice_pdf("2024-001", pdf_bytes, output_dir=output_dir)
+
+    from pathlib import Path
+
+    assert Path(result_path).exists()
+    assert Path(result_path).read_bytes() == pdf_bytes
+
+
+def test_save_invoice_pdf_sanitises_slash_in_number(tmp_path: pytest.TempPathFactory) -> None:
+    output_dir = str(tmp_path / "pdfs")
+    result_path = save_invoice_pdf("2024/001", b"pdf", output_dir=output_dir)
+    assert "/" not in result_path.split("pdfs")[-1] or result_path.endswith("2024-001.pdf")
+
+
+def test_save_invoice_pdf_returns_path_string(tmp_path: pytest.TempPathFactory) -> None:
+    output_dir = str(tmp_path / "pdfs")
+    result = save_invoice_pdf("INV-999", b"bytes", output_dir=output_dir)
+    assert isinstance(result, str)
+    assert "INV-999" in result


### PR DESCRIPTION
## Summary

This PR delivers **Lots O and P** (technical quality improvements — v0.7 target).

---

## Backend — Lot O

### TEC-098 — SQL pagination in accounting entry service
- `get_balance`, `get_resultat`, `get_bilan`: replaced `limit=100_000` + Python iteration with SQL `GROUP BY + SUM` aggregations
- `get_grouped_journal`: replaced Python `slice()` with SQL `OFFSET/LIMIT` pushed into SQLAlchemy; added `_query_group_keys_paged()` helper
- `export_service.py`: passes `limit=None` to remove the 100,000-row cap without memory saturation

### TEC-099 — Cascade FK: payments → invoices
- Added `ondelete="CASCADE"` on `payments.invoice_id` FK in `backend/models/payment.py`
- New Alembic migration `0030_payment_invoice_cascade.py` using `batch_alter_table(recreate="always")` (required for SQLite)

### TEC-100 — Missing unit tests
- `tests/unit/test_pdf_service.py` (13 tests): covers `render_invoice_html` HTML content and `generate_invoice_pdf`/`save_invoice_pdf`. WeasyPrint mocked via `patch.dict(sys.modules, {"weasyprint": ...})` to avoid importing the native GTK library on dev machines.
- `tests/unit/test_email_service.py` (11 tests): covers STARTTLS, SSL, optional BCC, message subject, SMTP/OS/auth error handling. `smtplib` fully mocked with fake context managers.

---

## Frontend — Lot P

### TEC-101 — ClientInvoicesView.vue refactoring
- New `frontend/src/composables/useInvoiceMetrics.ts`: extracts `receivableMetrics` and `portfolioMetrics` computed properties; also exports pure helpers `remainingForInvoice`, `isOpenReceivableInvoice`, `isOverdueInvoice`
- `ClientInvoicesView.vue` reduced by ~60 lines; no behavioral change

### TEC-102 — Shared `getErrorDetail()` utility
- New `frontend/src/utils/errorUtils.ts` with `getErrorDetail(error, fallback)` that safely extracts the `detail` field from FastAPI structured error responses
- Replaced 7 inline extraction patterns across `BankClientPaymentDialog.vue`, `BankSupplierPaymentDialog.vue`, `BankLinkClientPaymentDialog.vue`, `BankLinkSupplierPaymentDialog.vue`

### TEC-103 — Debounce on text filters
- `ClientInvoicesView.vue`: added `globalFilterInput` ref bound to the `InputText`, with 300 ms debounce via native `setTimeout`/`clearTimeout` before writing to `globalFilter`
- No new dependency added; `resetAllFilters()` wrapper clears both `globalFilterInput` and `globalFilter`

### TEC-104 — Unsafe TypeScript casts in CashView.vue
- Added `CashDenomField` union type for denomination keys → replaces `as unknown as Record<string, number>` in the template
- Changed `CashEntryFormState.date` to `Date | string` → removes two `as unknown as Date` casts

---

## Quality gate

| Check | Result |
|---|---|
| `ruff check` | ✅ |
| `ruff format --check` | ✅ |
| `mypy backend/` | ✅ 131 files, no issues |
| `pytest tests/` | ✅ 976/977 (1 pre-existing failure in `test_swagger_disabled_in_production`, unrelated to this PR) |
| `eslint src/` | ✅ |
| `vue-tsc --noEmit` | ✅ |
| `vitest run` | ✅ 131/131 |

## Breaking changes

None.