### PR TITLE
fix(merge): post-merge cleanup and CI fixes

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   build-push:

--- a/backend/models/accounting_entry.py
+++ b/backend/models/accounting_entry.py
@@ -39,16 +39,6 @@ def build_entry_group_key(
     return f"{source_value}:{source_id}"
 
 
-def build_entry_group_key(
-    source_type: EntrySourceType | str | None,
-    source_id: int | None,
-) -> str | None:
-    if source_type is None or source_id is None:
-        return None
-    source_value = source_type.value if isinstance(source_type, EntrySourceType) else source_type
-    return f"{source_value}:{source_id}"
-
-
 class AccountingEntry(Base):
     """A single debit or credit line in the accounting journal."""
 

--- a/backend/models/accounting_entry.py
+++ b/backend/models/accounting_entry.py
@@ -22,7 +22,6 @@ class EntrySourceType(StrEnum):
     PAYMENT = "payment"
     DEPOSIT = "deposit"
     SALARY = "salary"
-    GESTION = "gestion"
     MANUAL = "manual"
     CASH = "cash"
     CLOTURE = "cloture"

--- a/backend/models/payment.py
+++ b/backend/models/payment.py
@@ -5,16 +5,12 @@ from __future__ import annotations
 from datetime import date, datetime
 from decimal import Decimal
 from enum import StrEnum
-from typing import TYPE_CHECKING
 
 from sqlalchemy import Boolean, Date, DateTime, ForeignKey, String, Text, func
 from sqlalchemy.orm import Mapped, mapped_column
 
 from backend.database import Base
 from backend.models.types import DecimalType
-
-if TYPE_CHECKING:
-    from backend.models.invoice import InvoiceType
 
 _Date = date
 _Decimal = Decimal
@@ -28,10 +24,6 @@ class PaymentMethod(StrEnum):
 
 class Payment(Base):
     __tablename__ = "payments"
-    __allow_unmapped__ = True
-
-    invoice_number: str | None = None
-    invoice_type: InvoiceType | None = None
 
     id: Mapped[int] = mapped_column(primary_key=True, index=True)
     invoice_id: Mapped[int] = mapped_column(

--- a/backend/routers/fiscal_year.py
+++ b/backend/routers/fiscal_year.py
@@ -114,25 +114,6 @@ async def administrative_close_fiscal_year(
     return closed  # type: ignore[return-value]
 
 
-@router.post("/{fy_id}/close-administrative", response_model=FiscalYearRead)
-async def administrative_close_fiscal_year(
-    fy_id: int,
-    db: Annotated[AsyncSession, Depends(get_db)],
-    _: _AdminAccess,
-) -> FiscalYearRead:
-    """Close a fiscal year without generating new accounting entries."""
-    fy = await fiscal_year_service.get_fiscal_year(db, fy_id)
-    if fy is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Fiscal year not found")
-    try:
-        closed = await fiscal_year_service.administrative_close_fiscal_year(db, fy)
-    except FiscalYearError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)
-        ) from exc
-    return closed  # type: ignore[return-value]
-
-
 @router.post(
     "/{fy_id}/open-next",
     response_model=FiscalYearRead,


### PR DESCRIPTION
Post-merge cleanup after v1.0.0 — fixes for merge artifacts and CI.

### Changes

- `fix(merge)`: remove duplicate `build_entry_group_key` function (accounting_entry.py)
- `fix(merge)`: remove duplicate `administrative_close_fiscal_year` endpoint (fiscal_year.py)
- `fix(merge)`: remove duplicate `GESTION` member in `EntrySourceType` enum
- `fix(merge)`: remove `__allow_unmapped__`, `invoice_number`, `invoice_type` from `Payment` model
- `chore(ci)`: add `workflow_dispatch` trigger to Docker build workflow

## Summary by Sourcery

Clean up duplicate post-merge artifacts and adjust CI triggers.

Bug Fixes:
- Remove duplicate administrative_close_fiscal_year endpoint from the fiscal year router.
- Remove duplicate build_entry_group_key helper and redundant GESTION enum member from accounting entries.
- Simplify the Payment model by removing unused invoice-related attributes and unmapped allowance.

CI:
- Add manual workflow_dispatch trigger to the Docker build GitHub Actions workflow.