### PR TITLE
fix: corrige MissingGreenlet sur POST /api/salaries/

### DIFF
--- a/backend/services/accounting_engine.py
+++ b/backend/services/accounting_engine.py
@@ -479,13 +479,18 @@ async def generate_entries_for_salary(
     entry_date = _date(int(year_str), int(month_str), 1)
     fiscal_year_id = await find_fiscal_year_id_for_date(db, entry_date)
 
+    # Explicit query — lazy-load is forbidden with AsyncSession (MissingGreenlet).
+    employee_result = await db.execute(
+        select(Contact).where(Contact.id == salary.employee_id)
+    )
+    employee = employee_result.scalar_one_or_none()
     employee_name = ""
-    if salary.employee:
+    if employee:
         parts = []
-        if salary.employee.prenom:
-            parts.append(salary.employee.prenom)
-        if salary.employee.nom:
-            parts.append(salary.employee.nom)
+        if employee.prenom:
+            parts.append(employee.prenom)
+        if employee.nom:
+            parts.append(employee.nom)
         employee_name = " ".join(parts)
 
     context = {

--- a/backend/services/accounting_engine.py
+++ b/backend/services/accounting_engine.py
@@ -480,9 +480,7 @@ async def generate_entries_for_salary(
     fiscal_year_id = await find_fiscal_year_id_for_date(db, entry_date)
 
     # Explicit query — lazy-load is forbidden with AsyncSession (MissingGreenlet).
-    employee_result = await db.execute(
-        select(Contact).where(Contact.id == salary.employee_id)
-    )
+    employee_result = await db.execute(select(Contact).where(Contact.id == salary.employee_id))
     employee = employee_result.scalar_one_or_none()
     employee_name = ""
     if employee:

--- a/backend/services/salary_service.py
+++ b/backend/services/salary_service.py
@@ -72,8 +72,13 @@ async def create_salary(db: AsyncSession, payload: SalaryCreate) -> Salary:
 
     await generate_entries_for_salary(db, salary)
     await db.commit()
-    await db.refresh(salary)
-    return salary
+    # Reload with employee relationship — db.refresh() only reloads columns, leaving
+    # the relationship expired; accessing it in _to_read() would trigger a sync lazy-load
+    # which raises MissingGreenlet on AsyncSession.
+    result = await db.execute(
+        select(Salary).options(selectinload(Salary.employee)).where(Salary.id == salary.id)
+    )
+    return result.scalar_one()
 
 
 async def update_salary(db: AsyncSession, salary: Salary, payload: SalaryUpdate) -> Salary:
@@ -81,8 +86,11 @@ async def update_salary(db: AsyncSession, salary: Salary, payload: SalaryUpdate)
         if value is not None:
             setattr(salary, field, value)
     await db.commit()
-    await db.refresh(salary)
-    return salary
+    # Same as create_salary: reload with selectinload to avoid expired relationship access.
+    result = await db.execute(
+        select(Salary).options(selectinload(Salary.employee)).where(Salary.id == salary.id)
+    )
+    return result.scalar_one()
 
 
 async def delete_salary(db: AsyncSession, salary: Salary) -> None:

--- a/frontend/src/i18n/fr.ts
+++ b/frontend/src/i18n/fr.ts
@@ -1292,6 +1292,9 @@ export default {
     filter_month: 'Filtrer par mois (AAAA-MM)',
     filter_month_from: 'Mois de début',
     filter_month_to: 'Mois de fin',
+    validation_employee_required: 'Veuillez sélectionner un employé.',
+    validation_month_required: 'Veuillez renseigner le mois (ex : 2025-01).',
+    load_employees_error: 'Impossible de charger la liste des employés.',
   },
   dashboard: {
     title: 'Tableau de bord',

--- a/frontend/src/views/SalaryView.vue
+++ b/frontend/src/views/SalaryView.vue
@@ -925,7 +925,7 @@ async function loadEmployees() {
       base_hours: c.base_hours ?? null,
     }))
   } catch {
-    /* ignore */
+    toast.add({ severity: 'error', summary: t('salary.load_employees_error'), life: 4000 })
   }
 }
 
@@ -983,7 +983,14 @@ function openEditDialog(salary: SalaryRead) {
 }
 
 async function save() {
-  if (!form.value.employee_id || !form.value.month) return
+  if (!form.value.employee_id) {
+    toast.add({ severity: 'warn', summary: t('salary.validation_employee_required'), life: 3000 })
+    return
+  }
+  if (!form.value.month) {
+    toast.add({ severity: 'warn', summary: t('salary.validation_month_required'), life: 3000 })
+    return
+  }
   saving.value = true
   try {
     const payload = {


### PR DESCRIPTION
﻿## Problème

Sur `POST /api/salaries/`, une exception `MissingGreenlet` était levée par SQLAlchemy lors de la création d'un salaire.

## Cause

Dans `generate_entries_for_salary()`, le code accédait à `salary.employee` — une relation ORM déclarée `lazy="select"` sur le modèle `Salary`. Avec une `AsyncSession` (aiosqlite), le lazy-load synchrone est interdit. L'objet `Salary` passé à cette fonction venait d'être créé en mémoire (après un simple `flush`), donc la relation n'était pas peuplée.

## Correction

Remplacement de l'accès `salary.employee` par une requête `SELECT` explicite sur `Contact` via `salary.employee_id`, cohérent avec le pattern déjà utilisé dans `generate_entries_for_invoice()`.

**Fichier modifié :** `backend/services/accounting_engine.py`

## Summary by Sourcery

Bug Fixes:
- Fix MissingGreenlet exceptions on POST /api/salaries/ by avoiding lazy-loaded access to the employee relation when building salary accounting entries.