### PR TITLE
release: v1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ Ce projet respecte le [Versionnage sémantique](https://semver.org/lang/fr/).
 
 ---
 
+## [1.1.1] — 2026-05-01
+
+### Corrigé
+
+- Salaires : erreur `MissingGreenlet` (SQLAlchemy async) à la création et modification d'une fiche de paie — accès lazy à `salary.employee` remplacé par des requêtes async explicites (`selectinload` / query directe)
+- Salaires : le bouton « Enregistrer » restait silencieux lorsque l'employé ou le mois n'était pas renseigné — un toast d'avertissement est désormais affiché
+- Salaires : échec du chargement de la liste des employés passé silencieusement — une erreur toast est maintenant affichée si `GET /api/contacts/?type=employe` échoue
+
+---
+
 ## [1.1.0] — 2026-04-28
 
 ### Ajouté

--- a/backend/services/accounting_engine.py
+++ b/backend/services/accounting_engine.py
@@ -479,13 +479,18 @@ async def generate_entries_for_salary(
     entry_date = _date(int(year_str), int(month_str), 1)
     fiscal_year_id = await find_fiscal_year_id_for_date(db, entry_date)
 
+    # Explicit query — lazy-load is forbidden with AsyncSession (MissingGreenlet).
+    employee_result = await db.execute(
+        select(Contact).where(Contact.id == salary.employee_id)
+    )
+    employee = employee_result.scalar_one_or_none()
     employee_name = ""
-    if salary.employee:
+    if employee:
         parts = []
-        if salary.employee.prenom:
-            parts.append(salary.employee.prenom)
-        if salary.employee.nom:
-            parts.append(salary.employee.nom)
+        if employee.prenom:
+            parts.append(employee.prenom)
+        if employee.nom:
+            parts.append(employee.nom)
         employee_name = " ".join(parts)
 
     context = {

--- a/backend/services/accounting_engine.py
+++ b/backend/services/accounting_engine.py
@@ -480,9 +480,7 @@ async def generate_entries_for_salary(
     fiscal_year_id = await find_fiscal_year_id_for_date(db, entry_date)
 
     # Explicit query — lazy-load is forbidden with AsyncSession (MissingGreenlet).
-    employee_result = await db.execute(
-        select(Contact).where(Contact.id == salary.employee_id)
-    )
+    employee_result = await db.execute(select(Contact).where(Contact.id == salary.employee_id))
     employee = employee_result.scalar_one_or_none()
     employee_name = ""
     if employee:

--- a/backend/services/salary_service.py
+++ b/backend/services/salary_service.py
@@ -72,8 +72,13 @@ async def create_salary(db: AsyncSession, payload: SalaryCreate) -> Salary:
 
     await generate_entries_for_salary(db, salary)
     await db.commit()
-    await db.refresh(salary)
-    return salary
+    # Reload with employee relationship — db.refresh() only reloads columns, leaving
+    # the relationship expired; accessing it in _to_read() would trigger a sync lazy-load
+    # which raises MissingGreenlet on AsyncSession.
+    result = await db.execute(
+        select(Salary).options(selectinload(Salary.employee)).where(Salary.id == salary.id)
+    )
+    return result.scalar_one()
 
 
 async def update_salary(db: AsyncSession, salary: Salary, payload: SalaryUpdate) -> Salary:
@@ -81,8 +86,11 @@ async def update_salary(db: AsyncSession, salary: Salary, payload: SalaryUpdate)
         if value is not None:
             setattr(salary, field, value)
     await db.commit()
-    await db.refresh(salary)
-    return salary
+    # Same as create_salary: reload with selectinload to avoid expired relationship access.
+    result = await db.execute(
+        select(Salary).options(selectinload(Salary.employee)).where(Salary.id == salary.id)
+    )
+    return result.scalar_one()
 
 
 async def delete_salary(db: AsyncSession, salary: Salary) -> None:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/frontend/src/i18n/fr.ts
+++ b/frontend/src/i18n/fr.ts
@@ -1292,6 +1292,9 @@ export default {
     filter_month: 'Filtrer par mois (AAAA-MM)',
     filter_month_from: 'Mois de début',
     filter_month_to: 'Mois de fin',
+    validation_employee_required: 'Veuillez sélectionner un employé.',
+    validation_month_required: 'Veuillez renseigner le mois (ex : 2025-01).',
+    load_employees_error: 'Impossible de charger la liste des employés.',
   },
   dashboard: {
     title: 'Tableau de bord',

--- a/frontend/src/views/SalaryView.vue
+++ b/frontend/src/views/SalaryView.vue
@@ -925,7 +925,7 @@ async function loadEmployees() {
       base_hours: c.base_hours ?? null,
     }))
   } catch {
-    /* ignore */
+    toast.add({ severity: 'error', summary: t('salary.load_employees_error'), life: 4000 })
   }
 }
 
@@ -983,7 +983,14 @@ function openEditDialog(salary: SalaryRead) {
 }
 
 async function save() {
-  if (!form.value.employee_id || !form.value.month) return
+  if (!form.value.employee_id) {
+    toast.add({ severity: 'warn', summary: t('salary.validation_employee_required'), life: 3000 })
+    return
+  }
+  if (!form.value.month) {
+    toast.add({ severity: 'warn', summary: t('salary.validation_month_required'), life: 3000 })
+    return
+  }
   saving.value = true
   try {
     const payload = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "solde"
-version = "1.1.0"
+version = "1.1.1"
 description = "Web app for French non-profit accounting — invoicing, payments, cash management and double-entry bookkeeping."
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## v1.1.1 - 2026-05-01

Patch release corrigeant l'erreur MissingGreenlet sur les fiches de paie et ameliorant le feedback frontend du formulaire salaire.

### Corrige

- **Salaires - backend** : erreur MissingGreenlet (SQLAlchemy async) a la creation et modification d'une fiche de paie - acces lazy a salary.employee remplace par des requetes async explicites (selectinload / query directe) dans accounting_engine.py et salary_service.py
- **Salaires - frontend** : le bouton Enregistrer restait silencieux lorsque l'employe ou le mois n'etait pas renseigne - un toast d'avertissement est desormais affiche
- **Salaires - frontend** : echec du chargement de la liste des employes passe silencieusement - une erreur toast est maintenant affichee si GET /api/contacts/?type=employe echoue

### Fichiers modifies

- backend/services/accounting_engine.py
- backend/services/salary_service.py
- frontend/src/views/SalaryView.vue
- frontend/src/i18n/fr.ts
- CHANGELOG.md, pyproject.toml, frontend/package.json

## Summary by Sourcery

Prepare patch release 1.1.1 with fixes to salary processing and related frontend feedback.

Bug Fixes:
- Avoid MissingGreenlet errors when creating or updating salaries by replacing lazy access to the employee relationship with explicit async queries and eager loading.
- Prevent MissingGreenlet in accounting entry generation by querying the employee contact explicitly instead of relying on lazy loading.
- Provide user feedback when saving a salary without an employee or month by showing validation toasts instead of silently ignoring the action.
- Surface errors when loading the employee list in the salary view by displaying an error toast instead of failing silently.

Enhancements:
- Add French i18n strings for salary validation and employee loading error messages.

Build:
- Bump backend project version to 1.1.1 in pyproject.toml and align frontend package.json version.

Documentation:
- Update CHANGELOG with 1.1.1 release notes for salary-related fixes.