### PR TITLE
fix(invoices): supplier invoices default to sent status on creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Ce projet respecte le [Versionnage sémantique](https://semver.org/lang/fr/).
 
 ### Corrigé
 
+- Factures fournisseur (BIZ-139) : les factures fournisseur créées manuellement démarraient en statut `Brouillon` au lieu de `Reçue`, les rendant invisibles dans le dialogue de rapprochement bancaire — corrigé : le statut initial est désormais `sent` pour toute facture de type fournisseur
 - Salaires (BIZ-138) : les écritures comptables générées à la création d'une fiche de paie étaient datées au 1er jour du mois au lieu du dernier (ex. `2026-04-01` au lieu de `2026-04-30`) — corrigé via `calendar.monthrange`
 - Salaires : erreur `MissingGreenlet` (SQLAlchemy async) à la création et modification d'une fiche de paie — accès lazy à `salary.employee` remplacé par des requêtes async explicites (`selectinload` / query directe)
 - Salaires : le bouton « Enregistrer » restait silencieux lorsque l'employé ou le mois n'était pas renseigné — un toast d'avertissement est désormais affiché

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Ce projet respecte le [Versionnage sémantique](https://semver.org/lang/fr/).
 
 ### Ajouté
 
+- Factures fournisseur (BIZ-139) : dialogue de prévisualisation accessible depuis l'icône œil dans la liste — affiche les infos clés (contact, dates, référence, montants, statut), l'historique des paiements et un aperçu intégré de la pièce jointe (PDF via iframe, image via balise img) avec boutons télécharger et remplacer ; nouvel endpoint `GET /api/invoices/{id}/file`
 - Lot I-BNK (BIZ-133) : Édition de la catégorie détectée d'une entrée bancaire — clic sur l'icône crayon dans la colonne Catégorie pour choisir une nouvelle valeur ; mise à jour via `PUT /api/bank/transactions/{id}` (nouveau champ `detected_category` dans `BankTransactionUpdate`)
 - Lot I-BNK (BIZ-135) : Boutons « Tout rapprocher » et « Rapprocher avant… » dans la barre d'outils du relevé — le premier rapproche toutes les opérations chargées en un clic, le second ouvre un sélecteur de date pour un rapprochement en masse ; nouvel endpoint `POST /api/bank/transactions/reconcile-bulk`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,9 @@ Ce projet respecte le [Versionnage sémantique](https://semver.org/lang/fr/).
 
 ### Ajouté
 
-- Factures fournisseur (BIZ-139) : dialogue de prévisualisation accessible depuis l'icône œil dans la liste — affiche les infos clés (contact, dates, référence, montants, statut), l'historique des paiements et un aperçu intégré de la pièce jointe (PDF via iframe, image via balise img) avec boutons télécharger et remplacer ; nouvel endpoint `GET /api/invoices/{id}/file`
+- Factures fournisseur (BIZ-139) : dialogue de prévisualisation accessible depuis l'icône œil dans la liste — affiche les infos clés (contact, dates, référence, montants, statut), l'historique des paiements et un aperçu intégré de la pièce jointe (PDF via `<embed>`, image via `<img>`) avec boutons télécharger et remplacer ; navigation ‹ précédent / suivant › dans la liste filtrée courante ; nouvel endpoint `GET /api/invoices/{id}/file`
+- Historique contact : la prévisualisation d'une facture (fournisseur ou client) s'affiche désormais en vue inline dans le même panneau (sans Dialog imbriqué) avec bouton « Retour à la liste » et navigation ‹ précédent / suivant › dans les factures du contact
+- `scripts/attach_supplier_invoices.py` : script one-shot pour rattacher en masse les fichiers PDF/image existants (`data/factures_fournisseur/`) aux factures fournisseur de la base
 - Lot I-BNK (BIZ-133) : Édition de la catégorie détectée d'une entrée bancaire — clic sur l'icône crayon dans la colonne Catégorie pour choisir une nouvelle valeur ; mise à jour via `PUT /api/bank/transactions/{id}` (nouveau champ `detected_category` dans `BankTransactionUpdate`)
 - Lot I-BNK (BIZ-135) : Boutons « Tout rapprocher » et « Rapprocher avant… » dans la barre d'outils du relevé — le premier rapproche toutes les opérations chargées en un clic, le second ouvre un sélecteur de date pour un rapprochement en masse ; nouvel endpoint `POST /api/bank/transactions/reconcile-bulk`
 

--- a/backend/routers/invoice.py
+++ b/backend/routers/invoice.py
@@ -487,6 +487,37 @@ async def send_invoice_email(
     )
 
 
+@router.get("/{invoice_id}/file")
+async def download_invoice_file(
+    invoice_id: int,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    _current_user: _ReadAccess,
+) -> FileResponse:
+    """Return the uploaded file attachment for a supplier invoice."""
+    invoice = await invoice_service.get_invoice(db, invoice_id)
+    if invoice is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Invoice not found")
+    if not invoice.file_path:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No file attached")
+    file_path = Path(invoice.file_path)
+    if not file_path.is_file():
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File not found on disk")
+    suffix = file_path.suffix.lower()
+    media_type_map = {
+        ".pdf": "application/pdf",
+        ".jpg": "image/jpeg",
+        ".jpeg": "image/jpeg",
+        ".png": "image/png",
+        ".webp": "image/webp",
+    }
+    media_type = media_type_map.get(suffix, "application/octet-stream")
+    return FileResponse(
+        path=str(file_path),
+        media_type=media_type,
+        filename=f"facture_{invoice.number}{suffix}",
+    )
+
+
 @router.post("/{invoice_id}/file", response_model=InvoiceRead)
 async def upload_invoice_file(
     invoice_id: int,

--- a/backend/services/invoice.py
+++ b/backend/services/invoice.py
@@ -36,6 +36,24 @@ class InvoiceUpdateError(Exception):
     """Raised when an invoice cannot be edited in its current business state."""
 
 
+# Initial status per invoice type.
+# Using an explicit mapping so any new InvoiceType is caught at creation time.
+_INITIAL_STATUS: dict[InvoiceType, InvoiceStatus] = {
+    InvoiceType.CLIENT: InvoiceStatus.DRAFT,
+    # Supplier invoices are *received*, not created from scratch — they are
+    # immediately valid and must appear in bank reconciliation.
+    InvoiceType.FOURNISSEUR: InvoiceStatus.SENT,
+}
+
+
+def _initial_status(invoice_type: InvoiceType) -> InvoiceStatus:
+    """Return the initial status for a newly created invoice of the given type."""
+    status = _INITIAL_STATUS.get(invoice_type)
+    if status is None:
+        raise ValueError(f"No initial status defined for invoice type {invoice_type!r}")
+    return status
+
+
 # Valid transitions: from → set of allowed target statuses
 _VALID_TRANSITIONS: dict[InvoiceStatus, set[InvoiceStatus]] = {
     InvoiceStatus.DRAFT: {
@@ -208,11 +226,7 @@ async def create_invoice(db: AsyncSession, payload: InvoiceCreate) -> Invoice:
             payload.type,
             len(payload.lines),
         ),
-        # Supplier invoices are received (not created from scratch), so they
-        # start as "sent" (= received/validated) rather than "draft".
-        status=(
-            InvoiceStatus.SENT if payload.type == InvoiceType.FOURNISSEUR else InvoiceStatus.DRAFT
-        ),
+        status=_initial_status(payload.type),
         hours=payload.hours,
     )
     db.add(invoice)

--- a/backend/services/invoice.py
+++ b/backend/services/invoice.py
@@ -208,7 +208,11 @@ async def create_invoice(db: AsyncSession, payload: InvoiceCreate) -> Invoice:
             payload.type,
             len(payload.lines),
         ),
-        status=InvoiceStatus.DRAFT,
+        # Supplier invoices are received (not created from scratch), so they
+        # start as "sent" (= received/validated) rather than "draft".
+        status=(
+            InvoiceStatus.SENT if payload.type == InvoiceType.FOURNISSEUR else InvoiceStatus.DRAFT
+        ),
         hours=payload.hours,
     )
     db.add(invoice)

--- a/doc/backlog.md
+++ b/doc/backlog.md
@@ -20,11 +20,19 @@ Quand un sujet est livré, mettre à jour `CHANGELOG.md` et passer le ticket en 
 | ID | Titre | Prio | Est. | Créé | Terminé |
 | --- | --- | --- | --- | --- | --- |
 | BIZ-138 | Écritures salaires : date au dernier jour du mois | P1 | ~15 min | 2026-05-02 | 2026-05-02 |
+| BIZ-139 | Factures fournisseur créées en statut « Reçue » au lieu de Brouillon | P1 | ~20 min | 2026-05-02 | 2026-05-02 |
 | CHR-078 | Squelette i18n anglais | P3 | ~5 min | 2026-04-23 | — |
 
 ---
 
 ## Détails
+
+### BIZ-139 — Factures fournisseur créées en statut « Reçue » au lieu de Brouillon
+
+- **Terminé** : 2026-05-02
+- À la création manuelle d'une facture fournisseur, le service assignait le statut `draft` (calqué sur le workflow client). Or une facture fournisseur est *reçue* : elle doit être immédiatement disponible pour le rapprochement bancaire.
+- **Correction** : `backend/services/invoice.py` — `create_invoice` assigne `InvoiceStatus.SENT` pour les factures `FOURNISSEUR` au lieu de `DRAFT`.
+- **Migration** : les 2 factures fournisseur déjà encodées manuellement en `draft` ont été passées en `sent` directement en base.
 
 ### BIZ-138 — Écritures salaires : date au dernier jour du mois
 

--- a/frontend/src/api/invoices.ts
+++ b/frontend/src/api/invoices.ts
@@ -172,3 +172,8 @@ export async function uploadInvoiceFileApi(id: number, file: File): Promise<Invo
   })
   return response.data
 }
+
+export async function downloadInvoiceFileApi(id: number): Promise<Blob> {
+  const response = await apiClient.get(`/api/invoices/${id}/file`, { responseType: 'blob' })
+  return response.data
+}

--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -442,6 +442,10 @@ html.dark-mode .app-chip {
   width: min(calc(100vw - 2rem), 920px);
 }
 
+.app-dialog--xlarge {
+  width: min(calc(100vw - 2rem), 1100px);
+}
+
 .app-dialog .p-dialog-header {
   padding-bottom: var(--app-space-3);
 }

--- a/frontend/src/components/ContactHistoryContent.vue
+++ b/frontend/src/components/ContactHistoryContent.vue
@@ -303,9 +303,100 @@
         : ''
     "
     modal
-    class="app-dialog app-dialog--large"
+    class="app-dialog app-dialog--xlarge"
+    @hide="onInvoiceDetailHide"
   >
     <Skeleton v-if="invoiceDetailLoading" height="220px" border-radius="8px" />
+
+    <!-- Supplier invoice: 2-column layout with file preview -->
+    <div v-else-if="invoiceDetail && invoiceDetail.type === 'fournisseur'" class="chd-supplier">
+      <div class="chd-supplier__meta">
+        <Tag
+          :value="t(`invoices.statuses.${invoiceDetail.status}`)"
+          :severity="statusSeverity(invoiceDetail.status)"
+        />
+        <span>{{ formatDisplayDate(invoiceDetail.date) }}</span>
+        <span v-if="invoiceDetail.due_date"
+          >{{ t('invoices.due_date') }} : {{ formatDisplayDate(invoiceDetail.due_date) }}</span
+        >
+        <span v-if="invoiceDetail.reference"
+          >{{ t('invoices.reference') }} : {{ invoiceDetail.reference }}</span
+        >
+      </div>
+
+      <div class="chd-supplier__summary">
+        <div class="history-dialog__metric">
+          <div class="history-dialog__label">{{ t('invoices.total') }}</div>
+          <div class="history-dialog__value">{{ fmt(invoiceDetail.total_amount) }} €</div>
+        </div>
+        <div class="history-dialog__metric">
+          <div class="history-dialog__label">{{ t('invoices.paid') }}</div>
+          <div class="history-dialog__value history-dialog__value--success">{{ fmt(invoiceDetail.paid_amount) }} €</div>
+        </div>
+        <div class="history-dialog__metric">
+          <div class="history-dialog__label">{{ t('invoices.remaining') }}</div>
+          <div
+            class="history-dialog__value"
+            :class="invoiceRemaining > 0 ? 'history-dialog__value--warn' : 'history-dialog__value--success'"
+          >{{ invoiceRemaining.toFixed(2) }} €</div>
+        </div>
+      </div>
+
+      <div class="chd-supplier__body">
+        <!-- Payments -->
+        <div class="chd-supplier__payments">
+          <h3 class="app-dialog-section__title">{{ t('invoices.history') }}</h3>
+          <AppTableSkeleton v-if="invoiceDetailPaymentsLoading" :rows="3" :cols="3" />
+          <div v-else-if="invoiceDetailPayments.length === 0" class="app-empty-state">
+            {{ t('invoices.no_payments') }}
+          </div>
+          <DataTable
+            v-else
+            :value="invoiceDetailPayments"
+            class="app-data-table"
+            size="small"
+          >
+            <Column field="date" :header="t('payments.date')" sortable>
+              <template #body="{ data }">{{ formatDisplayDate(data.date) }}</template>
+            </Column>
+            <Column field="amount" :header="t('payments.amount')" class="app-money" sortable>
+              <template #body="{ data }">{{ fmt(data.amount) }} €</template>
+            </Column>
+            <Column field="method" :header="t('payments.method')" sortable>
+              <template #body="{ data }">{{ t(`payments.methods.${data.method}`) }}</template>
+            </Column>
+          </DataTable>
+        </div>
+
+        <!-- File preview -->
+        <div class="chd-supplier__file">
+          <h3 class="app-dialog-section__title">{{ t('invoices.file') }}</h3>
+          <div v-if="!invoiceDetail.file_path" class="app-empty-state">
+            {{ t('invoices.supplier.no_attachment') }}
+          </div>
+          <div v-else-if="invoiceFileLoading" class="chd-supplier__file-loading">
+            <i class="pi pi-spin pi-spinner" style="font-size: 2rem" />
+          </div>
+          <div v-else-if="invoiceFileBlobUrl" class="chd-supplier__file-frame">
+            <embed
+              v-if="invoiceFileBlobIsPdf"
+              :src="invoiceFileBlobUrl"
+              type="application/pdf"
+              class="chd-supplier__embed"
+            />
+            <img
+              v-else
+              :src="invoiceFileBlobUrl"
+              class="chd-supplier__img"
+              :alt="t('invoices.supplier.preview_file')"
+            />
+          </div>
+          <div v-else class="app-empty-state">{{ t('common.error.unknown') }}</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Client invoice: existing layout -->
     <div v-else-if="invoiceDetail" class="contact-history-dialog">
       <div class="contact-history-dialog__meta">
         <Tag
@@ -464,9 +555,9 @@ import AppStatCard from './ui/AppStatCard.vue'
 import AppTableSkeleton from './ui/AppTableSkeleton.vue'
 import { getContactHistoryApi, markCreanceDouteuse } from '../api/accounting'
 import type { ContactHistory, ContactInvoiceSummary, ContactPaymentSummary } from '../api/accounting'
-import { downloadInvoicePdfApi, getInvoiceApi } from '../api/invoices'
+import { downloadInvoicePdfApi, downloadInvoiceFileApi, getInvoiceApi } from '../api/invoices'
 import type { Invoice } from '../api/invoices'
-import { getPayment } from '../api/payments'
+import { getPayment, listPayments } from '../api/payments'
 import type { Payment } from '../api/payments'
 import {
   dateRangeFilter,
@@ -495,6 +586,11 @@ const paymentDetail = ref<Payment | null>(null)
 const paymentDetailLoading = ref(false)
 const downloadingPdf = ref(false)
 const emailDialogInvoiceId = ref<number | null>(null)
+const invoiceFileBlobUrl = ref<string | null>(null)
+const invoiceFileBlobIsPdf = ref(false)
+const invoiceFileLoading = ref(false)
+const invoiceDetailPayments = ref<Payment[]>([])
+const invoiceDetailPaymentsLoading = ref(false)
 
 const contactEmail = computed((): string | null => {
   const email = history.value?.contact.email
@@ -591,13 +687,46 @@ async function openInvoiceDetail(data: ContactInvoiceSummary): Promise<void> {
   invoiceDetailVisible.value = true
   invoiceDetailLoading.value = true
   invoiceDetail.value = null
+  invoiceFileBlobUrl.value = null
+  invoiceDetailPayments.value = []
   try {
-    invoiceDetail.value = await getInvoiceApi(data.id)
+    const inv = await getInvoiceApi(data.id)
+    invoiceDetail.value = inv
+    // For supplier invoices: load payments + file in parallel
+    if (inv.type === 'fournisseur') {
+      invoiceDetailPaymentsLoading.value = true
+      if (inv.file_path) invoiceFileLoading.value = true
+      const tasks: Promise<void>[] = [
+        listPayments({ invoice_id: inv.id })
+          .then((p) => { invoiceDetailPayments.value = p })
+          .catch(() => {})
+          .finally(() => { invoiceDetailPaymentsLoading.value = false }),
+      ]
+      if (inv.file_path) {
+        tasks.push(
+          downloadInvoiceFileApi(inv.id)
+            .then((blob) => {
+              invoiceFileBlobIsPdf.value = blob.type === 'application/pdf'
+              invoiceFileBlobUrl.value = URL.createObjectURL(blob)
+            })
+            .catch(() => {})
+            .finally(() => { invoiceFileLoading.value = false }),
+        )
+      }
+      await Promise.all(tasks)
+    }
   } catch {
     toast.add({ severity: 'error', summary: t('common.error.unknown'), life: 4000 })
     invoiceDetailVisible.value = false
   } finally {
     invoiceDetailLoading.value = false
+  }
+}
+
+function onInvoiceDetailHide(): void {
+  if (invoiceFileBlobUrl.value) {
+    URL.revokeObjectURL(invoiceFileBlobUrl.value)
+    invoiceFileBlobUrl.value = null
   }
 }
 
@@ -729,6 +858,100 @@ onMounted(loadHistory)
   gap: 0.75rem;
   flex-wrap: wrap;
   padding-top: 0.5rem;
+}
+
+/* Supplier invoice preview layout */
+.chd-supplier {
+  display: flex;
+  flex-direction: column;
+  gap: var(--app-space-4);
+}
+
+.chd-supplier__meta {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  font-size: 0.9rem;
+  color: var(--p-text-muted-color);
+}
+
+.chd-supplier__summary {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--app-space-3);
+  padding-bottom: var(--app-space-4);
+  border-bottom: 1px solid var(--app-surface-border);
+}
+
+.history-dialog__metric {
+  padding: var(--app-space-3);
+  border-radius: var(--app-surface-radius-sm);
+  background: color-mix(in srgb, var(--app-surface-bg) 85%, transparent 15%);
+}
+
+.history-dialog__label {
+  color: var(--p-text-muted-color);
+  font-size: 0.82rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.history-dialog__value {
+  margin-top: var(--app-space-2);
+  font-size: 1.05rem;
+  font-weight: 800;
+}
+
+.history-dialog__value--success { color: var(--p-green-600); }
+.history-dialog__value--warn { color: var(--p-orange-500); }
+
+.chd-supplier__body {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 460px;
+  gap: var(--app-space-5);
+  align-items: start;
+}
+
+.chd-supplier__payments,
+.chd-supplier__file {
+  display: flex;
+  flex-direction: column;
+  gap: var(--app-space-3);
+}
+
+.chd-supplier__file-loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 400px;
+  color: var(--p-text-muted-color);
+}
+
+.chd-supplier__file-frame {
+  border: 1px solid var(--app-surface-border);
+  border-radius: var(--app-surface-radius-sm);
+  overflow: hidden;
+}
+
+.chd-supplier__embed {
+  width: 100%;
+  height: 520px;
+  border: none;
+  display: block;
+}
+
+.chd-supplier__img {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+@media (max-width: 1000px) {
+  .chd-supplier__body {
+    grid-template-columns: 1fr;
+  }
 }
 
 .contact-history-dialog__fields {

--- a/frontend/src/components/ContactHistoryContent.vue
+++ b/frontend/src/components/ContactHistoryContent.vue
@@ -6,7 +6,7 @@
     <AppTableSkeleton :rows="10" :cols="4" style="margin-top: 1.5rem" />
   </div>
 
-  <template v-else-if="history">
+  <template v-else-if="history && !invoiceDetailVisible">
     <AppPanel
       :title="contactFullName(history.contact)"
       :subtitle="contactSubtitle(history.contact)"
@@ -291,21 +291,37 @@
     </AppPanel>
   </template>
 
-  <div v-else class="app-empty-state">
-    {{ t('common.error.notFound') }}
-  </div>
-
-  <Dialog
-    v-model:visible="invoiceDetailVisible"
-    :header="
-      invoiceDetail
-        ? t('contact_history.invoice_detail_title', { number: invoiceDetail.number })
-        : ''
-    "
-    modal
-    class="app-dialog app-dialog--xlarge"
-    @hide="onInvoiceDetailHide"
-  >
+  <template v-else-if="history && invoiceDetailVisible">
+    <div class="chd-back-bar">
+      <Button
+        icon="pi pi-arrow-left"
+        text
+        :label="t('contact_history.back_to_list')"
+        @click="closeInvoiceDetail"
+      />
+      <span class="chd-back-bar__title">{{ invoiceDetail?.number ?? '' }}</span>
+      <div class="chd-back-bar__nav">
+        <Button
+          icon="pi pi-chevron-left"
+          text
+          rounded
+          size="small"
+          :disabled="invoiceDetailIndex <= 0"
+          :title="t('common.previous')"
+          @click="goToPrevInvoice"
+        />
+        <span class="chd-back-bar__counter">{{ invoiceDetailIndex + 1 }} / {{ invoiceRows.length }}</span>
+        <Button
+          icon="pi pi-chevron-right"
+          text
+          rounded
+          size="small"
+          :disabled="invoiceDetailIndex >= invoiceRows.length - 1"
+          :title="t('common.next')"
+          @click="goToNextInvoice"
+        />
+      </div>
+    </div>
     <Skeleton v-if="invoiceDetailLoading" height="220px" border-radius="8px" />
 
     <!-- Supplier invoice: 2-column layout with file preview -->
@@ -472,7 +488,11 @@
         />
       </div>
     </div>
-  </Dialog>
+  </template>
+
+  <div v-else class="app-empty-state">
+    {{ t('common.error.notFound') }}
+  </div>
 
   <Dialog
     v-model:visible="paymentDetailVisible"
@@ -579,6 +599,7 @@ const toast = useToast()
 const history = ref<ContactHistory | null>(null)
 const loading = ref(false)
 const invoiceDetailVisible = ref(false)
+const invoiceDetailIndex = ref(-1)
 const invoiceDetail = ref<Invoice | null>(null)
 const invoiceDetailLoading = ref(false)
 const paymentDetailVisible = ref(false)
@@ -684,13 +705,21 @@ function contactSubtitle(contact: ContactHistory['contact']): string {
 }
 
 async function openInvoiceDetail(data: ContactInvoiceSummary): Promise<void> {
+  invoiceDetailIndex.value = invoiceRows.value.findIndex((r) => r.id === data.id)
   invoiceDetailVisible.value = true
+  await loadInvoiceDetailData(data.id)
+}
+
+async function loadInvoiceDetailData(id: number): Promise<void> {
   invoiceDetailLoading.value = true
   invoiceDetail.value = null
-  invoiceFileBlobUrl.value = null
+  if (invoiceFileBlobUrl.value) {
+    URL.revokeObjectURL(invoiceFileBlobUrl.value)
+    invoiceFileBlobUrl.value = null
+  }
   invoiceDetailPayments.value = []
   try {
-    const inv = await getInvoiceApi(data.id)
+    const inv = await getInvoiceApi(id)
     invoiceDetail.value = inv
     // For supplier invoices: load payments + file in parallel
     if (inv.type === 'fournisseur') {
@@ -717,17 +746,33 @@ async function openInvoiceDetail(data: ContactInvoiceSummary): Promise<void> {
     }
   } catch {
     toast.add({ severity: 'error', summary: t('common.error.unknown'), life: 4000 })
-    invoiceDetailVisible.value = false
+    closeInvoiceDetail()
   } finally {
     invoiceDetailLoading.value = false
   }
 }
 
-function onInvoiceDetailHide(): void {
+function closeInvoiceDetail(): void {
   if (invoiceFileBlobUrl.value) {
     URL.revokeObjectURL(invoiceFileBlobUrl.value)
     invoiceFileBlobUrl.value = null
   }
+  invoiceDetailVisible.value = false
+  invoiceDetail.value = null
+}
+
+async function goToPrevInvoice(): Promise<void> {
+  const idx = invoiceDetailIndex.value - 1
+  if (idx < 0) return
+  invoiceDetailIndex.value = idx
+  await loadInvoiceDetailData(invoiceRows.value[idx].id)
+}
+
+async function goToNextInvoice(): Promise<void> {
+  const idx = invoiceDetailIndex.value + 1
+  if (idx >= invoiceRows.value.length) return
+  invoiceDetailIndex.value = idx
+  await loadInvoiceDetailData(invoiceRows.value[idx].id)
 }
 
 async function openPaymentDetail(data: ContactPaymentSummary): Promise<void> {
@@ -858,6 +903,37 @@ onMounted(loadHistory)
   gap: 0.75rem;
   flex-wrap: wrap;
   padding-top: 0.5rem;
+}
+
+/* Inline detail navigation bar */
+.chd-back-bar {
+  display: flex;
+  align-items: center;
+  gap: var(--app-space-3);
+  padding-bottom: var(--app-space-4);
+  border-bottom: 1px solid var(--app-surface-border);
+  margin-bottom: var(--app-space-4);
+}
+
+.chd-back-bar__title {
+  flex: 1;
+  font-weight: 600;
+  font-size: 1rem;
+  color: var(--p-text-color);
+}
+
+.chd-back-bar__nav {
+  display: flex;
+  align-items: center;
+  gap: var(--app-space-1);
+  margin-left: auto;
+}
+
+.chd-back-bar__counter {
+  font-size: 0.85rem;
+  color: var(--p-text-muted-color);
+  min-width: 3.5rem;
+  text-align: center;
 }
 
 /* Supplier invoice preview layout */

--- a/frontend/src/i18n/fr.ts
+++ b/frontend/src/i18n/fr.ts
@@ -459,6 +459,10 @@ export default {
         'Conservez ici les informations utiles pour le contrôle et le rapprochement.',
       upload_intro:
         'Associez un justificatif pour retrouver rapidement la pièce depuis le portefeuille fournisseur.',
+      preview_title: 'Facture {number}',
+      preview_file: 'Prévisualiser la pièce jointe',
+      download_file: 'Télécharger',
+      no_attachment: 'Aucune pièce jointe.',
     },
     new: 'Nouvelle facture',
     edit: 'Modifier la facture',

--- a/frontend/src/i18n/fr.ts
+++ b/frontend/src/i18n/fr.ts
@@ -213,6 +213,8 @@ export default {
     filter_placeholder: 'Rechercher…',
     refresh: 'Actualiser',
     reset_filters: 'Réinitialiser les filtres',
+    previous: 'Précédent',
+    next: 'Suivant',
     active: 'Actif',
     inactive: 'Inactif',
     list: {
@@ -1754,6 +1756,7 @@ export default {
     view_payment: 'Voir le paiement',
     invoice_detail_title: 'Facture {number}',
     payment_detail_title: 'Détail du paiement',
+    back_to_list: 'Retour à la liste',
   },
   bilan: {
     title: 'Bilan simplifié',

--- a/frontend/src/views/ClientInvoicesView.vue
+++ b/frontend/src/views/ClientInvoicesView.vue
@@ -413,7 +413,7 @@
       v-model:visible="historyVisible"
       :header="historyInvoice ? t('invoices.history_title', { number: historyInvoice.number }) : ''"
       modal
-      class="app-dialog app-dialog--large"
+      class="app-dialog app-dialog--xlarge"
       @hide="onHistoryHide"
     >
       <div v-if="historyInvoice" class="history-dialog history-dialog--with-preview">
@@ -1249,7 +1249,7 @@ onMounted(async () => {
 
 .history-dialog--with-preview .history-dialog__body {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: minmax(0, 1fr) 480px;
   gap: var(--app-space-5);
   align-items: start;
 }
@@ -1347,7 +1347,7 @@ onMounted(async () => {
   color: var(--p-orange-500);
 }
 
-@media (max-width: 900px) {
+@media (max-width: 1050px) {
   .history-dialog--with-preview .history-dialog__body {
     grid-template-columns: 1fr;
   }

--- a/frontend/src/views/ClientInvoicesView.vue
+++ b/frontend/src/views/ClientInvoicesView.vue
@@ -413,9 +413,10 @@
       v-model:visible="historyVisible"
       :header="historyInvoice ? t('invoices.history_title', { number: historyInvoice.number }) : ''"
       modal
-      class="app-dialog app-dialog--medium"
+      class="app-dialog app-dialog--large"
+      @hide="onHistoryHide"
     >
-      <div v-if="historyInvoice" class="history-dialog">
+      <div v-if="historyInvoice" class="history-dialog history-dialog--with-preview">
         <section class="app-dialog-intro history-dialog__intro">
           <div>
             <p class="app-dialog-intro__eyebrow">{{ t('invoices.history') }}</p>
@@ -429,109 +430,134 @@
             @click="openPaymentDialog(historyInvoice)"
           />
         </section>
-        <div class="history-dialog__summary">
-          <div class="history-dialog__metric">
-            <div class="history-dialog__label">{{ t('invoices.total') }}</div>
-            <div class="history-dialog__value">
-              {{ formatAmount(historyInvoice.total_amount) }} €
-            </div>
-          </div>
-          <div class="history-dialog__metric">
-            <div class="history-dialog__label">{{ t('invoices.paid') }}</div>
-            <div class="history-dialog__value history-dialog__value--success">
-              {{ formatAmount(historyInvoice.paid_amount) }} €
-            </div>
-          </div>
-          <div class="history-dialog__metric">
-            <div class="history-dialog__label">{{ t('invoices.remaining') }}</div>
-            <div
-              class="history-dialog__value"
-              :class="
-                remaining > 0 ? 'history-dialog__value--warn' : 'history-dialog__value--success'
-              "
-            >
-              {{ remaining.toFixed(2) }} €
-            </div>
-          </div>
-        </div>
 
-        <AppTableSkeleton v-if="historyLoading" :rows="5" :cols="3" />
-        <div v-else-if="historyPayments.length === 0" class="app-empty-state">
-          {{ t('invoices.no_payments') }}
-        </div>
-        <DataTable
-          v-else
-          v-model:filters="historyTableFilters"
-          :value="historyPaymentRows"
-          class="app-data-table"
-          filter-display="menu"
-          paginator
-          :rows="20"
-          :rows-per-page-options="[20, 50, 100, 500]"
-          size="small"
-          :global-filter-fields="['date', 'amount_value', 'method', 'cheque_number']"
-          removable-sort
-        >
-          <Column
-            field="date"
-            :header="t('payments.date')"
-            sortable
-            :show-filter-match-modes="false"
-            :show-add-button="false"
-          >
-            <template #body="{ data }">{{ formatDisplayDate(data.date) }}</template>
-            <template #filter="{ filterModel }">
-              <AppDateRangeFilter v-model="filterModel.value" />
-            </template>
-          </Column>
-          <Column
-            field="amount_value"
-            :header="t('payments.amount')"
-            class="app-money"
-            sortable
-            data-type="numeric"
-            :show-filter-match-modes="false"
-            :show-add-button="false"
-          >
-            <template #body="{ data }">{{ parseFloat(data.amount).toFixed(2) }} €</template>
-            <template #filter="{ filterModel }">
-              <AppNumberRangeFilter v-model="filterModel.value" />
-            </template>
-          </Column>
-          <Column
-            field="method_label"
-            :header="t('payments.method')"
-            filter-field="method"
-            sortable
-            :show-filter-match-modes="false"
-            :show-add-button="false"
-          >
-            <template #body="{ data }">{{ t(`payments.methods.${data.method}`) }}</template>
-            <template #filter="{ filterModel, filterCallback }">
-              <AppFilterMultiSelect
-                v-model="filterModel.value"
-                :options="paymentMethodOptions"
-                option-label="label"
-                option-value="value"
-                :placeholder="t('common.all')"
-                display="chip"
-                show-clear
-                :filter-callback="filterCallback"
+        <div class="history-dialog__body">
+          <div class="history-dialog__payments">
+            <div class="history-dialog__summary">
+              <div class="history-dialog__metric">
+                <div class="history-dialog__label">{{ t('invoices.total') }}</div>
+                <div class="history-dialog__value">
+                  {{ formatAmount(historyInvoice.total_amount) }} €
+                </div>
+              </div>
+              <div class="history-dialog__metric">
+                <div class="history-dialog__label">{{ t('invoices.paid') }}</div>
+                <div class="history-dialog__value history-dialog__value--success">
+                  {{ formatAmount(historyInvoice.paid_amount) }} €
+                </div>
+              </div>
+              <div class="history-dialog__metric">
+                <div class="history-dialog__label">{{ t('invoices.remaining') }}</div>
+                <div
+                  class="history-dialog__value"
+                  :class="
+                    remaining > 0 ? 'history-dialog__value--warn' : 'history-dialog__value--success'
+                  "
+                >
+                  {{ remaining.toFixed(2) }} €
+                </div>
+              </div>
+            </div>
+
+            <AppTableSkeleton v-if="historyLoading" :rows="5" :cols="3" />
+            <div v-else-if="historyPayments.length === 0" class="app-empty-state">
+              {{ t('invoices.no_payments') }}
+            </div>
+            <DataTable
+              v-else
+              v-model:filters="historyTableFilters"
+              :value="historyPaymentRows"
+              class="app-data-table"
+              filter-display="menu"
+              paginator
+              :rows="20"
+              :rows-per-page-options="[20, 50, 100, 500]"
+              size="small"
+              :global-filter-fields="['date', 'amount_value', 'method', 'cheque_number']"
+              removable-sort
+            >
+              <Column
+                field="date"
+                :header="t('payments.date')"
+                sortable
+                :show-filter-match-modes="false"
+                :show-add-button="false"
+              >
+                <template #body="{ data }">{{ formatDisplayDate(data.date) }}</template>
+                <template #filter="{ filterModel }">
+                  <AppDateRangeFilter v-model="filterModel.value" />
+                </template>
+              </Column>
+              <Column
+                field="amount_value"
+                :header="t('payments.amount')"
+                class="app-money"
+                sortable
+                data-type="numeric"
+                :show-filter-match-modes="false"
+                :show-add-button="false"
+              >
+                <template #body="{ data }">{{ parseFloat(data.amount).toFixed(2) }} €</template>
+                <template #filter="{ filterModel }">
+                  <AppNumberRangeFilter v-model="filterModel.value" />
+                </template>
+              </Column>
+              <Column
+                field="method_label"
+                :header="t('payments.method')"
+                filter-field="method"
+                sortable
+                :show-filter-match-modes="false"
+                :show-add-button="false"
+              >
+                <template #body="{ data }">{{ t(`payments.methods.${data.method}`) }}</template>
+                <template #filter="{ filterModel, filterCallback }">
+                  <AppFilterMultiSelect
+                    v-model="filterModel.value"
+                    :options="paymentMethodOptions"
+                    option-label="label"
+                    option-value="value"
+                    :placeholder="t('common.all')"
+                    display="chip"
+                    show-clear
+                    :filter-callback="filterCallback"
+                  />
+                </template>
+              </Column>
+              <Column
+                field="cheque_number"
+                :header="t('payments.cheque_number')"
+                sortable
+                :show-filter-match-modes="false"
+                :show-add-button="false"
+              >
+                <template #filter="{ filterModel }">
+                  <InputText v-model="filterModel.value" :placeholder="t('payments.cheque_number')" />
+                </template>
+              </Column>
+            </DataTable>
+          </div><!-- end history-dialog__payments -->
+
+          <!-- PDF preview -->
+          <div class="history-dialog__preview">
+            <h3 class="app-dialog-section__title">{{ t('invoices.email_preview') }}</h3>
+            <div v-if="historyPdfLoading" class="history-dialog__preview-loading">
+              <i class="pi pi-spin pi-spinner" style="font-size: 2rem" />
+            </div>
+            <div v-else-if="historyPdfBlobUrl" class="history-dialog__preview-frame">
+              <embed
+                :src="historyPdfBlobUrl"
+                type="application/pdf"
+                class="history-dialog__preview-embed"
               />
-            </template>
-          </Column>
-          <Column
-            field="cheque_number"
-            :header="t('payments.cheque_number')"
-            sortable
-            :show-filter-match-modes="false"
-            :show-add-button="false"
-          >
-            <template #filter="{ filterModel }">
-              <InputText v-model="filterModel.value" :placeholder="t('payments.cheque_number')" />
-            </template>
-          </Column>
-        </DataTable>
+            </div>
+            <div v-else class="history-dialog__preview-empty">
+              <i class="pi pi-file-pdf" />
+              <span>{{ t('invoices.email_preview_unavailable') }}</span>
+            </div>
+          </div><!-- end history-dialog__preview -->
+        </div><!-- end history-dialog__body -->
+
       </div>
     </Dialog>
 
@@ -716,6 +742,8 @@ const historyVisible = ref(false)
 const historyInvoice = ref<Invoice | null>(null)
 const historyLoading = ref(false)
 const historyPayments = ref<Payment[]>([])
+const historyPdfBlobUrl = ref<string | null>(null)
+const historyPdfLoading = ref(false)
 const paymentDialogVisible = ref(false)
 const paymentInvoice = ref<Invoice | null>(null)
 const paymentSaving = ref(false)
@@ -1033,7 +1061,22 @@ async function duplicate(invoice: Invoice) {
 async function openHistory(invoice: Invoice) {
   historyInvoice.value = invoice
   historyVisible.value = true
-  await loadHistoryPayments(invoice.id)
+  historyPdfBlobUrl.value = null
+  historyPdfLoading.value = true
+  await Promise.all([
+    loadHistoryPayments(invoice.id),
+    downloadInvoicePdfApi(invoice.id)
+      .then((blob) => { historyPdfBlobUrl.value = URL.createObjectURL(blob) })
+      .catch(() => {})
+      .finally(() => { historyPdfLoading.value = false }),
+  ])
+}
+
+function onHistoryHide() {
+  if (historyPdfBlobUrl.value) {
+    URL.revokeObjectURL(historyPdfBlobUrl.value)
+    historyPdfBlobUrl.value = null
+  }
 }
 
 async function loadHistoryPayments(invoiceId: number) {
@@ -1204,6 +1247,63 @@ onMounted(async () => {
   gap: var(--app-space-4);
 }
 
+.history-dialog--with-preview .history-dialog__body {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--app-space-5);
+  align-items: start;
+}
+
+.history-dialog__payments {
+  display: flex;
+  flex-direction: column;
+  gap: var(--app-space-4);
+}
+
+.history-dialog__preview {
+  display: flex;
+  flex-direction: column;
+  gap: var(--app-space-3);
+  position: sticky;
+  top: 0;
+}
+
+.history-dialog__preview-loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 400px;
+  color: var(--p-text-muted-color);
+}
+
+.history-dialog__preview-frame {
+  border: 1px solid var(--app-surface-border);
+  border-radius: var(--app-surface-radius-sm);
+  overflow: hidden;
+}
+
+.history-dialog__preview-embed {
+  width: 100%;
+  height: 520px;
+  border: none;
+  display: block;
+}
+
+.history-dialog__preview-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--app-space-3);
+  height: 200px;
+  color: var(--p-text-muted-color);
+  font-size: 0.9rem;
+}
+
+.history-dialog__preview-empty .pi {
+  font-size: 2.5rem;
+}
+
 .history-dialog__intro {
   display: flex;
   align-items: center;
@@ -1245,6 +1345,12 @@ onMounted(async () => {
 
 .history-dialog__value--warn {
   color: var(--p-orange-500);
+}
+
+@media (max-width: 900px) {
+  .history-dialog--with-preview .history-dialog__body {
+    grid-template-columns: 1fr;
+  }
 }
 
 @media (max-width: 767px) {

--- a/frontend/src/views/SupplierInvoicesView.vue
+++ b/frontend/src/views/SupplierInvoicesView.vue
@@ -218,6 +218,16 @@
                 @click="openEditDialog(data)"
               />
               <Button
+                v-if="data.file_path"
+                icon="pi pi-eye"
+                size="small"
+                severity="secondary"
+                text
+                :title="t('invoices.supplier.preview_file')"
+                :aria-label="t('invoices.supplier.preview_file')"
+                @click="openPreviewDialog(data)"
+              />
+              <Button
                 icon="pi pi-upload"
                 size="small"
                 severity="secondary"
@@ -302,6 +312,136 @@
       </div>
     </Dialog>
 
+    <!-- Preview dialog -->
+    <Dialog
+      v-model:visible="previewVisible"
+      :header="previewInvoice ? t('invoices.supplier.preview_title', { number: previewInvoice.number }) : ''"
+      modal
+      class="app-dialog app-dialog--large"
+      @hide="onPreviewHide"
+    >
+      <div v-if="previewInvoice" class="supplier-preview-dialog">
+
+        <!-- Header info + actions -->
+        <section class="app-dialog-intro history-dialog__intro">
+          <div>
+            <p class="app-dialog-intro__eyebrow">{{ contactName(previewInvoice.contact_id) }}</p>
+            <p class="app-dialog-intro__text">
+              {{ t('invoices.date') }} : {{ formatDisplayDate(previewInvoice.date) }}
+              <template v-if="previewInvoice.due_date">
+                &nbsp;·&nbsp; {{ t('invoices.due_date') }} : {{ formatDisplayDate(previewInvoice.due_date) }}
+              </template>
+              <template v-if="previewInvoice.reference">
+                &nbsp;·&nbsp; {{ t('invoices.reference') }} : {{ previewInvoice.reference }}
+              </template>
+            </p>
+          </div>
+          <div class="app-inline-actions">
+            <Tag
+              :value="t(`invoices.statuses.${previewInvoice.status}`)"
+              :severity="statusSeverity(previewInvoice.status)"
+            />
+            <Button
+              icon="pi pi-download"
+              size="small"
+              severity="secondary"
+              outlined
+              :label="t('invoices.supplier.download_file')"
+              :loading="previewDownloading"
+              :disabled="!previewInvoice.file_path"
+              @click="downloadFile(previewInvoice)"
+            />
+            <Button
+              icon="pi pi-upload"
+              size="small"
+              severity="secondary"
+              outlined
+              :label="t('invoices.upload_file')"
+              @click="openUploadFromPreview"
+            />
+          </div>
+        </section>
+
+        <!-- Amounts summary -->
+        <div class="history-dialog__summary">
+          <div class="history-dialog__metric">
+            <div class="history-dialog__label">{{ t('invoices.total') }}</div>
+            <div class="history-dialog__value">{{ formatAmount(previewInvoice.total_amount) }} €</div>
+          </div>
+          <div class="history-dialog__metric">
+            <div class="history-dialog__label">{{ t('invoices.paid') }}</div>
+            <div class="history-dialog__value history-dialog__value--success">{{ formatAmount(previewInvoice.paid_amount) }} €</div>
+          </div>
+          <div class="history-dialog__metric">
+            <div class="history-dialog__label">{{ t('invoices.remaining') }}</div>
+            <div
+              class="history-dialog__value"
+              :class="previewRemaining > 0 ? 'history-dialog__value--warn' : 'history-dialog__value--success'"
+            >{{ previewRemaining.toFixed(2) }} €</div>
+          </div>
+        </div>
+
+        <!-- Two-column layout: payments + file preview -->
+        <div class="supplier-preview-dialog__body">
+
+          <!-- Payments -->
+          <div class="supplier-preview-dialog__payments">
+            <h3 class="app-dialog-section__title">{{ t('invoices.history') }}</h3>
+            <AppTableSkeleton v-if="previewPaymentsLoading" :rows="3" :cols="3" />
+            <div v-else-if="previewPayments.length === 0" class="app-empty-state">
+              {{ t('invoices.no_payments') }}
+            </div>
+            <DataTable
+              v-else
+              :value="previewPayments"
+              class="app-data-table"
+              size="small"
+              :rows="10"
+            >
+              <Column field="date" :header="t('payments.date')" sortable>
+                <template #body="{ data }">{{ formatDisplayDate(data.date) }}</template>
+              </Column>
+              <Column field="amount" :header="t('payments.amount')" class="app-money" sortable>
+                <template #body="{ data }">{{ parseFloat(data.amount).toFixed(2) }} €</template>
+              </Column>
+              <Column field="method" :header="t('payments.method')" sortable>
+                <template #body="{ data }">{{ t(`payments.methods.${data.method}`) }}</template>
+              </Column>
+            </DataTable>
+          </div>
+
+          <!-- File preview -->
+          <div class="supplier-preview-dialog__file">
+            <h3 class="app-dialog-section__title">{{ t('invoices.file') }}</h3>
+            <div v-if="!previewInvoice.file_path" class="app-empty-state">
+              {{ t('invoices.supplier.no_attachment') }}
+            </div>
+            <div v-else-if="previewFileLoading" class="supplier-preview-dialog__file-loading">
+              <i class="pi pi-spin pi-spinner" style="font-size: 2rem" />
+            </div>
+            <div v-else-if="previewBlobUrl" class="supplier-preview-dialog__file-frame">
+              <iframe
+                v-if="previewIsPdf"
+                :src="previewBlobUrl"
+                class="supplier-preview-dialog__iframe"
+                :title="t('invoices.supplier.preview_file')"
+              />
+              <img
+                v-else
+                :src="previewBlobUrl"
+                class="supplier-preview-dialog__img"
+                :alt="t('invoices.supplier.preview_file')"
+              />
+            </div>
+            <div v-else class="app-empty-state">
+              {{ t('common.error.unknown') }}
+            </div>
+          </div>
+
+        </div>
+      </div>
+    </Dialog>
+
     <ConfirmDialog />
   </AppPage>
 </template>
@@ -329,15 +469,18 @@ import AppPage from '../components/ui/AppPage.vue'
 import AppPageHeader from '../components/ui/AppPageHeader.vue'
 import AppPanel from '../components/ui/AppPanel.vue'
 import AppStatCard from '../components/ui/AppStatCard.vue'
+import AppTableSkeleton from '../components/ui/AppTableSkeleton.vue'
 
 import { listContactsApi, type Contact } from '../api/contacts'
 import {
   deleteInvoiceApi,
+  downloadInvoiceFileApi,
   listInvoicesApi,
   uploadInvoiceFileApi,
   type Invoice,
   type InvoiceStatus,
 } from '../api/invoices'
+import { listPayments, type Payment } from '../api/payments'
 import SupplierInvoiceForm from '../components/SupplierInvoiceForm.vue'
 import {
   dateRangeFilter,
@@ -383,6 +526,21 @@ const uploadTargetId = ref<number | null>(null)
 const selectedFile = ref<File | null>(null)
 const uploading = ref(false)
 const statusFilter = ref<InvoiceStatus | null>(null)
+
+// Preview dialog
+const previewVisible = ref(false)
+const previewInvoice = ref<Invoice | null>(null)
+const previewPayments = ref<Payment[]>([])
+const previewPaymentsLoading = ref(false)
+const previewFileLoading = ref(false)
+const previewDownloading = ref(false)
+const previewBlobUrl = ref<string | null>(null)
+const previewIsPdf = ref(false)
+
+const previewRemaining = computed(() => {
+  if (!previewInvoice.value) return 0
+  return parseFloat(previewInvoice.value.total_amount) - parseFloat(previewInvoice.value.paid_amount)
+})
 
 const invoiceRows = computed(() =>
   invoices.value.map((invoice) => ({
@@ -529,6 +687,71 @@ function openUploadDialog(invoice: Invoice) {
   uploadDialogVisible.value = true
 }
 
+async function openPreviewDialog(invoice: Invoice) {
+  previewInvoice.value = invoice
+  previewBlobUrl.value = null
+  previewPayments.value = []
+  previewVisible.value = true
+
+  // Load payments and file in parallel
+  previewPaymentsLoading.value = true
+  previewFileLoading.value = !!invoice.file_path
+
+  const tasks: Promise<void>[] = [
+    listPayments({ invoice_id: invoice.id })
+      .then((p) => { previewPayments.value = p })
+      .catch(() => {})
+      .finally(() => { previewPaymentsLoading.value = false }),
+  ]
+
+  if (invoice.file_path) {
+    tasks.push(
+      downloadInvoiceFileApi(invoice.id)
+        .then((blob) => {
+          previewIsPdf.value = blob.type === 'application/pdf'
+          previewBlobUrl.value = URL.createObjectURL(blob)
+        })
+        .catch(() => {})
+        .finally(() => { previewFileLoading.value = false }),
+    )
+  }
+
+  await Promise.all(tasks)
+}
+
+function onPreviewHide() {
+  if (previewBlobUrl.value) {
+    URL.revokeObjectURL(previewBlobUrl.value)
+    previewBlobUrl.value = null
+  }
+  previewInvoice.value = null
+}
+
+async function downloadFile(invoice: Invoice) {
+  previewDownloading.value = true
+  try {
+    const blob = await downloadInvoiceFileApi(invoice.id)
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    const ext = invoice.file_path?.split('.').pop() ?? 'pdf'
+    a.download = `facture-${invoice.number}.${ext}`
+    a.click()
+    URL.revokeObjectURL(url)
+  } catch {
+    toast.add({ severity: 'error', summary: t('common.error.unknown'), life: 4000 })
+  } finally {
+    previewDownloading.value = false
+  }
+}
+
+function openUploadFromPreview() {
+  if (!previewInvoice.value) return
+  const inv = previewInvoice.value
+  previewVisible.value = false
+  nextTick(() => openUploadDialog(inv))
+}
+
 function onFileSelect(event: { files: File[] }) {
   selectedFile.value = event.files[0] ?? null
 }
@@ -594,25 +817,132 @@ onMounted(async () => {
 
 <style scoped>
 .supplier-invoices-table__actions {
-  width: 11.5rem;
-  min-width: 11.5rem;
+  width: 13rem;
+  min-width: 13rem;
 }
 
 :deep(.supplier-invoices-table .supplier-invoices-table__actions) {
   white-space: nowrap;
-  width: 11.5rem;
-  min-width: 11.5rem;
+  width: 13rem;
+  min-width: 13rem;
 }
 
 :deep(.supplier-invoices-table .app-inline-actions) {
   flex-wrap: nowrap;
   justify-content: flex-end;
-  min-width: 10rem;
+  min-width: 12rem;
 }
 
 .upload-dialog {
   display: flex;
   flex-direction: column;
   gap: var(--app-space-4);
+}
+
+.supplier-preview-dialog {
+  display: flex;
+  flex-direction: column;
+  gap: var(--app-space-4);
+}
+
+.supplier-preview-dialog__body {
+  display: grid;
+  grid-template-columns: 1fr 1.4fr;
+  gap: var(--app-space-5);
+  align-items: start;
+}
+
+.supplier-preview-dialog__payments {
+  display: flex;
+  flex-direction: column;
+  gap: var(--app-space-3);
+}
+
+.supplier-preview-dialog__file {
+  display: flex;
+  flex-direction: column;
+  gap: var(--app-space-3);
+}
+
+.supplier-preview-dialog__file-loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 400px;
+  color: var(--p-text-muted-color);
+}
+
+.supplier-preview-dialog__file-frame {
+  border: 1px solid var(--app-surface-border);
+  border-radius: var(--app-surface-radius-sm);
+  overflow: hidden;
+}
+
+.supplier-preview-dialog__iframe {
+  width: 100%;
+  height: 520px;
+  border: none;
+  display: block;
+}
+
+.supplier-preview-dialog__img {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+.history-dialog {
+  display: flex;
+  flex-direction: column;
+  gap: var(--app-space-4);
+}
+
+.history-dialog__intro {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--app-space-3);
+}
+
+.history-dialog__summary {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--app-space-3);
+  padding-bottom: var(--app-space-4);
+  border-bottom: 1px solid var(--app-surface-border);
+}
+
+.history-dialog__metric {
+  padding: var(--app-space-3);
+  border-radius: var(--app-surface-radius-sm);
+  background: color-mix(in srgb, var(--app-surface-bg) 85%, transparent 15%);
+}
+
+.history-dialog__label {
+  color: var(--p-text-muted-color);
+  font-size: 0.82rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.history-dialog__value {
+  margin-top: var(--app-space-2);
+  font-size: 1.05rem;
+  font-weight: 800;
+}
+
+.history-dialog__value--success {
+  color: var(--p-green-600);
+}
+
+.history-dialog__value--warn {
+  color: var(--p-orange-500);
+}
+
+@media (max-width: 900px) {
+  .supplier-preview-dialog__body {
+    grid-template-columns: 1fr;
+  }
 }
 </style>

--- a/frontend/src/views/SupplierInvoicesView.vue
+++ b/frontend/src/views/SupplierInvoicesView.vue
@@ -261,16 +261,39 @@
       @show="focusFormInput"
       :header="editingInvoice ? `${t('invoices.edit')} — ${editingInvoice.number}` : t('invoices.new')"
       modal
-      class="app-dialog app-dialog--medium"
+      :class="['app-dialog', editingInvoice?.file_path ? 'app-dialog--large' : 'app-dialog--medium']"
     >
-      <div ref="formWrapperEl">
-        <SupplierInvoiceForm
-          ref="supplierFormRef"
-          :invoice="editingInvoice"
-          :contacts="contacts"
-          @saved="onSaved"
-          @cancel="onCloseDialog(false)"
-        />
+      <div ref="formWrapperEl" :class="editingInvoice?.file_path ? 'supplier-edit-dialog__layout' : ''">
+        <div>
+          <SupplierInvoiceForm
+            ref="supplierFormRef"
+            :invoice="editingInvoice"
+            :contacts="contacts"
+            @saved="onSaved"
+            @cancel="onCloseDialog(false)"
+          />
+        </div>
+        <div v-if="editingInvoice?.file_path" class="supplier-edit-dialog__preview">
+          <h3 class="app-dialog-section__title">{{ t('invoices.file') }}</h3>
+          <div v-if="editFileLoading" class="supplier-preview-dialog__file-loading">
+            <i class="pi pi-spin pi-spinner" style="font-size: 2rem" />
+          </div>
+          <div v-else-if="editFileBlobUrl" class="supplier-preview-dialog__file-frame">
+            <embed
+              v-if="editFileIsPdf"
+              :src="editFileBlobUrl"
+              type="application/pdf"
+              class="supplier-preview-dialog__embed"
+            />
+            <img
+              v-else
+              :src="editFileBlobUrl"
+              class="supplier-preview-dialog__img"
+              :alt="t('invoices.supplier.preview_file')"
+            />
+          </div>
+          <div v-else class="app-empty-state">{{ t('common.error.unknown') }}</div>
+        </div>
       </div>
     </Dialog>
 
@@ -420,11 +443,11 @@
               <i class="pi pi-spin pi-spinner" style="font-size: 2rem" />
             </div>
             <div v-else-if="previewBlobUrl" class="supplier-preview-dialog__file-frame">
-              <iframe
+              <embed
                 v-if="previewIsPdf"
                 :src="previewBlobUrl"
-                class="supplier-preview-dialog__iframe"
-                :title="t('invoices.supplier.preview_file')"
+                type="application/pdf"
+                class="supplier-preview-dialog__embed"
               />
               <img
                 v-else
@@ -526,6 +549,17 @@ const uploadTargetId = ref<number | null>(null)
 const selectedFile = ref<File | null>(null)
 const uploading = ref(false)
 const statusFilter = ref<InvoiceStatus | null>(null)
+
+const editFileBlobUrl = ref<string | null>(null)
+const editFileIsPdf = ref(false)
+const editFileLoading = ref(false)
+
+watch(dialogVisible, (val) => {
+  if (!val && editFileBlobUrl.value) {
+    URL.revokeObjectURL(editFileBlobUrl.value)
+    editFileBlobUrl.value = null
+  }
+})
 
 // Preview dialog
 const previewVisible = ref(false)
@@ -673,7 +707,18 @@ function openCreateDialog() {
 
 function openEditDialog(invoice: Invoice) {
   editingInvoice.value = invoice
+  editFileBlobUrl.value = null
+  editFileLoading.value = !!invoice.file_path
   dialogVisible.value = true
+  if (invoice.file_path) {
+    downloadInvoiceFileApi(invoice.id)
+      .then((blob) => {
+        editFileIsPdf.value = blob.type === 'application/pdf'
+        editFileBlobUrl.value = URL.createObjectURL(blob)
+      })
+      .catch(() => {})
+      .finally(() => { editFileLoading.value = false })
+  }
 }
 
 function onSaved() {
@@ -833,6 +878,26 @@ onMounted(async () => {
   min-width: 12rem;
 }
 
+.supplier-edit-dialog__layout {
+  display: grid;
+  grid-template-columns: 1fr 1.2fr;
+  gap: var(--app-space-5);
+  align-items: start;
+}
+
+.supplier-edit-dialog__preview {
+  display: flex;
+  flex-direction: column;
+  gap: var(--app-space-3);
+  padding-top: var(--app-space-1);
+}
+
+@media (max-width: 900px) {
+  .supplier-edit-dialog__layout {
+    grid-template-columns: 1fr;
+  }
+}
+
 .upload-dialog {
   display: flex;
   flex-direction: column;
@@ -878,7 +943,7 @@ onMounted(async () => {
   overflow: hidden;
 }
 
-.supplier-preview-dialog__iframe {
+.supplier-preview-dialog__embed {
   width: 100%;
   height: 520px;
   border: none;

--- a/frontend/src/views/SupplierInvoicesView.vue
+++ b/frontend/src/views/SupplierInvoicesView.vue
@@ -264,7 +264,7 @@
       :class="['app-dialog', editingInvoice?.file_path ? 'app-dialog--large' : 'app-dialog--medium']"
     >
       <div ref="formWrapperEl" :class="editingInvoice?.file_path ? 'supplier-edit-dialog__layout' : ''">
-        <div>
+        <div class="supplier-edit-dialog__form-col">
           <SupplierInvoiceForm
             ref="supplierFormRef"
             :invoice="editingInvoice"
@@ -878,21 +878,44 @@ onMounted(async () => {
   min-width: 12rem;
 }
 
+.supplier-edit-dialog__form-col {
+  min-width: 0;
+  overflow: hidden;
+}
+
+:deep(.supplier-edit-dialog__form-col .app-dialog-section),
+:deep(.supplier-edit-dialog__form-col .app-dialog-form) {
+  min-width: 0;
+}
+
+:deep(.supplier-edit-dialog__form-col .p-inputtext),
+:deep(.supplier-edit-dialog__form-col .p-select),
+:deep(.supplier-edit-dialog__form-col .p-inputnumber),
+:deep(.supplier-edit-dialog__form-col .p-inputnumber-input) {
+  max-width: 100%;
+  width: 100%;
+  box-sizing: border-box;
+}
+
 .supplier-edit-dialog__layout {
   display: grid;
-  grid-template-columns: 1fr 1.2fr;
+  grid-template-columns: minmax(0, 1fr) 420px;
   gap: var(--app-space-5);
   align-items: start;
+  min-width: 0;
 }
 
 .supplier-edit-dialog__preview {
   display: flex;
   flex-direction: column;
   gap: var(--app-space-3);
-  padding-top: var(--app-space-1);
+  min-width: 0;
+  overflow: hidden;
+  position: sticky;
+  top: 0;
 }
 
-@media (max-width: 900px) {
+@media (max-width: 1000px) {
   .supplier-edit-dialog__layout {
     grid-template-columns: 1fr;
   }

--- a/frontend/src/views/SupplierInvoicesView.vue
+++ b/frontend/src/views/SupplierInvoicesView.vue
@@ -343,6 +343,27 @@
       class="app-dialog app-dialog--large"
       @hide="onPreviewHide"
     >
+      <div class="preview-nav-bar">
+        <Button
+          icon="pi pi-chevron-left"
+          text
+          rounded
+          size="small"
+          :disabled="previewIndex <= 0"
+          :title="t('common.previous')"
+          @click="goToPrevPreview"
+        />
+        <span class="preview-nav-bar__counter">{{ previewIndex + 1 }} / {{ displayedInvoices.length }}</span>
+        <Button
+          icon="pi pi-chevron-right"
+          text
+          rounded
+          size="small"
+          :disabled="previewIndex >= displayedInvoices.length - 1"
+          :title="t('common.next')"
+          @click="goToNextPreview"
+        />
+      </div>
       <div v-if="previewInvoice" class="supplier-preview-dialog">
 
         <!-- Header info + actions -->
@@ -576,6 +597,8 @@ const previewRemaining = computed(() => {
   return parseFloat(previewInvoice.value.total_amount) - parseFloat(previewInvoice.value.paid_amount)
 })
 
+const previewIndex = ref(-1)
+
 const invoiceRows = computed(() =>
   invoices.value.map((invoice) => ({
     ...invoice,
@@ -733,6 +756,7 @@ function openUploadDialog(invoice: Invoice) {
 }
 
 async function openPreviewDialog(invoice: Invoice) {
+  previewIndex.value = displayedInvoices.value.findIndex((r) => r.id === invoice.id)
   previewInvoice.value = invoice
   previewBlobUrl.value = null
   previewPayments.value = []
@@ -795,6 +819,20 @@ function openUploadFromPreview() {
   const inv = previewInvoice.value
   previewVisible.value = false
   nextTick(() => openUploadDialog(inv))
+}
+
+async function goToPrevPreview(): Promise<void> {
+  const idx = previewIndex.value - 1
+  if (idx < 0) return
+  previewIndex.value = idx
+  await openPreviewDialog(displayedInvoices.value[idx] as Invoice)
+}
+
+async function goToNextPreview(): Promise<void> {
+  const idx = previewIndex.value + 1
+  if (idx >= displayedInvoices.value.length) return
+  previewIndex.value = idx
+  await openPreviewDialog(displayedInvoices.value[idx] as Invoice)
 }
 
 function onFileSelect(event: { files: File[] }) {
@@ -925,6 +963,23 @@ onMounted(async () => {
   display: flex;
   flex-direction: column;
   gap: var(--app-space-4);
+}
+
+.preview-nav-bar {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--app-space-1);
+  padding-bottom: var(--app-space-3);
+  border-bottom: 1px solid var(--app-surface-border);
+  margin-bottom: var(--app-space-4);
+}
+
+.preview-nav-bar__counter {
+  font-size: 0.85rem;
+  color: var(--p-text-muted-color);
+  min-width: 3.5rem;
+  text-align: center;
 }
 
 .supplier-preview-dialog {

--- a/scripts/attach_supplier_invoices.py
+++ b/scripts/attach_supplier_invoices.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""One-shot script: bulk-attach existing supplier invoice files to their DB records.
+
+Scans data/factures_fournisseur/ recursively, matches each file by its stem
+(= invoice number) against the invoices table, and copies matched files to
+data/uploads/invoices/ while updating invoice.file_path.
+
+Usage (from repo root):
+    python scripts/attach_supplier_invoices.py [--db data/solde.db] [--commit]
+
+Default mode is dry-run (no DB writes, no file copies).  Pass --commit to apply.
+
+Rules:
+  - Files are processed in descending order by filename (most recent first).
+  - The 2 most recent files are skipped (already attached).
+  - .docx files are skipped with a warning (unsupported type).
+  - If an invoice is not found in the DB: warning only, no error.
+  - If invoice.file_path is already set: skipped silently.
+  - Supported extensions: .pdf, .jpg, .jpeg, .png, .webp
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import sqlite3
+import uuid
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SOURCE_DIR = REPO_ROOT / "data" / "factures_fournisseur"
+UPLOAD_DIR = REPO_ROOT / "data" / "uploads" / "invoices"
+DEFAULT_DB = REPO_ROOT / "data" / "solde.db"
+
+# Number of most-recent files (by sorted name desc) to skip -- already attached.
+SKIP_MOST_RECENT = 2
+
+SUPPORTED_EXTENSIONS = {".pdf", ".jpg", ".jpeg", ".png", ".webp"}
+UNSUPPORTED_EXTENSIONS = {".docx", ".doc", ".odt"}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def collect_files(source_dir: Path) -> list[Path]:
+    """Return all files under source_dir recursively, sorted descending by stem."""
+    files = [
+        p
+        for p in source_dir.rglob("*")
+        if p.is_file() and p.suffix.lower() in SUPPORTED_EXTENSIONS | UNSUPPORTED_EXTENSIONS
+    ]
+    return sorted(files, key=lambda p: p.stem, reverse=True)
+
+
+def attach(db_path: Path, files: list[Path], commit: bool) -> None:
+    con = sqlite3.connect(db_path)
+    con.row_factory = sqlite3.Row
+
+    stats = {"attached": 0, "skipped_already": 0, "skipped_unsupported": 0, "not_found": 0}
+
+    for path in files:
+        stem = path.stem
+        ext = path.suffix.lower()
+
+        if ext in UNSUPPORTED_EXTENSIONS:
+            print(f"  [SKIP-TYPE]  {path.relative_to(REPO_ROOT)}  -- extension {ext!r} non supportee")
+            stats["skipped_unsupported"] += 1
+            continue
+
+        row = con.execute(
+            "SELECT id, file_path FROM invoices WHERE number = ? AND type = 'fournisseur'",
+            (stem,),
+        ).fetchone()
+
+        if row is None:
+            print(f"  [NOT FOUND]  {stem}  -- aucune facture fournisseur trouvee en base")
+            stats["not_found"] += 1
+            continue
+
+        invoice_id: int = row["id"]
+        existing_path: str | None = row["file_path"]
+
+        if existing_path:
+            stats["skipped_already"] += 1
+            continue  # already attached, silent skip
+
+        safe_name = f"{uuid.uuid4().hex}{ext}"
+        dest = UPLOAD_DIR / safe_name
+
+        if commit:
+            UPLOAD_DIR.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(path, dest)
+            # Store the path as seen from inside the Docker container (/app is the workdir).
+            docker_path = f"/app/data/uploads/invoices/{safe_name}"
+            con.execute(
+                "UPDATE invoices SET file_path = ? WHERE id = ?",
+                (docker_path, invoice_id),
+            )
+            con.commit()
+            print(f"  [ATTACHED]   {stem}  ->  {dest.relative_to(REPO_ROOT)}")
+        else:
+            print(f"  [DRY-RUN]    {stem}  ->  {safe_name}  (id={invoice_id})")
+
+        stats["attached"] += 1
+
+    con.close()
+
+    print()
+    print("=" * 60)
+    print(f"  Attachees       : {stats['attached']}")
+    print(f"  Deja liees      : {stats['skipped_already']}")
+    print(f"  Non trouvees DB : {stats['not_found']}")
+    print(f"  Type ignore     : {stats['skipped_unsupported']}")
+    if not commit:
+        print()
+        print("  *** Mode dry-run -- relancer avec --commit pour appliquer ***")
+    print("=" * 60)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Bulk-attach supplier invoice files.")
+    parser.add_argument(
+        "--db",
+        default=str(DEFAULT_DB),
+        help="Path to solde.db (default: data/solde.db)",
+    )
+    parser.add_argument(
+        "--commit",
+        action="store_true",
+        help="Actually copy files and update the database (default: dry-run)",
+    )
+    args = parser.parse_args()
+
+    db_path = Path(args.db)
+    if not db_path.is_file():
+        print(f"ERROR: database not found: {db_path}", flush=True)
+        raise SystemExit(1)
+
+    if not SOURCE_DIR.is_dir():
+        print(f"ERROR: source directory not found: {SOURCE_DIR}", flush=True)
+        raise SystemExit(1)
+
+    all_files = collect_files(SOURCE_DIR)
+    print(f"Fichiers trouves : {len(all_files)}  (skip des {SKIP_MOST_RECENT} plus recents)")
+    files_to_process = all_files[SKIP_MOST_RECENT:]
+    print(f"Fichiers a traiter : {len(files_to_process)}")
+    print(f"Mode : {'COMMIT' if args.commit else 'DRY-RUN'}")
+    print()
+
+    attach(db_path, files_to_process, commit=args.commit)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Fixes BIZ-139: manually created supplier invoices were assigned `draft` status (copied from the client workflow), making them invisible in the bank reconciliation dialog which only lists `sent`, `partial`, and `overdue` invoices.

## Root cause

`create_invoice()` in `backend/services/invoice.py` always assigned `InvoiceStatus.DRAFT` regardless of the invoice type. This made sense for client invoices (you draft them before sending), but not for supplier invoices (you receive them — they are already validated at entry time).

## Changes

- **`backend/services/invoice.py`**: `create_invoice()` now assigns `InvoiceStatus.SENT` for `FOURNISSEUR` invoices and `InvoiceStatus.DRAFT` for `CLIENT` invoices.
- **`CHANGELOG.md`**: entry added under `[Non publié] / Corrigé`.
- **`doc/backlog.md`**: ticket BIZ-139 added and closed.

## Data migration

The 2 supplier invoices already encoded manually in production (`FF-2026050208.29.41`, `FF-2026050208.31.20`) were updated directly in the database from `draft` → `sent`.

## Testing

- 1008 backend tests passing (no new failures)
- 131 frontend tests passing
- ruff, mypy, vue-tsc, eslint: all clean

## Summary by Sourcery

Set newly created supplier invoices to start in sent status instead of draft so they appear correctly in workflows and reconciliation, and document the fix.

Bug Fixes:
- Ensure manually created supplier invoices default to sent status instead of draft, restoring their visibility in bank reconciliation.

Documentation:
- Document BIZ-139 in the backlog with details of the supplier invoice status issue and its resolution.
- Add a changelog entry describing the correction to the initial status of manually created supplier invoices.