### PR TITLE
feat(payment): supplier cash payments + recording dialog (BIZ-155, BIZ-156)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Ce projet respecte le [Versionnage sémantique](https://semver.org/lang/fr/).
 
 ## [Non publié]
 
+### Corrigé
+
+- **BIZ-155** — Paiement fournisseur en espèces : crée désormais automatiquement une sortie caisse (`CashMovementType.OUT`) au lieu de ne rien faire.
+
 ---
 
 ## [1.2.1] — 2026-05-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Ce projet respecte le [Versionnage sémantique](https://semver.org/lang/fr/).
 
 - **BIZ-155** — Paiement fournisseur en espèces : crée désormais automatiquement une sortie caisse (`CashMovementType.OUT`) au lieu de ne rien faire.
 
+### Ajouté
+
+- **BIZ-156** — Factures fournisseur : bouton « Enregistrer un règlement » dans la liste et dans le dialog de prévisualisation (espèces et chèque).
+
 ---
 
 ## [1.2.1] — 2026-05-02

--- a/backend/services/payment.py
+++ b/backend/services/payment.py
@@ -308,20 +308,32 @@ async def _create_treasury_entries_for_payment(
     payment: Payment,
     invoice: Invoice,
 ) -> None:
-    """Mirror client payment receipts into the operational treasury journals."""
-    if invoice.type != InvoiceType.CLIENT:
+    """Mirror payment receipts/outlays into the operational treasury journals."""
+    if payment.method != PaymentMethod.ESPECES:
         return
+
+    from backend.services.cash_service import create_cash_entry_record  # noqa: PLC0415
 
     description = f"Reglement facture {invoice.number}"
 
-    if payment.method == PaymentMethod.ESPECES:
-        from backend.services.cash_service import create_cash_entry_record  # noqa: PLC0415
-
+    if invoice.type == InvoiceType.CLIENT:
         await create_cash_entry_record(
             db,
             date=payment.date,
             amount=payment.amount,
             type=CashMovementType.IN,
+            contact_id=payment.contact_id,
+            payment_id=payment.id,
+            reference=payment.reference,
+            description=description,
+            source=CashEntrySource.PAYMENT,
+        )
+    elif invoice.type == InvoiceType.FOURNISSEUR:
+        await create_cash_entry_record(
+            db,
+            date=payment.date,
+            amount=payment.amount,
+            type=CashMovementType.OUT,
             contact_id=payment.contact_id,
             payment_id=payment.id,
             reference=payment.reference,

--- a/doc/backlog.md
+++ b/doc/backlog.md
@@ -34,6 +34,7 @@ Quand un sujet est livré, mettre à jour `CHANGELOG.md` et passer le ticket en 
 | TEC-146 | Bug : aperçu PDF Chrome (download au lieu de preview) | P2 | ~30 min | 2026-05-02 | 2026-05-02 |
 | BIZ-148 | Recalcul immédiat dans les lignes facture | P2 | ~20 min | 2026-05-02 | — |
 | BIZ-149 | Auto-capitalisation des intitulés facture | P2 | ~15 min | 2026-05-02 | — |
+| BIZ-155 | Paiement fournisseur espèces : sortie caisse automatique | P2 | ~30 min | 2026-05-02 | 2026-05-02 |
 | BIZ-150 | Heures décimales : accepter « . » et « , » | P2 | ~15 min | 2026-05-02 | — |
 | TEC-143 | Références OFX (FITID) : ne jamais afficher dans l'UI | P2 | ~15 min | 2026-05-02 | 2026-05-02 |
 | TEC-142 | Script one-shot : dépôts bancaires 14/04/2026 non encodés | P2 | ~30 min | 2026-05-02 | 2026-05-02 |
@@ -88,6 +89,14 @@ Quand un sujet est livré, mettre à jour `CHANGELOG.md` et passer le ticket en 
 - Ajouter jusqu'à 3 emails avec label libre (ex. « Email principal », « Email comptabilité »).
 - Lors de l'envoi d'une facture par mail, proposer le choix de l'adresse (ou des adresses) à utiliser ; toutes cochées par défaut.
 - Nécessite : migration Alembic, nouveau modèle `ContactEmail`, endpoints CRUD, mise à jour du formulaire contact et du dialog d'envoi.
+
+### BIZ-155 — Paiement fournisseur espèces : sortie caisse automatique
+
+- Lors de l'enregistrement d'un paiement en espèces lié à une facture **fournisseur**, aucun mouvement de caisse n'est créé automatiquement.
+- Côté client (recette), la sortie caisse est générée automatiquement par `_create_treasury_entries_for_payment` dans `backend/services/payment.py`. Pour les fournisseurs, la fonction retourne sans rien faire (`invoice.type != CLIENT`).
+- **Comportement attendu** : un paiement fournisseur en espèces doit créer automatiquement une **sortie caisse** (montant négatif, `CashMovementType.OUT`) avec la même date, le même contact et la référence à la facture.
+- **Périmètre** : `backend/services/payment.py` (`_create_treasury_entries_for_payment`) + tests.
+- **Impact UX** : évite la double saisie manuelle (créer le paiement puis créer la sortie caisse séparément).
 
 ### BIZ-148 — Recalcul immédiat dans les lignes facture
 

--- a/doc/backlog.md
+++ b/doc/backlog.md
@@ -34,8 +34,7 @@ Quand un sujet est livré, mettre à jour `CHANGELOG.md` et passer le ticket en 
 | TEC-146 | Bug : aperçu PDF Chrome (download au lieu de preview) | P2 | ~30 min | 2026-05-02 | 2026-05-02 |
 | BIZ-148 | Recalcul immédiat dans les lignes facture | P2 | ~20 min | 2026-05-02 | — |
 | BIZ-149 | Auto-capitalisation des intitulés facture | P2 | ~15 min | 2026-05-02 | — |
-| BIZ-155 | Paiement fournisseur espèces : sortie caisse automatique | P2 | ~30 min | 2026-05-02 | 2026-05-02 |
-| BIZ-156 | Factures fournisseur : bouton « Enregistrer un règlement » | P2 | ~45 min | 2026-05-02 | 2026-05-02 |
+| BIZ-155 | Paiement fournisseur espèces : sortie caisse automatique | P2 | ~30 min | 2026-05-02 | 2026-05-02 || BIZ-156 | Factures fournisseur : bouton « Enregistrer un règlement » | P2 | ~45 min | 2026-05-02 | 2026-05-02 |
 | BIZ-150 | Heures décimales : accepter « . » et « , » | P2 | ~15 min | 2026-05-02 | — |
 | TEC-143 | Références OFX (FITID) : ne jamais afficher dans l'UI | P2 | ~15 min | 2026-05-02 | 2026-05-02 |
 | TEC-142 | Script one-shot : dépôts bancaires 14/04/2026 non encodés | P2 | ~30 min | 2026-05-02 | 2026-05-02 |
@@ -91,11 +90,11 @@ Quand un sujet est livré, mettre à jour `CHANGELOG.md` et passer le ticket en 
 - Lors de l'envoi d'une facture par mail, proposer le choix de l'adresse (ou des adresses) à utiliser ; toutes cochées par défaut.
 - Nécessite : migration Alembic, nouveau modèle `ContactEmail`, endpoints CRUD, mise à jour du formulaire contact et du dialog d'envoi.
 
-### BIZ-155 — Paiement fournisseur espèces : sortie caisse automatique
+### BIZ-155 — Paiement fournisseur en espèces : sortie caisse automatique
 
 - Lors de l'enregistrement d'un paiement en espèces lié à une facture **fournisseur**, aucun mouvement de caisse n'est créé automatiquement.
-- Côté client (recette), la sortie caisse est générée automatiquement par `_create_treasury_entries_for_payment` dans `backend/services/payment.py`. Pour les fournisseurs, la fonction retourne sans rien faire (`invoice.type != CLIENT`).
-- **Comportement attendu** : un paiement fournisseur en espèces doit créer automatiquement une **sortie caisse** (montant négatif, `CashMovementType.OUT`) avec la même date, le même contact et la référence à la facture.
+- Côté client (recette), l'entrée caisse est générée automatiquement par `_create_treasury_entries_for_payment` dans `backend/services/payment.py`. Pour les fournisseurs, la fonction retournait sans rien faire (`invoice.type != CLIENT`).
+- **Comportement attendu** : un paiement fournisseur en espèces doit créer automatiquement une **sortie caisse** (`CashMovementType.OUT`, montant positif — la direction est portée par le type) avec la même date, le même contact et la référence à la facture.
 - **Périmètre** : `backend/services/payment.py` (`_create_treasury_entries_for_payment`) + tests.
 - **Impact UX** : évite la double saisie manuelle (créer le paiement puis créer la sortie caisse séparément).
 

--- a/doc/backlog.md
+++ b/doc/backlog.md
@@ -35,6 +35,7 @@ Quand un sujet est livré, mettre à jour `CHANGELOG.md` et passer le ticket en 
 | BIZ-148 | Recalcul immédiat dans les lignes facture | P2 | ~20 min | 2026-05-02 | — |
 | BIZ-149 | Auto-capitalisation des intitulés facture | P2 | ~15 min | 2026-05-02 | — |
 | BIZ-155 | Paiement fournisseur espèces : sortie caisse automatique | P2 | ~30 min | 2026-05-02 | 2026-05-02 |
+| BIZ-156 | Factures fournisseur : bouton « Enregistrer un règlement » | P2 | ~45 min | 2026-05-02 | 2026-05-02 |
 | BIZ-150 | Heures décimales : accepter « . » et « , » | P2 | ~15 min | 2026-05-02 | — |
 | TEC-143 | Références OFX (FITID) : ne jamais afficher dans l'UI | P2 | ~15 min | 2026-05-02 | 2026-05-02 |
 | TEC-142 | Script one-shot : dépôts bancaires 14/04/2026 non encodés | P2 | ~30 min | 2026-05-02 | 2026-05-02 |

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/frontend/src/tests/views/SupplierInvoicesView.spec.ts
+++ b/frontend/src/tests/views/SupplierInvoicesView.spec.ts
@@ -1,0 +1,432 @@
+import { mount } from '@vue/test-utils'
+import { defineComponent, h, inject, nextTick, provide, reactive } from 'vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+const toastAdd = vi.fn()
+
+vi.mock('primevue/usetoast', () => ({
+  useToast: () => ({
+    add: toastAdd,
+  }),
+}))
+
+vi.mock('primevue/useconfirm', () => ({
+  useConfirm: () => ({
+    require: vi.fn(),
+  }),
+}))
+
+const fiscalYearStoreMock = reactive({
+  selectedFiscalYearId: 2 as number | undefined,
+  selectedFiscalYear: {
+    id: 2,
+    name: 'Exercice 2025',
+    start_date: '2025-01-01',
+    end_date: '2025-12-31',
+  } as { id: number; name: string; start_date: string; end_date: string } | undefined,
+  initialized: true,
+  initialize: vi.fn().mockResolvedValue(undefined),
+})
+
+vi.mock('../../stores/fiscalYear', () => ({
+  useFiscalYearStore: () => fiscalYearStoreMock,
+}))
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ query: {} }),
+  useRouter: () => ({ replace: vi.fn() }),
+}))
+
+vi.mock('../../api/contacts', () => ({
+  listContactsApi: vi.fn(),
+}))
+
+vi.mock('../../api/invoices', () => ({
+  listInvoicesApi: vi.fn(),
+  deleteInvoiceApi: vi.fn(),
+  downloadInvoiceFileApi: vi.fn(() =>
+    Promise.resolve(new Blob(['%PDF'], { type: 'application/pdf' })),
+  ),
+  uploadInvoiceFileApi: vi.fn(),
+}))
+
+vi.mock('../../api/payments', () => ({
+  listPayments: vi.fn(),
+  createPayment: vi.fn(),
+}))
+
+import SupplierInvoicesView from '../../views/SupplierInvoicesView.vue'
+import { listContactsApi } from '../../api/contacts'
+import { listInvoicesApi } from '../../api/invoices'
+import { createPayment, listPayments } from '../../api/payments'
+
+const mockListContactsApi = vi.mocked(listContactsApi)
+const mockListInvoicesApi = vi.mocked(listInvoicesApi)
+const mockListPayments = vi.mocked(listPayments)
+const mockCreatePayment = vi.mocked(createPayment)
+
+const invoiceFixture = {
+  id: 1,
+  number: 'FF-2025-001',
+  type: 'fournisseur' as const,
+  contact_id: 10,
+  date: '2025-02-10',
+  due_date: '2025-03-10',
+  label: null,
+  description: 'Fournitures',
+  reference: 'REF-001',
+  total_amount: '200.00',
+  paid_amount: '50.00',
+  status: 'partial' as const,
+  pdf_path: null,
+  file_path: null,
+  created_at: '2025-02-10T00:00:00',
+  updated_at: '2025-02-10T00:00:00',
+  lines: [],
+}
+
+const paidInvoiceFixture = {
+  ...invoiceFixture,
+  id: 2,
+  number: 'FF-2025-002',
+  total_amount: '100.00',
+  paid_amount: '100.00',
+  status: 'paid' as const,
+}
+
+const draftInvoiceFixture = {
+  ...invoiceFixture,
+  id: 3,
+  number: 'FF-2025-003',
+  total_amount: '80.00',
+  paid_amount: '0.00',
+  status: 'draft' as const,
+}
+
+// ---------------------------------------------------------------------------
+// Stubs
+// ---------------------------------------------------------------------------
+
+const ContainerStub = defineComponent({
+  template: '<div><slot /><slot name="actions" /></div>',
+})
+
+const AppStatCardStub = defineComponent({
+  props: {
+    label: { type: String, default: '' },
+    value: { type: [String, Number], default: '' },
+    caption: { type: String, default: '' },
+  },
+  template: '<div>{{ label }} {{ value }}</div>',
+})
+
+const ButtonStub = defineComponent({
+  props: {
+    label: { type: String, default: '' },
+    disabled: { type: Boolean, default: false },
+    loading: { type: Boolean, default: false },
+    icon: { type: String, default: '' },
+    title: { type: String, default: '' },
+  },
+  emits: ['click'],
+  setup(props, { emit, slots }) {
+    return () =>
+      h(
+        'button',
+        {
+          disabled: props.disabled || props.loading,
+          title: props.title,
+          onClick: () => emit('click'),
+        },
+        slots.default ? slots.default() : props.label || props.icon,
+      )
+  },
+})
+
+const InputTextStub = defineComponent({
+  props: { modelValue: { type: String, default: '' } },
+  emits: ['update:modelValue'],
+  setup(props, { emit }) {
+    return () =>
+      h('input', {
+        value: props.modelValue,
+        onInput: (e: Event) => emit('update:modelValue', (e.target as HTMLInputElement).value),
+      })
+  },
+})
+
+const TextareaStub = defineComponent({
+  props: { modelValue: { type: String, default: '' } },
+  emits: ['update:modelValue'],
+  setup(props, { emit }) {
+    return () =>
+      h('textarea', {
+        value: props.modelValue,
+        onInput: (e: Event) => emit('update:modelValue', (e.target as HTMLTextAreaElement).value),
+      })
+  },
+})
+
+const InputNumberStub = defineComponent({
+  props: { modelValue: { type: [String, Number], default: 0 } },
+  emits: ['update:modelValue'],
+  setup(props, { emit }) {
+    return () =>
+      h('input', {
+        type: 'number',
+        value: props.modelValue,
+        onInput: (e: Event) =>
+          emit('update:modelValue', Number((e.target as HTMLInputElement).value)),
+      })
+  },
+})
+
+const DatePickerStub = defineComponent({
+  props: { modelValue: { type: [String, Date], default: '' } },
+  emits: ['update:modelValue'],
+  setup(props, { emit }) {
+    return () =>
+      h('input', {
+        type: 'date',
+        value:
+          props.modelValue instanceof Date
+            ? props.modelValue.toISOString().slice(0, 10)
+            : props.modelValue,
+        onInput: (e: Event) => emit('update:modelValue', (e.target as HTMLInputElement).value),
+      })
+  },
+})
+
+const SelectStub = defineComponent({
+  props: {
+    modelValue: { type: [String, Number], default: undefined },
+    options: { type: Array, default: () => [] },
+    optionLabel: { type: String, default: 'label' },
+    optionValue: { type: String, default: 'value' },
+  },
+  emits: ['update:modelValue'],
+  setup(props, { emit }) {
+    return () =>
+      h(
+        'select',
+        {
+          value: props.modelValue ?? '',
+          onChange: (e: Event) =>
+            emit('update:modelValue', (e.target as HTMLSelectElement).value),
+        },
+        (props.options as Array<Record<string, string>>).map((opt) =>
+          h('option', { key: opt[props.optionValue], value: opt[props.optionValue] }, opt[props.optionLabel]),
+        ),
+      )
+  },
+})
+
+const DialogStub = defineComponent({
+  props: {
+    visible: { type: Boolean, default: false },
+    modelValue: { type: Boolean, default: false },
+    header: { type: String, default: '' },
+  },
+  template: '<div v-if="visible || modelValue"><h2>{{ header }}</h2><slot /></div>',
+})
+
+const TagStub = defineComponent({
+  props: { value: { type: String, default: '' } },
+  template: '<span>{{ value }}</span>',
+})
+
+const CurrentRowKey = Symbol('supplier-invoices-row')
+
+const DataTableRowStub = defineComponent({
+  props: { row: { type: Object, required: true } },
+  setup(props, { slots }) {
+    provide(CurrentRowKey, props.row)
+    return () => h('div', { class: 'data-row' }, slots.default ? slots.default() : [])
+  },
+})
+
+const DataTableStub = defineComponent({
+  props: { value: { type: Array, default: () => [] } },
+  components: { DataTableRowStub },
+  template:
+    '<div><slot /><DataTableRowStub v-for="row in value" :key="row.id" :row="row"><slot /></DataTableRowStub></div>',
+})
+
+const ColumnStub = defineComponent({
+  props: {
+    field: { type: String, default: '' },
+    header: { type: String, default: '' },
+  },
+  setup(props, { slots }) {
+    const row = inject<Record<string, unknown> | null>(CurrentRowKey, null)
+    return () =>
+      h('div', [
+        props.header ? h('div', props.header) : null,
+        row
+          ? slots.body
+            ? slots.body({ data: row })
+            : h('div', String(row[props.field] ?? ''))
+          : null,
+      ])
+  },
+})
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function flushView() {
+  await Promise.resolve()
+  await Promise.resolve()
+  await nextTick()
+}
+
+function mountView() {
+  return mount(SupplierInvoicesView, {
+    global: {
+      stubs: {
+        AppPage: ContainerStub,
+        AppPageHeader: ContainerStub,
+        AppPanel: ContainerStub,
+        AppStatCard: AppStatCardStub,
+        AppListState: ContainerStub,
+        AppDateRangeFilter: ContainerStub,
+        AppFilterMultiSelect: ContainerStub,
+        AppNumberRangeFilter: ContainerStub,
+        AppTableSkeleton: ContainerStub,
+        SupplierInvoiceForm: ContainerStub,
+        Button: ButtonStub,
+        Column: ColumnStub,
+        ConfirmDialog: ContainerStub,
+        DataTable: DataTableStub,
+        AppDatePicker: DatePickerStub,
+        Dialog: DialogStub,
+        FileUpload: ContainerStub,
+        InputNumber: InputNumberStub,
+        InputText: InputTextStub,
+        Select: SelectStub,
+        Tag: TagStub,
+        Textarea: TextareaStub,
+      },
+    },
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('SupplierInvoicesView — payment dialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockListContactsApi.mockResolvedValue([
+      { id: 10, type: 'fournisseur', nom: 'Martin', prenom: 'Bob', email: null, telephone: null },
+    ] as never)
+    mockListInvoicesApi.mockResolvedValue([invoiceFixture, paidInvoiceFixture, draftInvoiceFixture] as never)
+    mockListPayments.mockResolvedValue([])
+    mockCreatePayment.mockResolvedValue({
+      id: 5,
+      invoice_id: 1,
+      invoice_number: 'FF-2025-001',
+      invoice_type: 'fournisseur',
+      contact_id: 10,
+      amount: '150.00',
+      date: '2025-03-01',
+      method: 'especes',
+      cheque_number: null,
+      reference: null,
+      notes: null,
+      deposited: true,
+      in_deposit: false,
+      deposit_date: '2025-03-01',
+      created_at: '2025-03-01T00:00:00',
+    })
+  })
+
+  it('shows the payment button only for invoices with remaining balance and not draft', async () => {
+    const wrapper = mountView()
+    await flushView()
+
+    const paymentButtons = wrapper
+      .findAll('button')
+      .filter((btn) => btn.attributes('title') === 'invoices.record_payment')
+
+    // Only invoiceFixture (partial, remaining=150) should show the button
+    // paidInvoiceFixture (remaining=0) and draftInvoiceFixture (draft) must not
+    expect(paymentButtons).toHaveLength(1)
+  })
+
+  it('pre-fills amount with remaining balance when opening the dialog', async () => {
+    const wrapper = mountView()
+    await flushView()
+
+    const paymentButton = wrapper
+      .findAll('button')
+      .find((btn) => btn.attributes('title') === 'invoices.record_payment')
+    expect(paymentButton).toBeTruthy()
+
+    await paymentButton!.trigger('click')
+    await flushView()
+
+    const amountInput = wrapper.find('input[type="number"]')
+    // remaining = 200 - 50 = 150
+    expect(Number((amountInput.element as HTMLInputElement).value)).toBe(150)
+  })
+
+  it('records a cash payment and calls createPayment with correct payload', async () => {
+    const wrapper = mountView()
+    await flushView()
+
+    const paymentButton = wrapper
+      .findAll('button')
+      .find((btn) => btn.attributes('title') === 'invoices.record_payment')
+    await paymentButton!.trigger('click')
+    await flushView()
+
+    // Switch method to especes
+    const selects = wrapper.findAll('select')
+    const methodSelect = selects.at(-1)!
+    await methodSelect.setValue('especes')
+
+    const paymentForm = wrapper.findAll('form').at(-1)!
+    await paymentForm.trigger('submit')
+    await flushView()
+
+    expect(mockCreatePayment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        invoice_id: 1,
+        contact_id: 10,
+        amount: '150.00',
+        method: 'especes',
+        cheque_number: null,
+      }),
+    )
+  })
+
+  it('requires a cheque number when method is cheque', async () => {
+    const wrapper = mountView()
+    await flushView()
+
+    const paymentButton = wrapper
+      .findAll('button')
+      .find((btn) => btn.attributes('title') === 'invoices.record_payment')
+    await paymentButton!.trigger('click')
+    await flushView()
+
+    // method is 'cheque' by default, cheque_number is empty — submit should be blocked
+    const paymentForm = wrapper.findAll('form').at(-1)!
+    await paymentForm.trigger('submit')
+    await flushView()
+
+    expect(mockCreatePayment).not.toHaveBeenCalled()
+    expect(toastAdd).toHaveBeenCalledWith(
+      expect.objectContaining({ severity: 'warn' }),
+    )
+  })
+})

--- a/frontend/src/views/SupplierInvoicesView.vue
+++ b/frontend/src/views/SupplierInvoicesView.vue
@@ -237,6 +237,16 @@
                 @click="openUploadDialog(data)"
               />
               <Button
+                v-if="canRecordPayment(data)"
+                icon="pi pi-wallet"
+                size="small"
+                severity="secondary"
+                text
+                :title="t('invoices.record_payment')"
+                :aria-label="t('invoices.record_payment')"
+                @click="openPaymentDialog(data)"
+              />
+              <Button
                 v-if="data.status === 'draft'"
                 icon="pi pi-trash"
                 size="small"
@@ -403,6 +413,13 @@
               :label="t('invoices.upload_file')"
               @click="openUploadFromPreview"
             />
+            <Button
+              v-if="canRecordPayment(previewInvoice)"
+              icon="pi pi-wallet"
+              size="small"
+              :label="t('invoices.record_payment')"
+              @click="openPaymentDialog(previewInvoice!)"
+            />
           </div>
         </section>
 
@@ -486,6 +503,83 @@
       </div>
     </Dialog>
 
+    <!-- Payment dialog -->
+    <Dialog
+      v-model:visible="paymentDialogVisible"
+      :header="paymentInvoice ? t('invoices.record_payment') : ''"
+      modal
+      class="app-dialog app-dialog--medium"
+    >
+      <form class="app-dialog-form" @submit.prevent="submitPayment">
+        <section v-if="paymentInvoice" class="app-dialog-intro">
+          <p class="app-dialog-intro__eyebrow">{{ paymentInvoice.number }}</p>
+          <p class="app-dialog-intro__text">
+            {{ contactName(paymentInvoice.contact_id) }}
+          </p>
+          <p class="app-dialog-intro__text">
+            {{ t('invoices.total') }} : <strong>{{ paymentInvoice.total_amount }} €</strong>
+          </p>
+        </section>
+        <section class="app-dialog-section">
+          <div class="history-dialog__summary">
+            <div class="history-dialog__metric">
+              <div class="history-dialog__label">{{ t('invoices.remaining') }}</div>
+              <div class="history-dialog__value history-dialog__value--warn">
+                {{ paymentRemaining.toFixed(2) }} €
+              </div>
+            </div>
+          </div>
+          <div class="app-form-grid">
+            <div class="app-field">
+              <label class="app-field__label">{{ t('payments.date') }}</label>
+              <AppDatePicker v-model="paymentForm.date" />
+            </div>
+            <div class="app-field">
+              <label class="app-field__label">{{ t('payments.amount') }}</label>
+              <InputNumber
+                v-model="paymentForm.amount"
+                mode="decimal"
+                :min="0.01"
+                :min-fraction-digits="2"
+                :max-fraction-digits="2"
+              />
+            </div>
+            <div class="app-field">
+              <label class="app-field__label">{{ t('payments.method') }}</label>
+              <Select
+                v-model="paymentForm.method"
+                :options="paymentMethodOptions"
+                option-label="label"
+                option-value="value"
+              />
+            </div>
+            <div v-if="paymentForm.method === 'cheque'" class="app-field">
+              <label class="app-field__label">{{ t('payments.cheque_number') }}</label>
+              <InputText v-model="paymentForm.cheque_number" />
+            </div>
+            <div class="app-field">
+              <label class="app-field__label">{{ t('payments.reference') }}</label>
+              <InputText v-model="paymentForm.reference" />
+            </div>
+            <div class="app-field app-field--span-2">
+              <label class="app-field__label">{{ t('payments.notes') }}</label>
+              <Textarea v-model="paymentForm.notes" rows="3" />
+            </div>
+          </div>
+        </section>
+        <div class="app-form-actions">
+          <Button
+            :label="t('common.cancel')"
+            severity="secondary"
+            text
+            type="button"
+            @click="paymentDialogVisible = false"
+          />
+          <Button type="submit" :label="t('common.save')" :loading="paymentSaving" />
+        </div>
+      </form>
+    </Dialog>
+
     <ConfirmDialog />
   </AppPage>
 </template>
@@ -497,9 +591,11 @@ import ConfirmDialog from 'primevue/confirmdialog'
 import DataTable from 'primevue/datatable'
 import Dialog from 'primevue/dialog'
 import FileUpload from 'primevue/fileupload'
+import InputNumber from 'primevue/inputnumber'
 import InputText from 'primevue/inputtext'
 import Select from 'primevue/select'
 import Tag from 'primevue/tag'
+import Textarea from 'primevue/textarea'
 import { useConfirm } from 'primevue/useconfirm'
 import { useToast } from 'primevue/usetoast'
 import { computed, onMounted, nextTick, ref, watch } from 'vue'
@@ -515,6 +611,7 @@ import AppPanel from '../components/ui/AppPanel.vue'
 import AppStatCard from '../components/ui/AppStatCard.vue'
 import AppTableSkeleton from '../components/ui/AppTableSkeleton.vue'
 
+import AppDatePicker from '../components/ui/AppDatePicker.vue'
 import { listContactsApi, type Contact } from '../api/contacts'
 import {
   deleteInvoiceApi,
@@ -524,7 +621,7 @@ import {
   type Invoice,
   type InvoiceStatus,
 } from '../api/invoices'
-import { listPayments, type Payment } from '../api/payments'
+import { createPayment, listPayments, type Payment } from '../api/payments'
 import SupplierInvoiceForm from '../components/SupplierInvoiceForm.vue'
 import {
   dateRangeFilter,
@@ -666,6 +763,96 @@ const fileFilterOptions = [
   { label: t('common.yes'), value: true },
   { label: t('common.no'), value: false },
 ]
+
+const paymentMethodOptions = [
+  { label: t('payments.methods.especes'), value: 'especes' },
+  { label: t('payments.methods.cheque'), value: 'cheque' },
+]
+
+// Payment dialog state
+const paymentDialogVisible = ref(false)
+const paymentInvoice = ref<Invoice | null>(null)
+const paymentSaving = ref(false)
+const paymentForm = ref({
+  date: new Date() as Date,
+  amount: 0,
+  method: 'cheque' as 'especes' | 'cheque',
+  cheque_number: '',
+  reference: '',
+  notes: '',
+})
+
+const paymentRemaining = computed(() => {
+  if (!paymentInvoice.value) return 0
+  return parseFloat(paymentInvoice.value.total_amount) - parseFloat(paymentInvoice.value.paid_amount)
+})
+
+function canRecordPayment(invoice: Invoice | null): boolean {
+  if (!invoice) return false
+  const remaining = parseFloat(invoice.total_amount) - parseFloat(invoice.paid_amount)
+  return invoice.status !== 'draft' && remaining > 0
+}
+
+function openPaymentDialog(invoice: Invoice) {
+  paymentInvoice.value = invoice
+  paymentForm.value = {
+    date: new Date(),
+    amount: parseFloat(invoice.total_amount) - parseFloat(invoice.paid_amount),
+    method: 'cheque',
+    cheque_number: '',
+    reference: '',
+    notes: '',
+  }
+  paymentDialogVisible.value = true
+}
+
+async function submitPayment() {
+  if (!paymentInvoice.value) return
+
+  const amount = Number(paymentForm.value.amount)
+  if (!(amount > 0)) {
+    toast.add({ severity: 'warn', summary: t('payments.errors.amount_positive'), life: 3500 })
+    return
+  }
+  if (amount - paymentRemaining.value > 0.001) {
+    toast.add({ severity: 'warn', summary: t('payments.errors.amount_exceeds_remaining'), life: 3500 })
+    return
+  }
+  if (paymentForm.value.method === 'cheque' && paymentForm.value.cheque_number.trim().length === 0) {
+    toast.add({ severity: 'warn', summary: t('payments.errors.cheque_number_required'), life: 3500 })
+    return
+  }
+
+  paymentSaving.value = true
+  try {
+    const dateVal = paymentForm.value.date
+    const isoDate = typeof dateVal === 'string' ? dateVal : dateVal.toISOString().slice(0, 10)
+    await createPayment({
+      invoice_id: paymentInvoice.value.id,
+      contact_id: paymentInvoice.value.contact_id,
+      amount: amount.toFixed(2),
+      date: isoDate,
+      method: paymentForm.value.method,
+      cheque_number: paymentForm.value.method === 'cheque' ? paymentForm.value.cheque_number : null,
+      reference: paymentForm.value.reference || null,
+      notes: paymentForm.value.notes || null,
+    })
+    toast.add({ severity: 'success', summary: t('payments.created'), life: 3000 })
+    paymentDialogVisible.value = false
+    await loadInvoices()
+    // Refresh preview payments if preview is open for the same invoice
+    if (previewInvoice.value?.id === paymentInvoice.value.id) {
+      previewPayments.value = await listPayments({ invoice_id: paymentInvoice.value.id })
+      // Re-fetch invoice to update paid_amount / status
+      const updated = invoices.value.find((inv) => inv.id === paymentInvoice.value!.id)
+      if (updated) previewInvoice.value = updated
+    }
+  } catch {
+    toast.add({ severity: 'error', summary: t('common.error.unknown'), life: 4000 })
+  } finally {
+    paymentSaving.value = false
+  }
+}
 
 function formatAmount(val: string | number) {
   return parseFloat(String(val)).toFixed(2)

--- a/frontend/src/views/SupplierInvoicesView.vue
+++ b/frontend/src/views/SupplierInvoicesView.vue
@@ -833,9 +833,9 @@ async function submitPayment() {
       amount: amount.toFixed(2),
       date: isoDate,
       method: paymentForm.value.method,
-      cheque_number: paymentForm.value.method === 'cheque' ? paymentForm.value.cheque_number : null,
-      reference: paymentForm.value.reference || null,
-      notes: paymentForm.value.notes || null,
+      cheque_number: paymentForm.value.method === 'cheque' ? (paymentForm.value.cheque_number.trim() || null) : null,
+      reference: paymentForm.value.reference.trim() || null,
+      notes: paymentForm.value.notes.trim() || null,
     })
     toast.add({ severity: 'success', summary: t('payments.created'), life: 3000 })
     paymentDialogVisible.value = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "solde"
-version = "1.2.1"
+version = "1.2.2"
 description = "Web app for French non-profit accounting — invoicing, payments, cash management and double-entry bookkeeping."
 requires-python = ">=3.11"
 dependencies = [

--- a/tests/unit/test_payment_service.py
+++ b/tests/unit/test_payment_service.py
@@ -457,7 +457,7 @@ async def test_delete_payment_reverts_invoice(db_session: AsyncSession) -> None:
 @pytest.mark.asyncio
 async def test_create_supplier_cash_payment_creates_cash_out(db_session: AsyncSession) -> None:
     """Supplier cash payment creates a CashMovementType.OUT entry automatically."""
-    contact = Contact(type=ContactType.CLIENT, nom="Fournisseur", prenom="Test")
+    contact = Contact(type=ContactType.FOURNISSEUR, nom="Fournisseur", prenom="Test")
     db_session.add(contact)
     await db_session.flush()
 
@@ -497,7 +497,7 @@ async def test_create_supplier_cash_payment_creates_cash_out(db_session: AsyncSe
 @pytest.mark.asyncio
 async def test_create_supplier_cheque_payment_no_cash_entry(db_session: AsyncSession) -> None:
     """Supplier cheque payment must not create any cash entry."""
-    contact = Contact(type=ContactType.CLIENT, nom="Fournisseur", prenom="Test")
+    contact = Contact(type=ContactType.FOURNISSEUR, nom="Fournisseur", prenom="Test")
     db_session.add(contact)
     await db_session.flush()
 

--- a/tests/unit/test_payment_service.py
+++ b/tests/unit/test_payment_service.py
@@ -455,6 +455,80 @@ async def test_delete_payment_reverts_invoice(db_session: AsyncSession) -> None:
 
 
 @pytest.mark.asyncio
+async def test_create_supplier_cash_payment_creates_cash_out(db_session: AsyncSession) -> None:
+    """Supplier cash payment creates a CashMovementType.OUT entry automatically."""
+    contact = Contact(type=ContactType.CLIENT, nom="Fournisseur", prenom="Test")
+    db_session.add(contact)
+    await db_session.flush()
+
+    inv = Invoice(
+        number="FF-2024-001",
+        type=InvoiceType.FOURNISSEUR,
+        contact_id=contact.id,
+        date=date(2024, 3, 1),
+        total_amount=Decimal("75.00"),
+        paid_amount=Decimal("0"),
+        status=InvoiceStatus.SENT,
+    )
+    db_session.add(inv)
+    await db_session.flush()
+
+    await payment_service.create_payment(
+        db_session,
+        PaymentCreate(
+            invoice_id=inv.id,
+            contact_id=contact.id,
+            amount=Decimal("75.00"),
+            date=date(2024, 3, 15),
+            method=PaymentMethod.ESPECES,
+        ),
+    )
+
+    cash_entries = list(
+        (await db_session.execute(select(CashRegister).order_by(CashRegister.id.asc()))).scalars()
+    )
+    assert len(cash_entries) == 1
+    assert cash_entries[0].amount == Decimal("75.00")
+    assert cash_entries[0].type == CashMovementType.OUT
+    assert cash_entries[0].source == CashEntrySource.PAYMENT
+    assert cash_entries[0].contact_id == contact.id
+
+
+@pytest.mark.asyncio
+async def test_create_supplier_cheque_payment_no_cash_entry(db_session: AsyncSession) -> None:
+    """Supplier cheque payment must not create any cash entry."""
+    contact = Contact(type=ContactType.CLIENT, nom="Fournisseur", prenom="Test")
+    db_session.add(contact)
+    await db_session.flush()
+
+    inv = Invoice(
+        number="FF-2024-002",
+        type=InvoiceType.FOURNISSEUR,
+        contact_id=contact.id,
+        date=date(2024, 3, 1),
+        total_amount=Decimal("50.00"),
+        paid_amount=Decimal("0"),
+        status=InvoiceStatus.SENT,
+    )
+    db_session.add(inv)
+    await db_session.flush()
+
+    await payment_service.create_payment(
+        db_session,
+        PaymentCreate(
+            invoice_id=inv.id,
+            contact_id=contact.id,
+            amount=Decimal("50.00"),
+            date=date(2024, 3, 15),
+            method=PaymentMethod.CHEQUE,
+        ),
+    )
+
+    cash_entries = list((await db_session.execute(select(CashRegister))).scalars())
+    assert cash_entries == []
+
+
+@pytest.mark.asyncio
 async def test_disputed_invoice_not_updated(db_session: AsyncSession) -> None:
     """DISPUTED invoice status is not overwritten by a payment."""
     contact = await _make_contact(db_session)


### PR DESCRIPTION
## Summary

Two related improvements for supplier invoice payments:

### BIZ-155 — Auto cash outflow for supplier cash payments (backend)

When a supplier invoice is paid in cash (`ESPECES`), the payment service now automatically creates a cash outflow (`CashMovementType.OUT`) in the cash register — mirroring the existing behaviour for client cash receipts (`CashMovementType.IN`).

Before this fix, paying a supplier invoice in cash required a manual second step: creating a cash outflow entry separately.

### BIZ-156 — Payment recording dialog in supplier invoices view (frontend)

The supplier invoices view had no way to record a manual payment (cash or cheque). This adds:
- A `pi pi-wallet` button in the action column (visible when `remaining > 0` and not `draft`)
- The same button in the preview dialog action bar
- A payment dialog: date, amount (pre-filled with remaining), method (Espèces / Chèque), cheque number (conditional), reference, notes
- Client-side validation: positive amount, amount ≤ remaining, cheque number required

## Changes

- `backend/services/payment.py` — `_create_treasury_entries_for_payment` refactored: guard on `ESPECES` first, then branches on `CLIENT` (IN) or `FOURNISSEUR` (OUT)
- `tests/unit/test_payment_service.py` — 2 new tests
- `frontend/src/views/SupplierInvoicesView.vue` — payment button + dialog

## No breaking changes

## Summary by Sourcery

Add automatic cash register entries for supplier cash payments and introduce a UI flow to record payments on supplier invoices.

New Features:
- Allow recording manual payments (cash or cheque) from the supplier invoices list and preview via a dedicated dialog with validation.

Bug Fixes:
- Ensure supplier invoices paid in cash automatically create a corresponding cash outflow in the cash register instead of doing nothing.

Enhancements:
- Extend treasury mirroring logic to handle both client cash inflows and supplier cash outflows from a single payment handler.
- Refresh supplier invoice and payment preview data after creating a new payment to keep the UI in sync.

Build:
- Bump backend and frontend project versions to 1.2.2.

Documentation:
- Document delivered business tickets BIZ-155 and BIZ-156 and update the unreleased changelog accordingly.