### PR TITLE
feat(help): lot DOC — user changelog tab, anchor links, activity index (BIZ-161/162/163)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -111,37 +111,37 @@ This avoids non-fast-forward push rejections. If a push is rejected, always use 
 
 Keep the following documents up to date with every significant change:
 
-| Document | Langue | Emplacement | Déclencheur |
+| Document | Language | Location | Trigger |
 |---|---|---|---|
-| `README.md` | **FR + EN** | root | Chaque release |
-| Documentation utilisateur | **FR + EN** | `doc/user/` | Fonctionnalité ajoutée ou modifiée |
-| Documentation d'installation / how-to | **FR + EN** | `doc/user/` ou root | Installation, exploitation ou premiers pas modifiés |
-| Documentation développeur | **EN** | `doc/dev/` | Architecture ou API modifiée |
-| Documentation technique historique | **Migration vers EN** | `doc/` | À traduire progressivement jusqu'à alignement complet |
-| `CHANGELOG.md` | **FR** | root | Chaque PR mergée vers `develop` |
-| `doc/user/changelog-user.md` | **FR** | `doc/user/` | Chaque fonctionnalité ou correctif visible par l'utilisateur |
-| Notes de release | **FR** | `doc/releases/` | Chaque release |
-| `doc/backlog.md` | **FR** | `doc/` | Ticket créé, avancé ou complété |
-| `doc/roadmap.md` | **EN à terme** | `doc/` | Lot complété, planifié ou repriorisé |
-| `doc/plan.md` | **EN à terme** | `doc/` | Décisions d'architecture mises à jour |
+| `README.md` | **FR + EN** | root | Every release |
+| User documentation | **FR + EN** | `doc/user/` | Feature added or modified |
+| Installation / how-to guides | **FR + EN** | `doc/user/` or root | Installation, deployment, or getting-started steps changed |
+| Developer documentation | **EN** | `doc/dev/` | Architecture or API changed |
+| Legacy technical documentation | **Migrating to EN** | `doc/` | Translate progressively until fully aligned |
+| `CHANGELOG.md` | **FR** | root | Every PR merged into `develop` |
+| `doc/user/changelog-user.md` | **FR** | `doc/user/` | Every user-visible feature or fix |
+| Release notes | **FR** | `doc/releases/` | Every release |
+| `doc/backlog.md` | **FR** | `doc/` | Ticket created, progressed, or completed |
+| `doc/roadmap.md` | **EN (in progress)** | `doc/` | Lot completed, planned, or reprioritised |
+| `doc/plan.md` | **EN (in progress)** | `doc/` | Architecture decisions updated |
 
-`CHANGELOG.md` suit le format **Keep a Changelog** (sections Unreleased → version).
+`CHANGELOG.md` follows the **Keep a Changelog** format (sections Unreleased → version).
 
-### Règles de rédaction de `doc/user/changelog-user.md`
+### Writing rules for `doc/user/changelog-user.md`
 
-`doc/user/changelog-user.md` est le changelog destiné aux **utilisateurs finaux**. Il doit être maintenu en parallèle de `CHANGELOG.md` à chaque version (déployée ou non).
+`doc/user/changelog-user.md` is the **end-user changelog** (written in French). It must be kept in sync with `CHANGELOG.md` for every version, whether deployed or not.
 
-**Structure** :
-- Un **chapitre par version** (titre `## Version X.Y.Z — date` ou `## Version X.Y *(à venir)*`).
-- Dans chaque version, un **chapitre par rôle** dans l'ordre : Tous les utilisateurs / Secrétaire / Trésorier / Administrateur. N'inclure un rôle que s'il y a des changements qui le concernent.
-- Dans chaque rôle, un **sous-chapitre par domaine fonctionnel**.
-- Une **liste à puces** par sous-chapitre.
+**Structure:**
+- One **chapter per version** (heading `## Version X.Y.Z — date` or `## Version X.Y *(à venir)*`).
+- Within each version, one **chapter per role** in this order: Tous les utilisateurs / Secrétaire / Trésorier / Administrateur. Only include a role if there are changes that affect it.
+- Within each role, one **sub-chapter per functional domain**.
+- A **bullet list** per sub-chapter.
 
-**Contenu** :
-- Uniquement les changements **visibles par l'utilisateur** (rien de technique, rien d'interne).
-- Langue et termes **compréhensibles par tout le monde** — pas de jargon technique (pas de « blur », « endpoint », « FITID », « migration », « async », etc.).
-- Sources : CHANGELOG.md, notes de release, **et** log git + lecture du code si nécessaire pour s'assurer de l'exhaustivité.
-- Les vrais rôles de l'application sont : `readonly` (lecture seule), `secretaire`, `tresorier`, `admin`. Utiliser leurs noms courants en français dans le document (Secrétaire, Trésorier, Administrateur).
+**Content:**
+- Only **user-visible** changes — no technical or internal details.
+- Language and wording must be **understandable by non-technical users** — no jargon (no "blur", "endpoint", "FITID", "migration", "async", etc.).
+- Sources: CHANGELOG.md, release notes, **and** git log + code review when needed to ensure completeness.
+- The actual application roles are: `readonly`, `secretaire`, `tresorier`, `admin`. Use their common French display names in the document (Secrétaire, Trésorier, Administrateur).
 
 ---
 
@@ -156,9 +156,11 @@ Keep the following documents up to date with every significant change:
    - Per lot header: sum of all ticket estimates (Copilot time) **+ 15 min user project management** (reviewing, approving, merging). Display as e.g. `~2h20 Copilot + 15 min gestion`.
 
    **Tracking actuals and calibrating estimates:**
-   - After completing each ticket, note the actual Copilot time spent (visible from session context or elapsed conversation time). Record it in the backlog ticket row or detail section as `Réel: ~X min`.
-   - After each PR is merged, note the actual user time spent on review + merge. Record it as a comment on the lot row: `PR réelle: ~X min`.
-   - After each completed lot, compare estimated vs actual totals. If the ratio differs from 1.15 by more than 20%, adjust the margin factor for future estimates and **explicitly inform the user** with a short message: e.g. "Note : le Lot CR a pris X min Copilot pour Y min estimés (ratio Z). J'ajuste le facteur de marge à 1.XX pour les prochains lots."
+   - **At the start of each ticket**: record the start time (`HH:MM`) in `/memories/session/timing.md`. Record the end time when the ticket is done. This start/end log is the source of truth for actual Copilot time per ticket.
+   - After completing each ticket, record the actual time in the backlog ticket row or detail section as `Réel: ~X min`.
+   - After each PR is merged, note the actual user time spent on review + merge. Record it on the lot row: `PR réelle: ~X min`.
+   - At the end of a lot, report actuals ticket by ticket in `doc/backlog.md` (in the `<details>` table) and in the Calibration table.
+   - After each completed lot, compare estimated vs actual totals. If the ratio differs from 1.15 by more than 20%, adjust the margin factor for future estimates and **explicitly inform the user** with a short message (in French, as per the language rules): e.g. "Note : le Lot CR a pris X min Copilot pour Y min estimés (ratio Z). J'ajuste le facteur de marge à 1.XX pour les prochains lots."
    - Keep a running calibration note in `doc/backlog.md` under a `## Calibration estimations` section (create it if absent), updated after every completed lot.
 2. **Feed the roadmap when relevant** — if a ticket represents a new feature, major initiative, innovative idea, or strategic shift, also add it to `doc/roadmap.md` under "Not yet planned".
 3. **Group tickets into lots** — related backlog items are bundled into named lots (e.g. *Lot A — Import Excel*, *Lot F — Tests*). Each lot is identified in the backlog.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -174,6 +174,7 @@ Keep the following documents up to date with every significant change:
 - `doc/backlog.md` and `doc/roadmap.md` must be **kept up to date at all times**: coherent content, correct dates, accurate statuses and priorities, proper lot grouping, zero markdown formatting errors.
 - `CHANGELOG.md` reflects **shipped work**; `doc/backlog.md` reflects **planned and in-progress work** — no item should live in both as active.
 - `doc/roadmap.md` contains **every versioned lot** from the backlog. Functional lots are detailed (one subsection per feature); technical lots are kept to a one-line summary.
+- `doc/user/changelog-user.md` must stay in sync with `CHANGELOG.md` for every version: every user-visible change in `CHANGELOG.md` must have a corresponding entry in `changelog-user.md`, written in plain French for non-technical users.
 
 ### Backlog management
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,11 @@ Ce projet respecte le [Versionnage sémantique](https://semver.org/lang/fr/).
 ## [Non publié]
 
 ### Ajouté
-
-- **BIZ-158** — Limite API relevée à 1 000 éléments par défaut sur `invoice`, `payment`, `contact`, `bank transactions`, `bank deposits`, `salary` (anciennement 100) ; bandeau d'avertissement PrimeVue `warn` affiché dans chaque vue liste quand le résultat atteint 1 000 items
+- **BIZ-161** — Onglet « Nouveautés » dans la page Aide : endpoint `GET /api/help/changelog`, affichage du changelog utilisateur rendu en Markdown
+- **BIZ-163** — Guide par rôle « Je veux… » ajouté en fin de `doc/user/manuel.md` (index des activités par rôle avec liens vers les sections)- **BIZ-158** — Limite API relevée à 1 000 éléments par défaut sur `invoice`, `payment`, `contact`, `bank transactions`, `bank deposits`, `salary` (anciennement 100) ; bandeau d'avertissement PrimeVue `warn` affiché dans chaque vue liste quand le résultat atteint 1 000 items
 
 ### Amélioré
-
-- **BIZ-149** — Auto-capitalisation de la première lettre des intitulés de lignes de facture client au `blur` (déjà implémentée — ticket fermé)
+- **BIZ-162** — Liens d’ancre dans le manuel en ligne : intercepteur de clics dans `HelpView.vue` pour défilement fluide vers les sections cibles- **BIZ-149** — Auto-capitalisation de la première lettre des intitulés de lignes de facture client au `blur` (déjà implémentée — ticket fermé)
 - **BIZ-150** — Champs quantité et prix unitaire dans `ClientInvoiceForm` acceptent désormais la virgule comme séparateur décimal (normalisée en point à la saisie)
 - **BIZ-157** — Pagination des DataTables : 50 lignes affichées par défaut (anciennement 20) dans toutes les vues de liste
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,12 @@ Ce projet respecte le [Versionnage sémantique](https://semver.org/lang/fr/).
 
 ### Ajouté
 - **BIZ-161** — Onglet « Nouveautés » dans la page Aide : endpoint `GET /api/help/changelog`, affichage du changelog utilisateur rendu en Markdown
-- **BIZ-163** — Guide par rôle « Je veux… » ajouté en fin de `doc/user/manuel.md` (index des activités par rôle avec liens vers les sections)- **BIZ-158** — Limite API relevée à 1 000 éléments par défaut sur `invoice`, `payment`, `contact`, `bank transactions`, `bank deposits`, `salary` (anciennement 100) ; bandeau d'avertissement PrimeVue `warn` affiché dans chaque vue liste quand le résultat atteint 1 000 items
+- **BIZ-163** — Guide par rôle « Je veux… » ajouté en fin de `doc/user/manuel.md` (index des activités par rôle avec liens vers les sections)
+- **BIZ-158** — Limite API relevée à 1 000 éléments par défaut sur `invoice`, `payment`, `contact`, `bank transactions`, `bank deposits`, `salary` (anciennement 100) ; bandeau d'avertissement PrimeVue `warn` affiché dans chaque vue liste quand le résultat atteint 1 000 items
 
 ### Amélioré
-- **BIZ-162** — Liens d’ancre dans le manuel en ligne : intercepteur de clics dans `HelpView.vue` pour défilement fluide vers les sections cibles- **BIZ-149** — Auto-capitalisation de la première lettre des intitulés de lignes de facture client au `blur` (déjà implémentée — ticket fermé)
+- **BIZ-162** — Liens d'ancre dans le manuel en ligne : intercepteur de clics dans `HelpView.vue` pour défilement fluide vers les sections cibles
+- **BIZ-149** — Auto-capitalisation de la première lettre des intitulés de lignes de facture client au `blur` (déjà implémentée — ticket fermé)
 - **BIZ-150** — Champs quantité et prix unitaire dans `ClientInvoiceForm` acceptent désormais la virgule comme séparateur décimal (normalisée en point à la saisie)
 - **BIZ-157** — Pagination des DataTables : 50 lignes affichées par défaut (anciennement 20) dans toutes les vues de liste
 

--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -37,6 +37,7 @@ _AdminRequired = Annotated[User, Depends(require_role(UserRole.ADMIN))]
 
 _SETTINGS_ID = 1
 _MANUEL_PATH = Path(__file__).resolve().parents[2] / "doc" / "user" / "manuel.md"
+_CHANGELOG_USER_PATH = Path(__file__).resolve().parents[2] / "doc" / "user" / "changelog-user.md"
 
 
 @router.get("/chat/config", response_model=ChatConfig)
@@ -105,3 +106,16 @@ async def get_manual(
             detail="Manuel utilisateur introuvable.",
         )
     return _MANUEL_PATH.read_text(encoding="utf-8")
+
+
+@router.get("/help/changelog", response_class=PlainTextResponse)
+async def get_changelog(
+    _current_user: _AnyUserRequired,
+) -> str:
+    """Return the user-facing changelog as raw Markdown (authenticated users only)."""
+    if not _CHANGELOG_USER_PATH.exists():
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Changelog utilisateur introuvable.",
+        )
+    return _CHANGELOG_USER_PATH.read_text(encoding="utf-8")

--- a/doc/backlog.md
+++ b/doc/backlog.md
@@ -21,14 +21,6 @@ Facteur de marge actuel : **1,00** (0%) — raméné après Lot UI (voir ci-dess
 
 ## Lots actifs
 
-### Lot DOC — Documentation utilisateur · v1.5 · ~115 min Copilot + 15 min gestion
-
-| ID | Titre | Prio | Est. | Créé | Démarré | Terminé |
-| --- | --- | --- | --- | --- | --- | --- |
-| BIZ-161 | Changelog utilisateur dans la page Aide | P2 | ~35 min | 2026-05-03 | | |
-| BIZ-162 | Liens fonctionnels dans le manuel en ligne | P2 | ~25 min | 2026-05-03 | | |
-| BIZ-163 | Index des activités dans le manuel (« en tant que… ») | P2 | ~55 min | 2026-05-03 | | |
-
 ### Hors lots
 
 | ID | Titre | Prio | Est. | Créé | Démarré | Terminé |
@@ -49,30 +41,13 @@ Décisions métier nécessaires avant implémentation.
 
 Créer `en.ts` avec les clés structurelles pour préparer la localisation anglaise.
 
-### BIZ-161 — Changelog utilisateur dans la page Aide
-
-Rendre `doc/user/changelog-user.md` accessible depuis la page `/aide` : onglet « Nouveautés »
-ou section dédiée. Servir le fichier via un endpoint backend (ex. `GET /api/help/changelog`)
-et afficher le rendu HTML côté Vue, à l'image du manuel.
-
-### BIZ-162 — Liens fonctionnels dans le manuel en ligne
-
-Les liens internes (ancres `#section`) et les liens vers d'autres pages du manuel ne fonctionnent
-pas dans la vue rendue sur `/aide`. Corriger la résolution des ancres et des liens relatifs dans
-`HelpView.vue` (ou le composant de rendu Markdown).
-
-### BIZ-163 — Index des activités dans le manuel (« en tant que… »)
-
-Ajouter une section ou une page d'index dans le manuel utilisateur qui liste les cas d'usage
-par rôle, sous la forme « En tant que secrétaire, je veux… » avec des liens pointant vers
-les sections correspondantes du manuel. Inclure : secrétaire, trésorier, administrateur.
-
 ---
 
 ## Lots terminés
 
 | Lot | Nom | Version | Tickets | Terminé | Est. Copilot | Réel Copilot |
 | --- | --- | --- | --- | --- | --- | --- |
+| DOC | Documentation utilisateur | v1.5 | BIZ-161, BIZ-162, BIZ-163 | 2026-05-03 | ~115 min | ~45 min |
 | 1 | Quick wins P3 | v0.2 | CHR-064, CHR-062, TEC-066, TEC-063 | 2026-04-22 | — | — |
 | 2 | Tests au vert | v0.2 | TEC-048 | 2026-04-22 | — | — |
 | 3 | Sécurité sans impact structurel | v0.2 | TEC-047, TEC-052, TEC-055, TEC-060, TEC-051 | 2026-04-22 | — | — |

--- a/doc/llm/reference.md
+++ b/doc/llm/reference.md
@@ -62,6 +62,7 @@ Main sections:
 - **Comptabilité** — Journal, chart of accounts, accounting rules, ledger, balance sheet *(Comptable/Admin only)*
 - **Paramètres** — Application settings, users, fiscal years *(Admin only)*
 - **Administration** — System supervision, Excel import *(Admin only)*
+- **Aide** — User manual and release notes (all authenticated users)
 
 ---
 
@@ -70,11 +71,14 @@ Main sections:
 The dashboard shows:
 - Key financial indicators for the current fiscal year (income, expenses, balance)
 - A list of overdue or nearly-due client invoices
+- **Pending bank deposits** (bordereaux en attente) — a summary of deposits prepared but not yet confirmed is visible directly on the dashboard.
 - **Quick-action cards** (three tiles in the dashboard body):
   - **Nouvelle facture client** — opens the invoice creation dialog
   - **Nouveau paiement** — opens the payment recording dialog
   - **Nouvelle entrée de caisse** — opens the cash entry dialog
   Each card opens the corresponding inline creation dialog without leaving the dashboard.
+
+**List size:** all list screens default to showing 50 rows. A warning banner appears when a list exceeds 1 000 results, indicating that filters should be used to narrow down the data.
 
 ---
 
@@ -82,9 +86,11 @@ The dashboard shows:
 
 **What a contact is:** a person or organisation linked to invoices, payments, and cash movements. A contact can be a client, a supplier, both, or an employee.
 
-**Creating a contact:** click “Nouveau contact”. Only the name is required. Email is optional but required to send invoices by email. Up to 2 additional email addresses can be added in the “Adresses e-mail supplémentaires” section, each with a free-form label (e.g. “Comptabilité”, “Direction”).
+**Creating a contact:** click "Nouveau contact". Only the name is required. Email is optional but required to send invoices by email. Up to 2 additional email addresses can be added in the "Adresses e-mail supplémentaires" section, each with a free-form label (e.g. "autre parent", "comptabilité"). The contact form also has fields for the **child's first and last name** and the **other parent's first and last name** — used when the client is a family.
 
-**Editing a contact:** click the contact in the list, modify, save. Additional email addresses can be added, edited, or removed in the same form.
+**Editing a contact:** click the contact in the list, modify, save. Additional email addresses and child/parent fields can be added, edited, or removed in the same form.
+
+**Searching contacts:** the search bar filters by contact name, child name, and other parent name.
 
 **Blocking a client (client indésirable):** available for contacts of type “Client” or “Les deux” only. Activate the “Client indésirable” toggle and save. A red badge “Indésirable” appears in the contact list. Creating an invoice for a blocked contact is prevented — the Valider button is disabled in the form and the wizard stops at the contact selection step with an error. To unblock: deactivate the same toggle and save.
 
@@ -92,7 +98,7 @@ The dashboard shows:
 
 **Why can't I delete a contact?** Contacts that have invoices or payments linked to them cannot be deleted. Deactivate them instead.
 
-**Searching contacts:** use the search bar at the top of the contact list to filter by name or email.
+
 
 ---
 
@@ -122,8 +128,8 @@ The dashboard shows:
 The wizard creates and validates a client invoice in 3 steps, accessible from the dashboard or the "+ Facture rapide" button:
 
 1. **Step 1 — Contact**: select the client. If the contact is marked as "Indésirable" (blocked), creation is blocked at this step.
-2. **Step 2 — Lines**: add invoice lines (type, description, quantity, unit price). Prices are pre-filled from settings.
-3. **Step 3 — Confirmation**: the invoice is created and validated. The confirmation shows the invoice number and client name. Buttons available: "Envoyer par e-mail" (opens the email dialog without closing the wizard), "Nouvelle facture" (restart wizard), "Voir la facture" (open full record).
+2. **Step 2 — Lines**: add invoice lines (type, description, quantity, unit price). Prices are pre-filled from settings. The comma (`,`) is accepted as a decimal separator and is converted to a dot automatically. Service descriptions are auto-capitalised when moving to the next field.
+3. **Step 3 — Confirmation**: the invoice is created and validated. The confirmation shows the full contact name and the invoice number. Buttons available: "Envoyer par e-mail" (opens the email dialog without closing the wizard, showing an "E-mail envoyé" badge after sending), "Nouvelle facture" (restart wizard), "Voir la facture" (open full record).
 
 The wizard always creates invoices in "Validée" status — there is no draft step.
 
@@ -131,8 +137,8 @@ The wizard always creates invoices in "Validée" status — there is no draft st
 
 1. Click "Nouvelle facture" (from Factures menu or dashboard quick card).
 2. Select the contact (required). If the contact is blocked, the Valider button is disabled.
-3. Set the date. The due date is filled automatically based on the default delay configured in settings.
-4. Add invoice lines: choose the type (cours / adhésion / autre), enter a description, quantity, and unit price. Prices are pre-filled from defaults configured in settings.
+3. Set the date (pre-filled with today's date). The due date is filled automatically based on the default delay configured in settings.
+4. Add invoice lines: choose the type (cours / adhésion / autre), enter a description, quantity, and unit price. Prices are pre-filled from defaults. The comma (`,`) is accepted as a decimal separator.
 5. Save as draft (Enregistrer) or finalise (Valider).
 
 The invoice number is assigned automatically when the invoice is validated. It cannot be changed manually.
@@ -141,6 +147,7 @@ The invoice number is assigned automatically when the invoice is validated. It c
 
 - **Draft invoices** can be fully edited.
 - **Validated invoices**: the due date and notes can be modified, but the lines cannot.
+- **Editing is blocked** if the invoice has already been fully paid, or if it has been sent and a partial payment has been recorded.
 
 ### Deleting an invoice
 
@@ -187,7 +194,7 @@ The format is configured by an admin (e.g. `2026-001`, `F-2026-001`). The sequen
 1. Click "Nouveau paiement".
 2. Select the contact (optional if the invoice is known).
 3. Enter the amount, date, and reference (cheque number, transfer reference, etc.).
-4. Optionally link the payment to one or more invoices.
+4. Optionally link the payment to one or more invoices. The payment dialog shows the client name, description, total amount, and due date of each linkable invoice.
 5. Save.
 
 When a payment is linked to an invoice, the invoice status updates automatically.
@@ -204,7 +211,13 @@ A bank deposit groups several payments remitted to the bank at the same time (e.
 
 ## Supplier invoices
 
-Record invoices received from suppliers under Factures → Fournisseurs. The workflow is similar to client invoices. You can attach the supplier's PDF file.
+Record invoices received from suppliers under Factures → Fournisseurs.
+
+- New manually-created supplier invoices start in **"Envoyée"** status (not draft).
+- You can **attach the supplier's PDF or image** file to the record.
+- Clicking a supplier invoice opens a **preview dialog** showing: the payment history, a preview of the attached PDF or image, and previous/next navigation between invoices. The same preview is accessible from a contact's history tab.
+- A **"Enregistrer un règlement"** button is available directly in the invoice list and in the preview dialog.
+- Paying a supplier invoice **in cash** automatically generates a corresponding cash outflow in the Caisse module.
 
 ---
 
@@ -213,7 +226,8 @@ Record invoices received from suppliers under Factures → Fournisseurs. The wor
 The cash register tracks physical cash movements.
 
 - **Creating a movement:** click "Nouveau mouvement". Amount: positive = cash in, negative = cash out.
-- **Counting (comptage):** enter the physical amount counted. The app computes and displays the discrepancy.
+- **Counting (comptage):** enter the physical amount counted. Coins are entered as a single "Pièces (ferraille)" total field; the app computes and displays the discrepancy.
+- **Cash payments received from clients** (by cash) are entered into the cash register immediately when the payment is recorded. The corresponding cash outflow to the bank is only generated when the bank deposit is confirmed.
 - **Deleting a movement:** only possible if no validated accounting entry is linked to it.
 
 ---
@@ -230,7 +244,7 @@ The cash register tracks physical cash movements.
 
 ### Importing bank transactions
 
-Import an OFX file exported from your bank: click “Importer”, select the file, confirm. Exact duplicates are skipped automatically. Files with multiple bank accounts are rejected — ask the administrator.
+Import an OFX file exported from your bank: click "Importer", select the file, confirm. Exact duplicates are skipped automatically (no error, no duplicate entries). Files with multiple bank accounts are rejected with an explicit error message — ask the administrator to export a single-account file. The import source (OFX, Excel, CSV, QIF) is shown on each transaction row.
 
 ### Correcting a transaction category
 
@@ -264,7 +278,7 @@ Manage employees under Salaires → Employés. Create an employee with name, opt
 
 ### Salary slips
 
-Create a salary slip under Salaires → Fiches de salaire. Select the employee, the period (month/year), enter gross salary, employer contributions, employee contributions (and withholding tax), net pay. For CDD employees, entering hours automatically computes the gross (hours × hourly rate). The “Copier la fiche précédente” button pre-fills contributions from the previous month to save time. Validating a salary slip generates accounting entries automatically.
+Create a salary slip under Salaires → Fiches de salaire. Select the employee, the period (month/year), enter gross salary, employer contributions, employee contributions (and withholding tax), net pay. For CDD employees, entering hours automatically computes the gross (hours × hourly rate). The "Copier la fiche précédente" button pre-fills contributions from the previous month to save time. Validating a salary slip generates accounting entries automatically; those entries are **dated to the last day of the month** of the pay period.
 
 ---
 
@@ -309,15 +323,42 @@ Accessible by clicking the username in the top-right corner → Mon profil.
 
 ---
 
-## Settings (Paramètres) — Admin only
+## Help page (Aide)
 
+Accessible from the left sidebar → Aide. Available to all authenticated users.
+
+### Manual tab (Manuel)
+
+Displays the full user manual as formatted text. Section links in the table of contents scroll the page smoothly to the target section.
+
+### Release notes tab (Nouveautés)
+
+Displays the user-facing changelog: all user-visible changes grouped by version, then by role and functional domain. Users can check what changed in the latest version and in past versions.
+
+### Activity index by role (Guide par rôle)
+
+The end of the manual contains a **"Guide par rôle — Je veux…"** section: three tables (Secrétaire, Trésorier, Administrateur) listing common tasks with direct links to the corresponding manual section.
+
+### Internal notes (Ajouter une note)
+
+A **"Ajouter une note"** button on the Help page lets any authenticated user submit an internal note or remark to the administrators. Administrators can view all notes, mark them as resolved, or delete them from the Administration section.
+
+---
+
+## Settings (Paramètres)
+
+The settings page is accessible to all authenticated users:
+- **Gestionnaire (secrétaire) and Comptable (trésorier)**: read-only access — they can view the association information, invoice numbering, default prices, and SMTP status.
+- **Admin**: full read-write access to all settings.
+
+Available settings:
 - **Association information**: name, address, SIRET, logo — shown on invoices.
 - **Invoice numbering templates**: format of invoice numbers.
 - **Default due date**: days added to invoice date to auto-compute the due date.
 - **Default prices**: pre-filled unit prices by invoice line type.
 - **SMTP**: email sending configuration.
-- **Users**: create, edit, deactivate accounts; reset passwords.
-- **Fiscal years**: create and manage accounting periods.
+- **Users**: create, edit, deactivate accounts; reset passwords. *(Admin only)*
+- **Fiscal years**: create and manage accounting periods. *(Admin only)*
 
 ---
 
@@ -326,6 +367,10 @@ Accessible by clicking the username in the top-right corner → Mon profil.
 ### System supervision
 
 Located at Administration → Supervision système. Shows application version, database size, uptime, log viewer, and audit log.
+
+### Internal notes
+
+Administrators can view all internal notes submitted by users (via the Help page), mark them as resolved, or delete them.
 
 ### Excel import
 
@@ -385,6 +430,18 @@ The administrator or a developer can open a GitHub issue with details of the pro
 
 **Q: I can't see the Comptabilité menu.**
 A: Your role is Gestionnaire (secretaire). Only Comptable (tresorier) and Admin roles can access accounting.
+
+**Q: I can't see the Paramètres menu.**
+A: All authenticated users can access the Settings page in read-only mode. If a user cannot see it at all, it may be a navigation issue — ask them to look for "Paramètres" in the left sidebar. Only Admins can modify settings.
+
+**Q: Where can I see what's new in the application?**
+A: Open the Aide page from the sidebar, then click the "Nouveautés" tab. It lists all user-visible changes grouped by version.
+
+**Q: The table of contents links in the manual don't work.**
+A: The links should scroll the page smoothly to the relevant section. If they don't, try refreshing the page.
+
+**Q: I want to leave a note or remark for the admin.**
+A: Use the "Ajouter une note" button on the Aide page. The admin will see it in the Administration section.
 
 **Q: I can't send an invoice by email.**
 A: Either the contact has no email address (not even an additional one), or the SMTP server is not configured. Ask your administrator.

--- a/doc/llm/reference.md
+++ b/doc/llm/reference.md
@@ -225,7 +225,7 @@ Record invoices received from suppliers under Factures → Fournisseurs.
 
 The cash register tracks physical cash movements.
 
-- **Creating a movement:** click "Nouveau mouvement". Amount: positive = cash in, negative = cash out.
+- **Creating a movement:** click "Nouveau mouvement". Amount is always stored as a positive value; the type (IN or OUT) determines whether it is added to or subtracted from the balance.
 - **Counting (comptage):** enter the physical amount counted. Coins are entered as a single "Pièces (ferraille)" total field; the app computes and displays the discrepancy.
 - **Cash payments received from clients** (by cash) are entered into the cash register immediately when the payment is recorded. The corresponding cash outflow to the bank is only generated when the bank deposit is confirmed.
 - **Deleting a movement:** only possible if no validated accounting entry is linked to it.

--- a/doc/user/changelog-user.md
+++ b/doc/user/changelog-user.md
@@ -16,7 +16,7 @@ Ce document présente les changements visibles dans l'application, version par v
 
 #### Saisie des factures
 - Dans les lignes d'une facture, la **virgule est acceptée** comme séparateur décimal (elle est automatiquement convertie en point).
-- Le libellé d'une prestation est **mis en majuscule automatiquement** dès qu'on passe au champ suivant.
+- La **première lettre** d'un libellé de prestation est **mise en majuscule automatiquement** dès qu'on passe au champ suivant.
 
 ---
 

--- a/doc/user/manuel.md
+++ b/doc/user/manuel.md
@@ -19,6 +19,7 @@ Il est destiné aux utilisateurs disposant d'un rôle **Gestionnaire**, **Compta
 10. [Comptabilité](#10-comptabilité)
 11. [Exercices comptables](#11-exercices-comptables)
 12. [Mon profil](#12-mon-profil)
+13. [Guide par rôle — « Je veux… »](#guide-par-rôle--je-veux-)
 
 ---
 
@@ -575,3 +576,52 @@ Après clôture, l'exercice passe à l'état **Clôturé** et les écritures ne 
 4. Cliquer sur **Enregistrer**.
 
 Le nouveau mot de passe doit respecter la politique : minimum 8 caractères, au moins une majuscule et un chiffre.
+
+---
+
+## Guide par rôle — « Je veux… »
+
+Ce guide recense les actions courantes par rôle et renvoie vers la section correspondante du manuel.
+
+### Secrétaire
+
+| Je veux… | Section |
+|---|---|
+| Me connecter ou changer mon mot de passe | [1. Connexion et mot de passe](#1-connexion-et-mot-de-passe) |
+| Créer ou modifier un contact | [3. Contacts — Créer un contact](#créer-un-contact) |
+| Voir l'historique d'un contact | [3. Contacts — Historique d'un contact](#historique-dun-contact) |
+| Marquer un client comme indésirable | [3. Contacts — Marquer un client comme indésirable](#marquer-un-client-comme-indésirable) |
+| Créer une facture client rapidement | [4. Factures clients — Créer une facture rapidement (wizard)](#créer-une-facture-rapidement-wizard) |
+| Créer une facture client (formulaire complet) | [4. Factures clients — Créer une facture (formulaire complet)](#créer-une-facture-formulaire-complet) |
+| Envoyer une facture par e-mail | [4. Factures clients — Envoyer une facture par e-mail](#envoyer-une-facture-par-e-mail) |
+| Télécharger le PDF d'une facture | [4. Factures clients — Télécharger le PDF](#télécharger-le-pdf) |
+| Modifier ou supprimer une facture | [4. Factures clients — Modifier une facture](#modifier-une-facture) |
+| Créer un avoir (note de crédit) | [4. Factures clients](#4-factures-clients) |
+| Modifier mon profil ou mon mot de passe | [12. Mon profil](#12-mon-profil) |
+
+### Trésorier
+
+| Je veux… | Section |
+|---|---|
+| Enregistrer un paiement client | [5. Paiements — Encoder un paiement](#encoder-un-paiement) |
+| Préparer et confirmer une remise en banque (chèques ou espèces) | [5. Paiements — Remises en banque](#remises-en-banque) |
+| Créer ou payer une facture fournisseur | [6. Factures fournisseurs](#6-factures-fournisseurs) |
+| Enregistrer une entrée ou sortie de caisse | [7. Caisse — Enregistrer un mouvement](#enregistrer-un-mouvement) |
+| Faire un comptage de caisse | [7. Caisse — Comptage de caisse](#comptage-de-caisse) |
+| Importer un relevé bancaire (OFX) | [8. Banque — Importer des transactions (OFX)](#importer-des-transactions-ofx) |
+| Corriger la catégorie d'une transaction | [8. Banque — Corriger la catégorie d'une transaction](#corriger-la-catégorie-dune-transaction) |
+| Rapprocher des transactions bancaires | [8. Banque — Rapprochement bancaire](#rapprochement-bancaire) |
+| Confirmer une remise en banque | [8. Banque — Remises en banque](#remises-en-banque-1) |
+| Saisir une fiche de salaire | [9. Salaires et employés — Fiches de salaire](#fiches-de-salaire) |
+| Consulter le journal comptable | [10. Comptabilité — Journal comptable](#journal-comptable) |
+| Consulter le grand livre, le bilan ou le compte de résultat | [10. Comptabilité](#10-comptabilité) |
+| Clôturer un exercice comptable | [11. Exercices comptables — Clôturer un exercice](#clôturer-un-exercice) |
+
+### Administrateur
+
+| Je veux… | Section |
+|---|---|
+| Gérer les employés | [9. Salaires et employés — Gérer les employés](#gérer-les-employés) |
+| Configurer les règles comptables | [10. Comptabilité — Règles comptables](#règles-comptables) |
+| Créer un exercice comptable | [11. Exercices comptables — Créer un exercice](#créer-un-exercice) |
+| Toutes les actions Secrétaire et Trésorier | Voir les sections ci-dessus |

--- a/doc/user/manuel.md
+++ b/doc/user/manuel.md
@@ -19,7 +19,7 @@ Il est destiné aux utilisateurs disposant d'un rôle **Gestionnaire**, **Compta
 10. [Comptabilité](#10-comptabilité)
 11. [Exercices comptables](#11-exercices-comptables)
 12. [Mon profil](#12-mon-profil)
-13. [Guide par rôle — « Je veux… »](#guide-par-rôle--je-veux-)
+13. [Guide par rôle — « Je veux… »](#guide-par-rôle-je-veux)
 
 ---
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/frontend/src/api/chat.ts
+++ b/frontend/src/api/chat.ts
@@ -1,3 +1,4 @@
+import { useAuthStore } from '@/stores/auth'
 import apiClient from './client'
 
 export interface ChatMessage {
@@ -41,7 +42,7 @@ export async function* streamChat(
   messages: ChatMessage[],
   signal?: AbortSignal,
 ): AsyncGenerator<string> {
-  const token = localStorage.getItem('access_token')
+  const token = useAuthStore().accessToken
   const response = await fetch('/api/chat', {
     method: 'POST',
     headers: {

--- a/frontend/src/api/help.ts
+++ b/frontend/src/api/help.ts
@@ -6,3 +6,10 @@ export async function getManual(): Promise<string> {
   })
   return response.data
 }
+
+export async function getChangelogUser(): Promise<string> {
+  const response = await apiClient.get<string>('/api/help/changelog', {
+    responseType: 'text',
+  })
+  return response.data
+}

--- a/frontend/src/i18n/fr.ts
+++ b/frontend/src/i18n/fr.ts
@@ -253,6 +253,10 @@ export default {
     subtitle: "Manuel utilisateur complet de l'application Solde.",
     loading: 'Chargement du manuel…',
     error: 'Impossible de charger le manuel utilisateur.',
+    tab_manual: 'Manuel',
+    tab_changelog: 'Nouveautés',
+    changelog_loading: 'Chargement des nouveautés…',
+    changelog_error: 'Impossible de charger les nouveautés.',
   },
   contacts: {
     title: 'Contacts',

--- a/frontend/src/tests/utils/renderMarkdown.spec.ts
+++ b/frontend/src/tests/utils/renderMarkdown.spec.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+
+import { renderMarkdown } from '../../utils/renderMarkdown'
+
+// ---------------------------------------------------------------------------
+// headingSlug behaviour (verified via generated id attributes in the HTML)
+// ---------------------------------------------------------------------------
+
+describe('renderMarkdown — heading id generation', () => {
+  it('generates a lowercase hyphenated slug from an ASCII heading', () => {
+    const html = renderMarkdown('## Hello World')
+    expect(html).toContain('id="hello-world"')
+  })
+
+  it('keeps accented Unicode letters in the slug', () => {
+    const html = renderMarkdown('## Guide par rôle')
+    expect(html).toContain('id="guide-par-rôle"')
+  })
+
+  it('strips punctuation but keeps letters and hyphens', () => {
+    const html = renderMarkdown('## « Je veux… »')
+    expect(html).toContain('id="je-veux"')
+  })
+
+  it('collapses multiple spaces / mixed whitespace to a single hyphen', () => {
+    const html = renderMarkdown('## Foo   Bar')
+    expect(html).toContain('id="foo-bar"')
+  })
+
+  it('appends -1, -2 suffix for duplicate headings', () => {
+    const md = '## Remises en banque\n\nsome text\n\n## Remises en banque\n\nmore text'
+    const html = renderMarkdown(md)
+    expect(html).toContain('id="remises-en-banque"')
+    expect(html).toContain('id="remises-en-banque-1"')
+  })
+
+  it('counter resets between independent renderMarkdown calls', () => {
+    const first = renderMarkdown('## Section A\n\n## Section A')
+    const second = renderMarkdown('## Section A\n\n## Section A')
+    // Both calls should produce the same ids independently
+    expect(first).toBe(second)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// XSS sanitization — id attributes must be preserved; scripts must be stripped
+// ---------------------------------------------------------------------------
+
+describe('renderMarkdown — XSS sanitization', () => {
+  it('preserves id attributes on headings after sanitization', () => {
+    const html = renderMarkdown('## Mon titre')
+    expect(html).toContain('id="mon-titre"')
+  })
+
+  it('strips script tags', () => {
+    const html = renderMarkdown('<script>alert(1)</script> safe text')
+    expect(html).not.toContain('<script>')
+    expect(html).toContain('safe text')
+  })
+})

--- a/frontend/src/utils/renderMarkdown.ts
+++ b/frontend/src/utils/renderMarkdown.ts
@@ -2,14 +2,45 @@
  * Centralized Markdown rendering with XSS sanitization.
  * Always use this helper instead of calling marked.parse directly before v-html injection.
  */
-import { marked } from 'marked'
+import { Marked } from 'marked'
 import DOMPurify from 'dompurify'
 
 /**
+ * Convert a heading's raw Markdown text to a URL-friendly id.
+ * Strips leading # markers, lowercases, removes non-alphanumeric chars
+ * (keeping Unicode letters/digits and hyphens), collapses whitespace to a
+ * single hyphen. Duplicate headings get a -1, -2 … suffix (GitHub style).
+ */
+function headingSlug(raw: string): string {
+  return raw
+    .replace(/^#{1,6}\s+/, '') // strip leading # markers
+    .replace(/\s+$/, '')       // trim trailing whitespace / newline
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}\s-]/gu, '') // keep Unicode letters, digits, spaces, hyphens
+    .trim()
+    .replace(/\s+/g, '-')      // collapse whitespace runs to a single hyphen
+}
+
+/**
  * Parse Markdown and sanitize the resulting HTML to prevent XSS.
+ * Headings get deterministic id attributes so in-page anchor links work.
  * Safe to use with v-html.
  */
 export function renderMarkdown(text: string): string {
-  const raw = marked.parse(text, { async: false }) as string
-  return DOMPurify.sanitize(raw)
+  const usedIds = new Map<string, number>()
+
+  const instance = new Marked({
+    renderer: {
+      heading({ text: html, depth, raw }: { text: string; depth: number; raw: string }): string {
+        const base = headingSlug(raw)
+        const n = usedIds.get(base) ?? 0
+        const id = n === 0 ? base : `${base}-${n}`
+        usedIds.set(base, n + 1)
+        return `<h${depth} id="${id}">${html}</h${depth}>\n`
+      },
+    },
+  })
+
+  const rawHtml = instance.parse(text, { async: false }) as string
+  return DOMPurify.sanitize(rawHtml, { ADD_ATTR: ['id'] })
 }

--- a/frontend/src/views/HelpView.vue
+++ b/frontend/src/views/HelpView.vue
@@ -11,17 +11,50 @@
       </template>
     </AppPageHeader>
 
-    <div v-if="loading" class="help-loading">
-      <i class="pi pi-spin pi-spinner" style="font-size: 1.5rem" />
-      <span>{{ t('help.loading') }}</span>
-    </div>
+    <Tabs v-model:value="activeTab">
+      <TabList>
+        <Tab value="manual">{{ t('help.tab_manual') }}</Tab>
+        <Tab value="changelog">{{ t('help.tab_changelog') }}</Tab>
+      </TabList>
 
-    <Message v-else-if="error" severity="error" :closable="false">
-      {{ t('help.error') }}
-    </Message>
+      <TabPanels>
+        <!-- Onglet Manuel -->
+        <TabPanel value="manual">
+          <div v-if="loadingManual" class="help-loading">
+            <i class="pi pi-spin pi-spinner" style="font-size: 1.5rem" />
+            <span>{{ t('help.loading') }}</span>
+          </div>
+          <Message v-else-if="errorManual" severity="error" :closable="false">
+            {{ t('help.error') }}
+          </Message>
+          <!-- eslint-disable-next-line vue/no-v-html -->
+          <div
+            v-else
+            class="help-content prose"
+            v-html="renderedManual"
+            @click="handleContentClick"
+          />
+        </TabPanel>
 
-    <!-- eslint-disable-next-line vue/no-v-html -->
-    <div v-else class="help-content prose" v-html="renderedManual" />
+        <!-- Onglet Nouveautés -->
+        <TabPanel value="changelog">
+          <div v-if="loadingChangelog" class="help-loading">
+            <i class="pi pi-spin pi-spinner" style="font-size: 1.5rem" />
+            <span>{{ t('help.changelog_loading') }}</span>
+          </div>
+          <Message v-else-if="errorChangelog" severity="error" :closable="false">
+            {{ t('help.changelog_error') }}
+          </Message>
+          <!-- eslint-disable-next-line vue/no-v-html -->
+          <div
+            v-else
+            class="help-content prose"
+            v-html="renderedChangelog"
+            @click="handleContentClick"
+          />
+        </TabPanel>
+      </TabPanels>
+    </Tabs>
 
     <Dialog
       v-model:visible="commentDialogVisible"
@@ -63,25 +96,36 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
+import { computed, ref, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import Button from 'primevue/button'
 import Dialog from 'primevue/dialog'
 import Message from 'primevue/message'
+import Tab from 'primevue/tab'
+import TabList from 'primevue/tablist'
+import TabPanel from 'primevue/tabpanel'
+import TabPanels from 'primevue/tabpanels'
+import Tabs from 'primevue/tabs'
 import Textarea from 'primevue/textarea'
 import { useToast } from 'primevue/usetoast'
 import { renderMarkdown } from '@/utils/renderMarkdown'
 import AppPage from '@/components/ui/AppPage.vue'
 import AppPageHeader from '@/components/ui/AppPageHeader.vue'
-import { getManual } from '@/api/help'
+import { getManual, getChangelogUser } from '@/api/help'
 import { createCommentApi } from '@/api/app_comment'
 
 const { t } = useI18n()
 const toast = useToast()
 
+const activeTab = ref<string>('manual')
+
 const manualText = ref('')
-const loading = ref(true)
-const error = ref(false)
+const loadingManual = ref(true)
+const errorManual = ref(false)
+
+const changelogText = ref('')
+const loadingChangelog = ref(true)
+const errorChangelog = ref(false)
 
 const commentDialogVisible = ref(false)
 const newContent = ref('')
@@ -91,6 +135,34 @@ const renderedManual = computed(() => {
   if (!manualText.value) return ''
   return renderMarkdown(manualText.value)
 })
+
+const renderedChangelog = computed(() => {
+  if (!changelogText.value) return ''
+  return renderMarkdown(changelogText.value)
+})
+
+/**
+ * Intercept clicks on rendered Markdown content.
+ * - Anchor links (#section) → smooth-scroll within the page.
+ * - External or router links → let the browser handle them normally.
+ */
+function handleContentClick(event: MouseEvent): void {
+  const target = event.target as HTMLElement
+  const anchor = target.closest('a') as HTMLAnchorElement | null
+  if (!anchor) return
+
+  const href = anchor.getAttribute('href')
+  if (!href) return
+
+  if (href.startsWith('#')) {
+    event.preventDefault()
+    const id = href.slice(1)
+    const el = document.getElementById(id)
+    if (el) {
+      el.scrollIntoView({ behavior: 'smooth', block: 'start' })
+    }
+  }
+}
 
 async function submitComment(): Promise<void> {
   if (!newContent.value.trim()) return
@@ -108,13 +180,24 @@ async function submitComment(): Promise<void> {
 }
 
 onMounted(async () => {
-  try {
-    manualText.value = await getManual()
-  } catch {
-    error.value = true
-  } finally {
-    loading.value = false
+  const [manualResult, changelogResult] = await Promise.allSettled([
+    getManual(),
+    getChangelogUser(),
+  ])
+
+  if (manualResult.status === 'fulfilled') {
+    manualText.value = manualResult.value
+  } else {
+    errorManual.value = true
   }
+  loadingManual.value = false
+
+  if (changelogResult.status === 'fulfilled') {
+    changelogText.value = changelogResult.value
+  } else {
+    errorChangelog.value = true
+  }
+  loadingChangelog.value = false
 })
 </script>
 

--- a/frontend/src/views/HelpView.vue
+++ b/frontend/src/views/HelpView.vue
@@ -156,7 +156,7 @@ function handleContentClick(event: MouseEvent): void {
 
   if (href.startsWith('#')) {
     event.preventDefault()
-    const id = href.slice(1)
+    const id = decodeURIComponent(href.slice(1))
     const el = document.getElementById(id)
     if (el) {
       el.scrollIntoView({ behavior: 'smooth', block: 'start' })
@@ -235,6 +235,7 @@ onMounted(async () => {
   font-weight: 600;
   line-height: 1.3;
   margin-bottom: 0.5em;
+  scroll-margin-top: 80px;
 }
 
 .prose :deep(h1) {

--- a/frontend/src/views/HelpView.vue
+++ b/frontend/src/views/HelpView.vue
@@ -18,7 +18,7 @@
       </TabList>
 
       <TabPanels>
-        <!-- Onglet Manuel -->
+        <!-- Manual tab -->
         <TabPanel value="manual">
           <div v-if="loadingManual" class="help-loading">
             <i class="pi pi-spin pi-spinner" style="font-size: 1.5rem" />
@@ -36,7 +36,7 @@
           />
         </TabPanel>
 
-        <!-- Onglet Nouveautés -->
+        <!-- What's new tab -->
         <TabPanel value="changelog">
           <div v-if="loadingChangelog" class="help-loading">
             <i class="pi pi-spin pi-spinner" style="font-size: 1.5rem" />

--- a/frontend/src/views/HelpView.vue
+++ b/frontend/src/views/HelpView.vue
@@ -227,19 +227,43 @@ onMounted(async () => {
 }
 
 /* Basic prose styles for the rendered Markdown */
+/* Heading hierarchy: distinct sizes and colors per level */
 .prose :deep(h1),
 .prose :deep(h2),
 .prose :deep(h3),
 .prose :deep(h4) {
   font-weight: 600;
-  margin-top: 1.5em;
+  line-height: 1.3;
   margin-bottom: 0.5em;
-  color: var(--app-text-primary);
 }
 
-.prose :deep(h1) { font-size: 1.5rem; }
-.prose :deep(h2) { font-size: 1.25rem; border-bottom: 1px solid var(--p-surface-200); padding-bottom: 0.25em; }
-.prose :deep(h3) { font-size: 1.1rem; }
+.prose :deep(h1) {
+  font-size: 1.9rem;
+  font-weight: 700;
+  color: var(--app-text-primary);
+  margin-top: 2em;
+}
+
+.prose :deep(h2) {
+  font-size: 1.45rem;
+  color: var(--p-primary-color);
+  border-bottom: 2px solid color-mix(in srgb, var(--p-primary-color) 25%, transparent);
+  padding-bottom: 0.3em;
+  margin-top: 2em;
+}
+
+.prose :deep(h3) {
+  font-size: 1.15rem;
+  color: color-mix(in srgb, var(--p-primary-color) 75%, var(--app-text-primary));
+  margin-top: 1.4em;
+}
+
+.prose :deep(h4) {
+  font-size: 1rem;
+  color: var(--app-text-muted);
+  font-style: italic;
+  margin-top: 1em;
+}
 
 .prose :deep(p) {
   margin-bottom: 0.75em;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "solde"
-version = "1.3.2"
+version = "1.3.3"
 description = "Web app for French non-profit accounting — invoicing, payments, cash management and double-entry bookkeeping."
 requires-python = ">=3.11"
 dependencies = [

--- a/tests/integration/test_help_api.py
+++ b/tests/integration/test_help_api.py
@@ -1,0 +1,68 @@
+"""Integration tests for GET /api/help/manual and GET /api/help/changelog."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+from httpx import AsyncClient
+
+
+class TestGetHelpManual:
+    async def test_requires_auth(self, client: AsyncClient) -> None:
+        response = await client.get("/api/help/manual")
+        assert response.status_code == 401
+
+    async def test_returns_markdown_text(self, client: AsyncClient, auth_headers: dict) -> None:
+        response = await client.get("/api/help/manual", headers=auth_headers)
+        assert response.status_code == 200
+        assert "text/plain" in response.headers["content-type"]
+
+    async def test_returns_404_when_file_missing(
+        self, client: AsyncClient, auth_headers: dict
+    ) -> None:
+        with patch("backend.routers.chat._MANUEL_PATH", Path("/nonexistent/manuel.md")):
+            response = await client.get("/api/help/manual", headers=auth_headers)
+        assert response.status_code == 404
+
+
+class TestGetHelpChangelog:
+    async def test_requires_auth(self, client: AsyncClient) -> None:
+        response = await client.get("/api/help/changelog")
+        assert response.status_code == 401
+
+    async def test_any_authenticated_role_can_access(
+        self,
+        client: AsyncClient,
+        auth_headers: dict,
+        readonly_auth_headers: dict,
+        secretaire_auth_headers: dict,
+        tresorier_auth_headers: dict,
+    ) -> None:
+        for headers in (
+            auth_headers,
+            readonly_auth_headers,
+            secretaire_auth_headers,
+            tresorier_auth_headers,
+        ):
+            response = await client.get("/api/help/changelog", headers=headers)
+            assert response.status_code == 200
+
+    async def test_returns_plain_text(self, client: AsyncClient, auth_headers: dict) -> None:
+        response = await client.get("/api/help/changelog", headers=auth_headers)
+        assert response.status_code == 200
+        assert "text/plain" in response.headers["content-type"]
+
+    async def test_returns_markdown_content(self, client: AsyncClient, auth_headers: dict) -> None:
+        response = await client.get("/api/help/changelog", headers=auth_headers)
+        assert response.status_code == 200
+        # The changelog-user.md file contains version headings
+        assert "##" in response.text or "Version" in response.text
+
+    async def test_returns_404_when_file_missing(
+        self, client: AsyncClient, auth_headers: dict
+    ) -> None:
+        with patch(
+            "backend.routers.chat._CHANGELOG_USER_PATH",
+            Path("/nonexistent/changelog-user.md"),
+        ):
+            response = await client.get("/api/help/changelog", headers=auth_headers)
+        assert response.status_code == 404


### PR DESCRIPTION
## Summary

Implements Lot DOC (v1.5): three improvements to the Help page, plus associated fixes discovered during testing.

## Changes

### BIZ-161 — New "Nouveautés" tab
New `GET /api/help/changelog` endpoint serving `doc/user/changelog-user.md` as plain text. New "Nouveautés" tab in `HelpView.vue` alongside the Manual tab, using the same PrimeVue Tabs pattern. All authenticated roles can access it. Four new i18n keys added.

### BIZ-162 — Anchor links in the manual
Anchor links in the rendered manual now work end-to-end:
- Custom heading renderer in `renderMarkdown.ts` generates deterministic `id` attributes using a GitHub-compatible slug algorithm (`headingSlug()`), with duplicate-heading support (`-1`, `-2` suffix).
- `DOMPurify.sanitize` called with `{ ADD_ATTR: ['id'] }` to preserve `id` attributes.
- `handleContentClick` in `HelpView.vue` intercepts `#…` links and smooth-scrolls to the target element.
- `decodeURIComponent()` applied before `getElementById` to handle non-ASCII anchors (e.g. `#guide-par-rôle-je-veux`).
- `scroll-margin-top: 80px` on all prose headings to compensate for the sticky header.

### BIZ-163 — Activity index by role
"Guide par rôle — « Je veux… »" section added at the end of `manuel.md`: three tables (Secrétaire, Trésorier, Administrateur) listing common tasks with links to the relevant manual sections.

### Bug fix — Chat 401
`streamChat` in `api/chat.ts` was reading the auth token from `localStorage` (always `null` — token is stored in-memory only in the Pinia auth store for XSS mitigation). Fixed by reading `useAuthStore().accessToken` directly.

### Other
- Markdown prose heading styles updated: more distinct sizes (h1 1.9rem → h4 1rem) with per-level colors using `color-mix()` and PrimeVue CSS variables.
- `doc/llm/reference.md` updated to match all new user-doc content (v1.1 through Lot DOC).
- `.github/copilot-instructions.md`: translated FR sections to EN, added per-ticket timing rule, added `changelog-user.md` sync rule.

## Breaking changes

None.

## Migration notes

None.