### PR TITLE
chore(docker): fix cache invalidation on version bumps (v1.4.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Ce projet respecte le [Versionnage sémantique](https://semver.org/lang/fr/).
 
 ## [Non publié]
 
+### Amélioré
+- **CHR** — Docker : séparation des dépendances Python (`docker-requirements.txt`) et des métadonnées de version (`pyproject.toml`) en deux couches distinctes — évite la réinstallation complète de toutes les dépendances à chaque bump de version
+
 ---
 
 ## [1.4.0] — 2026-05-03

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,10 +32,17 @@ RUN addgroup --system solde && adduser --system --ingroup solde solde
 
 WORKDIR /app
 
-# Install Python dependencies
-COPY pyproject.toml ./
+# Step 1: install dependencies (cached layer — only invalidated when deps change,
+# NOT on version bumps in pyproject.toml)
+COPY docker-requirements.txt ./
 RUN pip install --no-cache-dir --upgrade pip \
-    && pip install --no-cache-dir .
+    && pip install --no-cache-dir -r docker-requirements.txt
+
+# Step 2: register package metadata with correct version (fast — no-deps)
+COPY pyproject.toml ./
+RUN mkdir -p backend && touch backend/__init__.py \
+    && pip install --no-cache-dir --no-deps . \
+    && rm -rf backend
 
 # Copy backend source
 COPY backend/ ./backend/

--- a/docker-requirements.txt
+++ b/docker-requirements.txt
@@ -1,0 +1,20 @@
+# Runtime dependencies for Docker layer caching.
+# Must mirror [project.dependencies] in pyproject.toml.
+# This file is intentionally separate so that version bumps in pyproject.toml
+# do NOT invalidate the Docker pip install layer (only actual dep changes do).
+fastapi>=0.115
+uvicorn[standard]>=0.30
+sqlalchemy[asyncio]>=2.0
+aiosqlite>=0.20
+alembic>=1.13
+pydantic[email]>=2.0
+pydantic-settings>=2.0
+python-jose[cryptography]>=3.3
+bcrypt>=4.0
+python-multipart>=0.0.9
+jinja2>=3.1
+aiofiles>=23.0
+weasyprint>=62.0
+openpyxl>=3.1
+google-genai>=0.8
+openai>=1.0

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "solde"
-version = "1.4.0"
+version = "1.4.1"
 description = "Web app for French non-profit accounting — invoicing, payments, cash management and double-entry bookkeeping."
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Summary

Fixes a Docker build performance issue where every version bump in `pyproject.toml` was invalidating the entire `pip install` cache layer, forcing a full reinstall of all dependencies (~30 min on ARM64 via QEMU on GitHub Actions).

## Root cause

The previous Dockerfile had a single layer:
```dockerfile
COPY pyproject.toml ./
RUN pip install --no-cache-dir .
```

Any change to `pyproject.toml` (including a version bump like `1.3.3 → 1.4.0`) invalidated this layer, triggering a full reinstall of all packages including WeasyPrint and its C dependencies on ARM64.

## Fix

Split into two layers:

1. **Dependency layer** (`docker-requirements.txt`) — only invalidated when actual dependencies change:
   ```dockerfile
   COPY docker-requirements.txt ./
   RUN pip install --no-cache-dir -r docker-requirements.txt
   ```

2. **Metadata layer** (`pyproject.toml`) — fast, no-deps install that only registers the package version:
   ```dockerfile
   COPY pyproject.toml ./
   RUN pip install --no-cache-dir --no-deps .
   ```

## Impact

- Version bumps: pip layer served from cache → build time drops from ~30 min to ~5 min
- Dependency changes: full reinstall still triggered (correct behaviour)
- `importlib.metadata.version("solde")` still returns the correct version at runtime

## Version

`1.4.0 → 1.4.1` (patch bump for this infrastructure fix)

## Checklist

- [x] ruff check/format ✓
- [x] mypy ✓ (158 files, no issues)
- [x] pytest ✓ (1021 passed)
- [x] eslint ✓
- [x] vue-tsc ✓
- [x] vitest ✓ (144 passed)
- [x] Local Docker build validated (exit 0)

## Summary by Sourcery

Improve Docker build caching around Python dependencies and package metadata to speed up builds on version bumps.

Enhancements:
- Split Python dependency installation and package metadata registration into separate Docker layers to avoid reinstalling all dependencies on every version bump.
- Document the Docker caching improvement in the changelog as an enhancement.

Build:
- Introduce docker-requirements.txt to define Docker image Python dependencies separately from pyproject.toml.

Chores:
- Bump backend and frontend package versions from 1.4.0 to 1.4.1 for this infrastructure change.