### PR TITLE
feat(ui): mobile card views on all remaining list screens (BIZ-164)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,9 @@ Ce projet respecte le [Versionnage sémantique](https://semver.org/lang/fr/).
 ## [Non publié]
 
 ### Ajouté
-- **BIZ-164** — Mode téléphone : vue carte mobile sur les listes Factures client, Contacts, Banque (transactions + dépôts), Règlements et Caisse (journal + comptages) — les DataTables laissent place à des cartes empilées sous 767 px
+- **BIZ-164** — Mode téléphone : vue carte mobile sur toutes les listes de l'application (Factures client/fournisseur, Contacts, Banque, Règlements, Caisse, Salaires, Employés, Comptabilité, Exercices, Règles comptables, Journal, Balance, Bilan, Résultat, Utilisateurs) — les DataTables laissent place à des cartes empilées sous 767 px
 - **BIZ-164** — Composable `useBreakpoints` (breakpoint 767 px via `window.matchMedia`, avec listener réactif)
-- **BIZ-164** — Composant générique `AppMobileCardList` avec slot `#card="{ item }"`
+- **BIZ-164** — Composant générique `AppMobileCardList` avec slot `#card="{ item }"` et typage générique `T` pour inférence TypeScript correcte dans les slots
 - **BIZ-164** — Suggestion automatique du numéro de chèque (`AAAAMMJJ.NN`) à l'ouverture du formulaire de paiement chèque (factures client et fournisseur, assistant saisie rapide) ; modèle de numérotation configurable dans les paramètres
 - **BIZ-164** — Endpoint `GET /api/payments/suggest_cheque_number` (sans effet de bord) et service `suggest_cheque_number` côté backend
 - **BIZ-164** — Paramètre `cheque_number_template` dans les réglages (champ `{date}.{seq}` par défaut, validé côté backend)
@@ -23,7 +23,7 @@ Ce projet respecte le [Versionnage sémantique](https://semver.org/lang/fr/).
 ### Amélioré
 - **BIZ-164** — Dialogs pleine largeur sur mobile (`app-dialog`, `app-dialog--medium`, `app-dialog--large`, `app-dialog--xlarge`) : 100 vw et hauteur max 95 dvh en dessous de 767 px
 - **BIZ-164** — Styles utilitaires mobiles ajoutés dans `main.css` : `app-mobile-card-row`, `app-mobile-card-label`, `app-mobile-card-value`, `app-mobile-card-actions`
-- **BIZ-164** — Tuile dépôt espèces : liste de coupures en colonne de droite, total en vert, hauteur automatique, layouts desktop et mobile séparés
+- **BIZ-164** — Tuile dépôt en attente : liste de coupures espèces ou comptage chèques en colonne de droite alignée ; layout desktop (1 ligne, coupures à droite alignées, bouton en bout de ligne) et layout mobile (empilé) séparés
 - **BIZ-164** — Grille de stat cards : 2 colonnes sur mobile
 
 ### Corrigé

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,23 @@ Ce projet respecte le [Versionnage sémantique](https://semver.org/lang/fr/).
 
 ## [Non publié]
 
+### Ajouté
+- **BIZ-164** — Mode téléphone : vue carte mobile sur les listes Factures client, Contacts, Banque (transactions + dépôts), Règlements et Caisse (journal + comptages) — les DataTables laissent place à des cartes empilées sous 767 px
+- **BIZ-164** — Composable `useBreakpoints` (breakpoint 767 px via `window.matchMedia`, avec listener réactif)
+- **BIZ-164** — Composant générique `AppMobileCardList` avec slot `#card="{ item }"`
+- **BIZ-164** — Suggestion automatique du numéro de chèque (`AAAAMMJJ.NN`) à l'ouverture du formulaire de paiement chèque (factures client et fournisseur, assistant saisie rapide) ; modèle de numérotation configurable dans les paramètres
+- **BIZ-164** — Endpoint `GET /api/payments/suggest_cheque_number` (sans effet de bord) et service `suggest_cheque_number` côté backend
+- **BIZ-164** — Paramètre `cheque_number_template` dans les réglages (champ `{date}.{seq}` par défaut, validé côté backend)
+- **BIZ-164** — Migration Alembic `0049` : colonne `cheque_number_template` dans `app_settings`
+
 ### Amélioré
-- **CHR** — Docker : séparation des dépendances Python (`docker-requirements.txt`) et des métadonnées de version (`pyproject.toml`) en deux couches distinctes — évite la réinstallation complète de toutes les dépendances à chaque bump de version
+- **BIZ-164** — Dialogs pleine largeur sur mobile (`app-dialog`, `app-dialog--medium`, `app-dialog--large`, `app-dialog--xlarge`) : 100 vw et hauteur max 95 dvh en dessous de 767 px
+- **BIZ-164** — Styles utilitaires mobiles ajoutés dans `main.css` : `app-mobile-card-row`, `app-mobile-card-label`, `app-mobile-card-value`, `app-mobile-card-actions`
+- **BIZ-164** — Tuile dépôt espèces : liste de coupures en colonne de droite, total en vert, hauteur automatique, layouts desktop et mobile séparés
+- **BIZ-164** — Grille de stat cards : 2 colonnes sur mobile
+
+### Corrigé
+- **BIZ-164** — Mock `window.matchMedia` ajouté dans le setup de tests Vitest pour éviter des erreurs jsdom dans les composants utilisant `useBreakpoints`
 
 ---
 

--- a/backend/alembic/versions/0049_add_cheque_number_template.py
+++ b/backend/alembic/versions/0049_add_cheque_number_template.py
@@ -1,0 +1,32 @@
+"""Migration 0049 — add cheque_number_template to app_settings.
+
+Adds a configurable template for auto-suggesting cheque numbers on payment
+entry. Default format: {date}.{seq} (e.g. 20260503.01).
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0049"
+down_revision: str = "0048"
+branch_labels: Sequence[str] | None = None
+depends_on: Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("app_settings") as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "cheque_number_template",
+                sa.String(100),
+                nullable=False,
+                server_default="{date}.{seq}",
+            )
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("app_settings") as batch_op:
+        batch_op.drop_column("cheque_number_template")

--- a/backend/models/app_settings.py
+++ b/backend/models/app_settings.py
@@ -66,3 +66,8 @@ class AppSettings(Base):
     payment_iban: Mapped[str | None] = mapped_column(String(34), nullable=True)
     payment_bic: Mapped[str | None] = mapped_column(String(11), nullable=True)
     payment_check_payee: Mapped[str | None] = mapped_column(String(255), nullable=True)
+
+    # Cheque numbering
+    cheque_number_template: Mapped[str] = mapped_column(
+        String(100), nullable=False, default="{date}.{seq}"
+    )

--- a/backend/routers/payment.py
+++ b/backend/routers/payment.py
@@ -58,7 +58,9 @@ async def list_payments(
 async def suggest_cheque_number(
     db: Annotated[AsyncSession, Depends(get_db)],
     _current_user: _ReadAccess,
-    payment_date: date = Query(default=None, description="Date du paiement (défaut: aujourd'hui)"),
+    payment_date: date | None = Query(
+        default=None, description="Date du paiement (défaut: aujourd'hui)"
+    ),
 ) -> str:
     """Return the next suggested cheque number for a given date."""
     effective_date = payment_date if payment_date is not None else date.today()

--- a/backend/routers/payment.py
+++ b/backend/routers/payment.py
@@ -12,6 +12,7 @@ from backend.models.user import User, UserRole
 from backend.routers.auth import require_role
 from backend.schemas.payment import PaymentCreate, PaymentRead, PaymentUpdate
 from backend.services import payment as payment_service
+from backend.services import settings as settings_service
 from backend.services.audit_service import AuditAction, record_audit
 
 router = APIRouter(prefix="/payments", tags=["payments"])
@@ -51,6 +52,17 @@ async def list_payments(
         limit=limit,
     )
     return payments
+
+
+@router.get("/suggest_cheque_number", response_model=str)
+async def suggest_cheque_number(
+    db: Annotated[AsyncSession, Depends(get_db)],
+    _current_user: _ReadAccess,
+    payment_date: date = Query(default=None, description="Date du paiement (défaut: aujourd'hui)"),
+) -> str:
+    """Return the next suggested cheque number for a given date."""
+    effective_date = payment_date if payment_date is not None else date.today()
+    return await settings_service.suggest_cheque_number(db, effective_date)
 
 
 @router.post("/", response_model=PaymentRead, status_code=status.HTTP_201_CREATED)

--- a/backend/schemas/settings.py
+++ b/backend/schemas/settings.py
@@ -54,6 +54,9 @@ class AppSettingsRead(BaseModel):
     payment_bic: str | None
     payment_check_payee: str | None
 
+    # Cheque numbering
+    cheque_number_template: str
+
     @model_validator(mode="before")
     @classmethod
     def inject_chat_enabled(cls, data: Any) -> Any:
@@ -112,6 +115,9 @@ class AppSettingsUpdate(BaseModel):
     payment_bic: str | None = None
     payment_check_payee: str | None = None
 
+    # Cheque numbering
+    cheque_number_template: str | None = None
+
     @field_validator("fiscal_year_start_month")
     @classmethod
     def validate_month(cls, v: int | None) -> int | None:
@@ -148,6 +154,16 @@ class AppSettingsUpdate(BaseModel):
                 raise ValueError("client_invoice_number_template must contain {year} and {seq}")
             if _re.search(r"\{(?!year\}|seq\})[^}]*\}", v):
                 raise ValueError("client_invoice_number_template only supports {year} and {seq}")
+        return v
+
+    @field_validator("cheque_number_template")
+    @classmethod
+    def validate_cheque_number_template(cls, v: str | None) -> str | None:
+        if v is not None:
+            if "{seq}" not in v:
+                raise ValueError("cheque_number_template must contain {seq}")
+            if _re.search(r"\{(?!date\}|seq\})[^}]*\}", v):
+                raise ValueError("cheque_number_template only supports {date} and {seq}")
         return v
 
 

--- a/backend/services/settings.py
+++ b/backend/services/settings.py
@@ -613,6 +613,62 @@ async def get_supplier_invoice_number_template(db: AsyncSession) -> str:
     return value or "FF-%Y%m%d%H.%M.%S"
 
 
+async def get_cheque_number_template(db: AsyncSession) -> str:
+    """Return the cheque number template. Default: '{date}.{seq}'."""
+    result = await db.execute(
+        select(AppSettings.cheque_number_template).where(AppSettings.id == _SETTINGS_ID)
+    )
+    value = result.scalar_one_or_none()
+    return value or "{date}.{seq}"
+
+
+async def suggest_cheque_number(db: AsyncSession, payment_date: date) -> str:
+    """Return the next suggested cheque number for *payment_date*.
+
+    Template placeholders:
+      {date} — payment date formatted as YYYYMMDD
+      {seq}  — two-digit counter of cheques already recorded that day + 1
+    """
+    from sqlalchemy import func  # noqa: PLC0415
+
+    from backend.models.payment import Payment, PaymentMethod  # noqa: PLC0415
+
+    template = await get_cheque_number_template(db)
+    date_str = payment_date.strftime("%Y%m%d")
+    filled = template.replace("{date}", date_str)
+    like_pattern = filled.replace("{seq}", "%")
+    seq_regex = re.escape(filled).replace(r"\{seq\}", r"(\d+)")
+
+    result = await db.execute(
+        select(func.count())
+        .select_from(Payment)
+        .where(Payment.method == PaymentMethod.CHEQUE)
+        .where(Payment.date == payment_date)
+    )
+    count: int = result.scalar_one()
+    next_seq = count + 1
+
+    # If there are existing cheques today, find the highest seq already used
+    # to avoid collisions in case of deletions / gaps.
+    if count > 0:
+        rows = await db.execute(
+            select(Payment.cheque_number)
+            .where(Payment.method == PaymentMethod.CHEQUE)
+            .where(Payment.date == payment_date)
+            .where(Payment.cheque_number.like(like_pattern))
+        )
+        max_seq = 0
+        for (cn,) in rows:
+            if cn:
+                m = re.match(f"{seq_regex}$", cn)
+                if m:
+                    max_seq = max(max_seq, int(m.group(1)))
+        if max_seq >= next_seq:
+            next_seq = max_seq + 1
+
+    return filled.replace("{seq}", f"{next_seq:02d}")
+
+
 async def update_settings(db: AsyncSession, payload: AppSettingsUpdate) -> AppSettings:
     """Partially update settings with provided fields."""
     settings = await get_settings(db)

--- a/doc/backlog.md
+++ b/doc/backlog.md
@@ -89,10 +89,10 @@ Créer `en.ts` avec les clés structurelles pour préparer la localisation angla
 | Wizard | Wizard factures & Contacts | v1.2 | BIZ-144, BIZ-145, BIZ-147, BIZ-151 | 2026-05-02 | — | — |
 | CR | Correctifs revue de code | v1.3.1 | TEC-133, TEC-134, TEC-135, TEC-136, TEC-137, TEC-138, TEC-139, TEC-140, TEC-141, TEC-155 | 2026-05-02 | — | — |
 | UI | Améliorations UI & saisie | v1.4 | BIZ-149, BIZ-150, BIZ-157, BIZ-158 | 2026-05-03 | ~65 min | ~30 min |
-| MOB | Mode téléphone | v1.5 | BIZ-164 | 2026-05-03 | ~90 min | — |
+| MOB | Mode téléphone | v1.5 | BIZ-164 | 2026-05-03 | ~90 min | 2026-05-03 |
 
 <details>
-<summary>Lot MOB — Mode téléphone (en cours)</summary>
+<summary>Lot MOB — Mode téléphone (2026-05-03)</summary>
 
 | Ticket | Titre | Est. | Réel | Écart |
 | --- | --- | --- | --- | --- |
@@ -103,7 +103,7 @@ Créer `en.ts` avec les clés structurelles pour préparer la localisation angla
 | **Total** | | **~90 min** | **—** | **—** |
 
 ### BIZ-164 — Mode téléphone & UX mobile
-Migration Alembic `0049` : `cheque_number_template` dans `app_settings`. Endpoint `GET /api/payments/suggest_cheque_number`. Service `suggest_cheque_number` dans `settings.py`. Auto-suggestion dans `ClientInvoicesView`, `SupplierInvoicesView`, `QuickPaymentWizard`. Champ configurable dans `SettingsAssociationPanel`. Vues cartes mobile sur les 5 listes principales via `AppMobileCardList` + `useBreakpoints`. Dialogs full-width mobile. Stat grid 2 colonnes mobile.
+Migration Alembic `0049` : `cheque_number_template` dans `app_settings`. Endpoint `GET /api/payments/suggest_cheque_number`. Service `suggest_cheque_number` dans `settings.py`. Auto-suggestion dans `ClientInvoicesView`, `SupplierInvoicesView`, `QuickPaymentWizard`. Champ configurable dans `SettingsAssociationPanel`. Vues cartes mobile sur **toutes les listes** via `AppMobileCardList` (générique `T`) + `useBreakpoints` : Factures client/fournisseur (historiques), Contacts, Banque (transactions + dépôts), Règlements, Caisse, Salaires (3 tables), Employés, Comptabilité (Comptes, Balance, Bilan, Résultat, Règles, Journal, Grand-livre), Exercices, Utilisateurs. Dialogs full-width mobile. Stat grid 2 colonnes mobile.
 
 </details>
 

--- a/doc/backlog.md
+++ b/doc/backlog.md
@@ -26,7 +26,7 @@ Facteur de marge actuel : **1,00** (0%) — raméné après Lot UI (voir ci-dess
 | ID | Titre | Prio | Est. | Créé | Démarré | Terminé |
 | --- | --- | --- | --- | --- | --- | --- |
 | TEC-156 | Fix token auth chat (localStorage → Pinia) | P1 | — | 2026-05-03 | 2026-05-03 | 2026-05-03 |
-| BIZ-164 | Amélioration UI mode téléphone | P2 | ? | 2026-05-03 | | |
+| BIZ-165 | Navigation précédent/suivant sur preview factures client | P2 | ~10 min | 2026-05-03 | | |
 | CHR-078 | Squelette i18n anglais | P3 | ~15 min | 2026-04-23 | | |
 | BIZ-034 | Support multi-compte banque | P3 | ~60 min | 2026-04-21 | | |
 
@@ -34,14 +34,14 @@ Facteur de marge actuel : **1,00** (0%) — raméné après Lot UI (voir ci-dess
 
 ## Détails
 
+### BIZ-165 — Navigation précédent/suivant sur preview factures client
+
+La preview des factures fournisseur dispose de boutons « ◀ Précédent / Suivant ▶ » permettant de naviguer dans la liste sans fermer le dialogue. Cette fonctionnalité est absente de la preview des factures client. Uniformiser les deux en ajoutant la même navigation dans `ClientInvoicesView.vue` / le composant de prévisualisation des factures client.
+
 ### BIZ-034 — Support multi-compte banque
 
 Distinguer compte courant et compte épargne dans les données, imports et écrans.
 Décisions métier nécessaires avant implémentation.
-
-### BIZ-164 — Amélioration UI mode téléphone
-
-À analyser avant implémentation. L'application est principalement utilisée sur desktop, mais une utilisation occasionnelle sur smartphone est envisageable (consultation, saisie rapide). Périmètre à définir : quelles vues doivent être utilisables sur mobile ? Responsive breakpoints, menus, tableaux, formulaires. Évaluer l'impact sur PrimeVue et les DataTables.
 
 ### TEC-156 — Fix token auth chat (localStorage → Pinia)
 
@@ -89,6 +89,23 @@ Créer `en.ts` avec les clés structurelles pour préparer la localisation angla
 | Wizard | Wizard factures & Contacts | v1.2 | BIZ-144, BIZ-145, BIZ-147, BIZ-151 | 2026-05-02 | — | — |
 | CR | Correctifs revue de code | v1.3.1 | TEC-133, TEC-134, TEC-135, TEC-136, TEC-137, TEC-138, TEC-139, TEC-140, TEC-141, TEC-155 | 2026-05-02 | — | — |
 | UI | Améliorations UI & saisie | v1.4 | BIZ-149, BIZ-150, BIZ-157, BIZ-158 | 2026-05-03 | ~65 min | ~30 min |
+| MOB | Mode téléphone | v1.5 | BIZ-164 | 2026-05-03 | ~90 min | — |
+
+<details>
+<summary>Lot MOB — Mode téléphone (en cours)</summary>
+
+| Ticket | Titre | Est. | Réel | Écart |
+| --- | --- | --- | --- | --- |
+| BIZ-164 (mobile) | Vues cartes + composant + breakpoint | ~50 min | — | — |
+| BIZ-164 (depot) | Tuile dépôt espèces redesignée | ~15 min | — | — |
+| BIZ-164 (stat) | Stat cards 2 colonnes mobile | ~5 min | — | — |
+| BIZ-164 (cheque) | Suggestion auto n° chèque | ~20 min | — | — |
+| **Total** | | **~90 min** | **—** | **—** |
+
+### BIZ-164 — Mode téléphone & UX mobile
+Migration Alembic `0049` : `cheque_number_template` dans `app_settings`. Endpoint `GET /api/payments/suggest_cheque_number`. Service `suggest_cheque_number` dans `settings.py`. Auto-suggestion dans `ClientInvoicesView`, `SupplierInvoicesView`, `QuickPaymentWizard`. Champ configurable dans `SettingsAssociationPanel`. Vues cartes mobile sur les 5 listes principales via `AppMobileCardList` + `useBreakpoints`. Dialogs full-width mobile. Stat grid 2 colonnes mobile.
+
+</details>
 
 <details>
 <summary>Lot UI — Améliorations UI & saisie (2026-05-03)</summary>

--- a/doc/backlog.md
+++ b/doc/backlog.md
@@ -26,6 +26,9 @@ Facteur de marge actuel : **1,00** (0%) — raméné après Lot UI (voir ci-dess
 | ID | Titre | Prio | Est. | Créé | Démarré | Terminé |
 | --- | --- | --- | --- | --- | --- | --- |
 | TEC-156 | Fix token auth chat (localStorage → Pinia) | P1 | — | 2026-05-03 | 2026-05-03 | 2026-05-03 |
+| TEC-157 | i18n : supprimer chaînes en dur dans AppMobileCardList + CashView | P3 | ~10 min | 2026-05-03 | | |
+| TEC-158 | Tests intégration suggest_cheque_number (statut, date, incrément, accès) | P2 | ~20 min | 2026-05-03 | | |
+| TEC-159 | Tests validation cheque_number_template dans settings API | P2 | ~15 min | 2026-05-03 | | |
 | BIZ-165 | Navigation précédent/suivant sur preview factures client | P2 | ~10 min | 2026-05-03 | | |
 | CHR-078 | Squelette i18n anglais | P3 | ~15 min | 2026-04-23 | | |
 | BIZ-034 | Support multi-compte banque | P3 | ~60 min | 2026-04-21 | | |
@@ -50,6 +53,18 @@ Décisions métier nécessaires avant implémentation.
 ### CHR-078 — Squelette i18n anglais
 
 Créer `en.ts` avec les clés structurelles pour préparer la localisation anglaise.
+
+### TEC-157 — i18n : supprimer chaînes en dur dans AppMobileCardList + CashView
+
+Suite à la revue Copilot de la PR #76 : `emptyMessage: 'Aucune donnée'` dans `AppMobileCardList.vue` et `"Écart :"` dans `CashView.vue` sont des chaînes UI codées en dur. Les remplacer par des clés i18n (ou exposer via slot `#empty`), cohérent avec le reste de l'app.
+
+### TEC-158 — Tests intégration suggest_cheque_number
+
+Suite à la revue Copilot de la PR #76 : l'endpoint `GET /api/payments/suggest_cheque_number` n'a pas de tests dans `tests/integration/test_payments_api.py`. Couvrir : statut 200 + format de retour, `payment_date` explicite vs défaut, incrément quand des paiements chèque existent, contrôle d'accès.
+
+### TEC-159 — Tests validation cheque_number_template dans settings API
+
+Suite à la revue Copilot de la PR #76 : `cheque_number_template` dans `AppSettingsUpdate` n'est pas testé dans `tests/integration/test_settings_api.py`. Couvrir : valeur par défaut renvoyée par `GET /api/settings/`, cas invalides (sans `{seq}`, placeholders non supportés).
 
 ---
 

--- a/doc/user/changelog-user.md
+++ b/doc/user/changelog-user.md
@@ -4,6 +4,34 @@ Ce document présente les changements visibles dans l'application, version par v
 
 ---
 
+## Version 1.4.3 *(à venir)*
+
+### Tous les utilisateurs
+
+#### Saisie des règlements
+- Lorsque le mode de paiement **chèque** est sélectionné, le numéro de chèque est **suggéré automatiquement** au format `AAAAMMJJ.NN` (exemple : `20260504.01`). Le numéro reste modifiable avant validation.
+
+### Administrateur
+
+#### Paramètres
+- Le **modèle de numérotation des chèques** est configurable dans les réglages (section Règlements). Par défaut : `{date}.{seq}` — les variables `{date}` et `{seq}` sont décrites dans l'aide en ligne.
+
+---
+
+## Version 1.4.2 *(à venir)*
+
+### Tous les utilisateurs
+
+#### Mode téléphone
+- Les principales listes (factures client et fournisseur, contacts, transactions bancaires, dépôts, règlements, caisse) s'affichent en **vue cartes** sur les petits écrans, plus lisibles que les tableaux.
+- Les fenêtres de dialogue s'adaptent automatiquement à la largeur de l'écran sur mobile.
+- Les **cartes de synthèse** (indicateurs chiffrés) s'affichent sur **2 colonnes** sur mobile.
+
+#### Tableau de bord — Dépôts en attente
+- Les détails du contenu d'un dépôt espèces (détail des coupures) sont affichés directement sur chaque dépôt en attente.
+
+---
+
 ## Version 1.4.0 — 3 mai 2026
 
 ### Tous les utilisateurs

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.4.1",
+  "version": "1.4.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/frontend/src/api/payments.ts
+++ b/frontend/src/api/payments.ts
@@ -75,3 +75,9 @@ export async function updatePayment(id: number, payload: PaymentUpdate): Promise
 export async function deletePayment(id: number): Promise<void> {
   await apiClient.delete(`/api/payments/${id}`)
 }
+
+export async function suggestChequeNumber(paymentDate?: string): Promise<string> {
+  const params = paymentDate ? { payment_date: paymentDate } : {}
+  const response = await apiClient.get<string>('/api/payments/suggest_cheque_number', { params })
+  return response.data
+}

--- a/frontend/src/api/settings.ts
+++ b/frontend/src/api/settings.ts
@@ -27,6 +27,7 @@ export interface AppSettings {
   payment_iban: string | null
   payment_bic: string | null
   payment_check_payee: string | null
+  cheque_number_template: string
 }
 
 export interface AppSettingsUpdate {
@@ -56,6 +57,7 @@ export interface AppSettingsUpdate {
   payment_iban?: string | null
   payment_bic?: string | null
   payment_check_payee?: string | null
+  cheque_number_template?: string | null
 }
 
 export interface SystemOpening {

--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -188,6 +188,8 @@ textarea {
   flex-direction: column;
   gap: var(--app-space-2);
   min-height: 132px;
+  min-width: 0;
+  overflow: hidden;
 }
 
 .app-stat-card--success {
@@ -245,6 +247,8 @@ a.app-stat-card {
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
+  overflow-wrap: break-word;
+  word-break: break-word;
 }
 
 .app-stat-card__value {
@@ -252,6 +256,9 @@ a.app-stat-card {
   font-size: clamp(1.4rem, 1vw + 1rem, 2rem);
   font-weight: 800;
   letter-spacing: -0.04em;
+  overflow-wrap: break-word;
+  word-break: break-word;
+  min-width: 0;
 }
 
 .app-stat-card__caption {
@@ -611,6 +618,19 @@ html.dark-mode .app-chip {
     gap: var(--app-space-5);
   }
 
+  .app-stat-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .app-stat-card {
+    padding: var(--app-space-3) var(--app-space-4);
+    min-height: unset;
+  }
+
+  .app-stat-card__value {
+    font-size: clamp(1rem, 5vw, 1.35rem);
+  }
+
   .app-panel__header,
   .app-panel__body {
     padding-left: var(--app-space-4);
@@ -623,5 +643,52 @@ html.dark-mode .app-chip {
 
   .app-field--span-2 {
     grid-column: auto;
+  }
+
+  /* Dialogs take the full viewport width on mobile */
+  .app-dialog,
+  .app-dialog--medium,
+  .app-dialog--large,
+  .app-dialog--xlarge {
+    width: 100vw !important;
+    max-width: 100vw !important;
+    max-height: 95dvh;
+    margin: 0;
+    border-radius: var(--p-border-radius-md, 6px) var(--p-border-radius-md, 6px) 0 0;
+  }
+
+  .app-dialog .p-dialog-content,
+  .app-dialog--medium .p-dialog-content,
+  .app-dialog--large .p-dialog-content,
+  .app-dialog--xlarge .p-dialog-content {
+    overflow-y: auto;
+  }
+
+  /* Mobile card rows for view-level badges / meta lines */
+  .app-mobile-card-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+  }
+
+  .app-mobile-card-row--between {
+    justify-content: space-between;
+  }
+
+  .app-mobile-card-label {
+    font-size: 0.78rem;
+    color: var(--p-text-muted-color);
+  }
+
+  .app-mobile-card-value {
+    font-size: 0.9rem;
+  }
+
+  .app-mobile-card-actions {
+    display: flex;
+    gap: 0.4rem;
+    flex-wrap: wrap;
+    margin-top: 0.25rem;
   }
 }

--- a/frontend/src/components/ContactHistoryContent.vue
+++ b/frontend/src/components/ContactHistoryContent.vue
@@ -61,8 +61,41 @@
           @click="resetInvoiceFilters"
         />
       </template>
+      <AppMobileCardList
+        v-if="isMobile && history.invoices.length"
+        :items="invoiceRows"
+        :empty-message="t('contact_history.no_invoices')"
+      >
+        <template #card="{ item: data }">
+          <div class="app-mobile-card-row app-mobile-card-row--between">
+            <span class="app-mobile-card-value" style="font-weight:700">{{ data.number }}</span>
+            <Tag
+              :value="t(`invoices.statuses.${data.status}`)"
+              :severity="statusSeverity(data.status)"
+            />
+          </div>
+          <div class="app-mobile-card-row app-mobile-card-row--between">
+            <span class="app-mobile-card-label">{{ formatDisplayDate(data.date) }}</span>
+            <span class="app-mobile-card-value" style="font-weight:600">{{ fmt(data.total_amount) }} €</span>
+          </div>
+          <div v-if="Number(data.balance_due) > 0" class="app-mobile-card-row app-mobile-card-row--between">
+            <span class="app-mobile-card-label">{{ t('contact_history.total_due') }} :</span>
+            <span class="app-mobile-card-value contact-history-due">{{ fmt(data.balance_due) }} €</span>
+          </div>
+          <div class="app-mobile-card-actions">
+            <Button
+              icon="pi pi-eye"
+              size="small"
+              severity="secondary"
+              text
+              :title="t('contact_history.view_invoice')"
+              @click.stop="openInvoiceDetail(data)"
+            />
+          </div>
+        </template>
+      </AppMobileCardList>
       <DataTable
-        v-if="history.invoices.length"
+        v-else-if="history.invoices.length"
         v-model:filters="invoiceTableFilters"
         :value="invoiceRows"
         class="app-data-table"
@@ -196,8 +229,38 @@
           @click="resetPaymentFilters"
         />
       </template>
+      <AppMobileCardList
+        v-if="isMobile && history.payments.length"
+        :items="paymentRows"
+        :empty-message="t('contact_history.no_payments')"
+      >
+        <template #card="{ item: data }">
+          <div class="app-mobile-card-row app-mobile-card-row--between">
+            <span class="app-mobile-card-label">{{ formatDisplayDate(data.date) }}</span>
+            <span class="app-mobile-card-value" style="font-weight:700">{{ fmt(data.amount) }} €</span>
+          </div>
+          <div class="app-mobile-card-row">
+            <span class="app-mobile-card-label">{{ t('payments.method') }} :</span>
+            <span class="app-mobile-card-value">{{ t(`payments.methods.${data.method}`) }}</span>
+          </div>
+          <div v-if="data.invoice_number" class="app-mobile-card-row">
+            <span class="app-mobile-card-label">{{ t('payments.invoice') }} :</span>
+            <span class="app-mobile-card-value">{{ data.invoice_number }}</span>
+          </div>
+          <div class="app-mobile-card-actions">
+            <Button
+              icon="pi pi-eye"
+              size="small"
+              severity="secondary"
+              text
+              :title="t('contact_history.view_payment')"
+              @click.stop="openPaymentDetail(data)"
+            />
+          </div>
+        </template>
+      </AppMobileCardList>
       <DataTable
-        v-if="history.payments.length"
+        v-else-if="history.payments.length"
         v-model:filters="paymentTableFilters"
         :value="paymentRows"
         class="app-data-table"
@@ -572,6 +635,7 @@ import AppFilterMultiSelect from './ui/AppFilterMultiSelect.vue'
 import AppNumberRangeFilter from './ui/AppNumberRangeFilter.vue'
 import AppPanel from './ui/AppPanel.vue'
 import AppStatCard from './ui/AppStatCard.vue'
+import AppMobileCardList from './ui/AppMobileCardList.vue'
 import AppTableSkeleton from './ui/AppTableSkeleton.vue'
 import { getContactHistoryApi, markCreanceDouteuse } from '../api/accounting'
 import type { ContactHistory, ContactInvoiceSummary, ContactPaymentSummary } from '../api/accounting'
@@ -587,12 +651,14 @@ import {
   useDataTableFilters,
 } from '../composables/useDataTableFilters'
 import { formatDisplayDate } from '@/utils/format'
+import { useBreakpoints } from '../composables/useBreakpoints'
 import InvoiceEmailDialog from './InvoiceEmailDialog.vue'
 
 const props = defineProps<{ contactId: number }>()
 const emit = defineEmits<{ 'contact-loaded': [name: string] }>()
 
 const { t } = useI18n()
+const { isMobile } = useBreakpoints()
 const confirm = useConfirm()
 const toast = useToast()
 

--- a/frontend/src/components/QuickPaymentWizard.vue
+++ b/frontend/src/components/QuickPaymentWizard.vue
@@ -20,6 +20,35 @@
         {{ t('dashboard.payment_wizard.invoice_empty') }}
       </div>
 
+      <template v-else-if="isMobile">
+        <AppMobileCardList :items="invoiceRows" :empty-message="t('dashboard.payment_wizard.invoice_empty')">
+          <template #card="{ item: data }">
+            <div class="app-mobile-card-row app-mobile-card-row--between">
+              <span class="app-mobile-card-value" style="font-weight:700">{{ data.number }}</span>
+              <span
+                class="app-mobile-card-value"
+                :class="data.overdue ? 'qpw-overdue' : ''"
+                style="font-weight:600"
+              >{{ data.remaining.toFixed(2) }} €</span>
+            </div>
+            <div class="app-mobile-card-row">
+              <span class="app-mobile-card-value">{{ data.contact_name }}</span>
+            </div>
+            <div class="app-mobile-card-row">
+              <span class="app-mobile-card-label">{{ t('dashboard.payment_wizard.col_date') }} :</span>
+              <span class="app-mobile-card-value">{{ formatDate(data.date) }}</span>
+            </div>
+            <div class="app-mobile-card-actions">
+              <Button
+                :label="t('dashboard.payment_wizard.choose')"
+                size="small"
+                @click="selectInvoice(data.raw)"
+              />
+            </div>
+          </template>
+        </AppMobileCardList>
+      </template>
+
       <DataTable
         v-else
         :value="invoiceRows"
@@ -165,16 +194,19 @@ import InputText from 'primevue/inputtext'
 import Select from 'primevue/select'
 import Textarea from 'primevue/textarea'
 import AppDatePicker from './ui/AppDatePicker.vue'
+import AppMobileCardList from './ui/AppMobileCardList.vue'
 import { listInvoicesApi, type Invoice } from '../api/invoices'
 import { listContactsApi, type Contact } from '../api/contacts'
 import { createPayment, suggestChequeNumber } from '../api/payments'
 import { remainingForInvoice, isOverdueInvoice } from '../composables/useInvoiceMetrics'
+import { useBreakpoints } from '../composables/useBreakpoints'
 import { formatContactDisplayName } from '../utils/contact'
 
 const props = defineProps<{ visible: boolean }>()
 const emit = defineEmits<{ (e: 'update:visible', v: boolean): void }>()
 
 const { t } = useI18n()
+const { isMobile } = useBreakpoints()
 
 // ── state ──────────────────────────────────────────────────────────────────
 const step = ref<1 | 2 | 3>(1)

--- a/frontend/src/components/QuickPaymentWizard.vue
+++ b/frontend/src/components/QuickPaymentWizard.vue
@@ -167,7 +167,7 @@ import Textarea from 'primevue/textarea'
 import AppDatePicker from './ui/AppDatePicker.vue'
 import { listInvoicesApi, type Invoice } from '../api/invoices'
 import { listContactsApi, type Contact } from '../api/contacts'
-import { createPayment } from '../api/payments'
+import { createPayment, suggestChequeNumber } from '../api/payments'
 import { remainingForInvoice, isOverdueInvoice } from '../composables/useInvoiceMetrics'
 import { formatContactDisplayName } from '../utils/contact'
 
@@ -273,6 +273,11 @@ function selectInvoice(invoice: Invoice) {
     reference: '',
     notes: '',
   }
+  void suggestChequeNumber().then((n) => {
+    if (form.value.method === 'cheque' && !form.value.cheque_number) {
+      form.value.cheque_number = n
+    }
+  })
   step.value = 2
 }
 

--- a/frontend/src/components/settings/SettingsAssociationPanel.vue
+++ b/frontend/src/components/settings/SettingsAssociationPanel.vue
@@ -210,6 +210,16 @@
           />
           <small class="app-field__hint">{{ t('settings.payment_instructions_help') }}</small>
         </div>
+        <div class="app-field app-field--full">
+          <label for="cheque_number_template" class="app-field__label">{{ t('settings.cheque_number_template') }}</label>
+          <InputText
+            id="cheque_number_template"
+            v-model="form.cheque_number_template"
+            :placeholder="t('settings.cheque_number_template_placeholder')"
+            class="w-full"
+          />
+          <small class="app-field__hint">{{ t('settings.cheque_number_template_help') }}</small>
+        </div>
       </div>
     </AppPanel>
 
@@ -262,6 +272,7 @@ interface AssociationForm {
   payment_iban: string
   payment_bic: string
   payment_check_payee: string
+  cheque_number_template: string
 }
 
 const monthFormatter = new Intl.DateTimeFormat('fr-FR', { month: 'long' })
@@ -285,6 +296,7 @@ const defaultForm = (): AssociationForm => ({
   payment_iban: '',
   payment_bic: '',
   payment_check_payee: '',
+  cheque_number_template: '{date}.{seq}',
 })
 
 const form = ref<AssociationForm>(defaultForm())
@@ -310,6 +322,7 @@ async function load(): Promise<void> {
       payment_iban: data.payment_iban ?? '',
       payment_bic: data.payment_bic ?? '',
       payment_check_payee: data.payment_check_payee ?? '',
+      cheque_number_template: data.cheque_number_template ?? '{date}.{seq}',
     }
   } catch {
     errorMessage.value = t('common.error.unknown')
@@ -336,6 +349,7 @@ async function save(): Promise<void> {
       payment_iban: form.value.payment_iban || null,
       payment_bic: form.value.payment_bic || null,
       payment_check_payee: form.value.payment_check_payee || null,
+      cheque_number_template: form.value.cheque_number_template || '{date}.{seq}',
     })
     successMessage.value = t('settings.saved')
   } catch {

--- a/frontend/src/components/ui/AppMobileCardList.vue
+++ b/frontend/src/components/ui/AppMobileCardList.vue
@@ -2,7 +2,7 @@
   <div class="app-mobile-card-list">
     <div
       v-for="(item, index) in items"
-      :key="index"
+      :key="itemKey ? itemKey(item, index) : index"
       class="app-mobile-card"
     >
       <slot name="card" :item="item" :index="index" />
@@ -20,9 +20,11 @@ withDefaults(
   defineProps<{
     items: T[]
     emptyMessage?: string
+    itemKey?: (item: T, index: number) => string | number
   }>(),
   {
     emptyMessage: 'Aucune donnée',
+    itemKey: undefined,
   },
 )
 defineSlots<{

--- a/frontend/src/components/ui/AppMobileCardList.vue
+++ b/frontend/src/components/ui/AppMobileCardList.vue
@@ -1,0 +1,53 @@
+<template>
+  <div class="app-mobile-card-list">
+    <div
+      v-for="(item, index) in items"
+      :key="index"
+      class="app-mobile-card"
+    >
+      <slot name="card" :item="item" :index="index" />
+    </div>
+    <div v-if="items.length === 0" class="app-mobile-card-list__empty">
+      <slot name="empty">
+        <span>{{ emptyMessage }}</span>
+      </slot>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+withDefaults(
+  defineProps<{
+    items: unknown[]
+    emptyMessage?: string
+  }>(),
+  {
+    emptyMessage: 'Aucune donnée',
+  },
+)
+</script>
+
+<style scoped>
+.app-mobile-card-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.app-mobile-card {
+  background: var(--app-surface-bg);
+  border: 1px solid var(--app-surface-border);
+  border-radius: var(--p-border-radius-md, 6px);
+  padding: 0.75rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.app-mobile-card-list__empty {
+  text-align: center;
+  color: var(--p-text-muted-color);
+  padding: 2rem 1rem;
+  font-size: 0.9rem;
+}
+</style>

--- a/frontend/src/components/ui/AppMobileCardList.vue
+++ b/frontend/src/components/ui/AppMobileCardList.vue
@@ -15,16 +15,20 @@
   </div>
 </template>
 
-<script setup lang="ts">
+<script setup lang="ts" generic="T = unknown">
 withDefaults(
   defineProps<{
-    items: unknown[]
+    items: T[]
     emptyMessage?: string
   }>(),
   {
     emptyMessage: 'Aucune donnée',
   },
 )
+defineSlots<{
+  card(props: { item: T; index: number }): unknown
+  empty(): unknown
+}>()
 </script>
 
 <style scoped>

--- a/frontend/src/composables/useBreakpoints.ts
+++ b/frontend/src/composables/useBreakpoints.ts
@@ -1,0 +1,29 @@
+import { ref, onMounted, onUnmounted } from 'vue'
+
+const MOBILE_BREAKPOINT = 767
+
+/**
+ * Returns a reactive `isMobile` ref that is true when the viewport width
+ * is ≤ 767px. Uses matchMedia for efficient listening without polling.
+ */
+export function useBreakpoints() {
+  const isMobile = ref(false)
+
+  let mediaQuery: MediaQueryList | null = null
+
+  function handleChange(event: MediaQueryListEvent) {
+    isMobile.value = event.matches
+  }
+
+  onMounted(() => {
+    mediaQuery = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT}px)`)
+    isMobile.value = mediaQuery.matches
+    mediaQuery.addEventListener('change', handleChange)
+  })
+
+  onUnmounted(() => {
+    mediaQuery?.removeEventListener('change', handleChange)
+  })
+
+  return { isMobile }
+}

--- a/frontend/src/i18n/fr.ts
+++ b/frontend/src/i18n/fr.ts
@@ -945,6 +945,10 @@ export default {
     payment_check_payee_placeholder: "Nom de l'association bénéficiaire",
     payment_instructions_help:
       'Laissez un champ vide pour ne pas afficher la ligne correspondante sur les factures.',
+    cheque_number_template: 'Modèle de numérotation — chèque',
+    cheque_number_template_placeholder: '{date}.{seq}',
+    cheque_number_template_help:
+      'Variables disponibles : {date} (date AAAAMMJJ), {seq} (séquence à 2 chiffres). {seq} est obligatoire.',
     section_chat: 'Assistant IA',
     section_chat_subtitle: 'Configurez le fournisseur et la clé API pour activer le chatbot.',
     chat_provider: 'Fournisseur',

--- a/frontend/src/tests/setup.ts
+++ b/frontend/src/tests/setup.ts
@@ -34,3 +34,19 @@ Object.defineProperty(globalThis, 'localStorage', {
   writable: true,
   configurable: true,
 })
+
+// Mock window.matchMedia for composables that use it (e.g. useBreakpoints)
+Object.defineProperty(globalThis, 'matchMedia', {
+  writable: true,
+  configurable: true,
+  value: (query: string): MediaQueryList => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  }),
+})

--- a/frontend/src/tests/views/ClientInvoicesView.spec.ts
+++ b/frontend/src/tests/views/ClientInvoicesView.spec.ts
@@ -60,6 +60,7 @@ vi.mock('../../api/invoices', () => ({
 vi.mock('../../api/payments', () => ({
   listPayments: vi.fn(),
   createPayment: vi.fn(),
+  suggestChequeNumber: vi.fn().mockResolvedValue('20250101.01'),
 }))
 
 import ClientInvoicesView from '../../views/ClientInvoicesView.vue'

--- a/frontend/src/tests/views/SupplierInvoicesView.spec.ts
+++ b/frontend/src/tests/views/SupplierInvoicesView.spec.ts
@@ -59,17 +59,19 @@ vi.mock('../../api/invoices', () => ({
 vi.mock('../../api/payments', () => ({
   listPayments: vi.fn(),
   createPayment: vi.fn(),
+  suggestChequeNumber: vi.fn().mockResolvedValue('20250101.01'),
 }))
 
 import SupplierInvoicesView from '../../views/SupplierInvoicesView.vue'
 import { listContactsApi } from '../../api/contacts'
 import { listInvoicesApi } from '../../api/invoices'
-import { createPayment, listPayments } from '../../api/payments'
+import { createPayment, listPayments, suggestChequeNumber } from '../../api/payments'
 
 const mockListContactsApi = vi.mocked(listContactsApi)
 const mockListInvoicesApi = vi.mocked(listInvoicesApi)
 const mockListPayments = vi.mocked(listPayments)
 const mockCreatePayment = vi.mocked(createPayment)
+const mockSuggestChequeNumber = vi.mocked(suggestChequeNumber)
 
 const invoiceFixture = {
   id: 1,
@@ -410,6 +412,9 @@ describe('SupplierInvoicesView — payment dialog', () => {
   })
 
   it('requires a cheque number when method is cheque', async () => {
+    // override: suggestion returns empty so the field stays empty
+    mockSuggestChequeNumber.mockResolvedValueOnce('')
+
     const wrapper = mountView()
     await flushView()
 
@@ -419,7 +424,7 @@ describe('SupplierInvoicesView — payment dialog', () => {
     await paymentButton!.trigger('click')
     await flushView()
 
-    // method is 'cheque' by default, cheque_number is empty — submit should be blocked
+    // method is 'cheque', cheque_number is empty — submit should be blocked
     const paymentForm = wrapper.findAll('form').at(-1)!
     await paymentForm.trigger('submit')
     await flushView()

--- a/frontend/src/views/AccountingAccountsView.vue
+++ b/frontend/src/views/AccountingAccountsView.vue
@@ -59,7 +59,35 @@
           </div>
         </div>
       </div>
+      <template v-if="isMobile">
+        <AppMobileCardList :items="accountRows" :empty-message="t('accounting.balance.empty')">
+          <template #card="{ item: data }">
+            <div class="app-mobile-card-row app-mobile-card-row--between">
+              <span class="app-mobile-card-value" style="font-weight:700">
+                <span :class="{ 'account-number--focus': data.focus_key }">{{ data.number }}</span>
+              </span>
+              <Tag
+                :value="t(`accounting.account_types.${data.type}`)"
+                :severity="typeSeverity(data.type)"
+              />
+            </div>
+            <div class="app-mobile-card-row">
+              <span class="app-mobile-card-value">{{ data.label }}</span>
+            </div>
+            <div class="app-mobile-card-actions">
+              <Button
+                icon="pi pi-pencil"
+                size="small"
+                severity="secondary"
+                text
+                @click="openEditDialog(data)"
+              />
+            </div>
+          </template>
+        </AppMobileCardList>
+      </template>
       <DataTable
+        v-else
         v-model:filters="tableFilters"
         :value="accountRows"
         :row-class="rowClass"
@@ -200,6 +228,7 @@ import { computed, onMounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import AppFilterMultiSelect from '@/components/ui/AppFilterMultiSelect.vue'
 import AppListState from '@/components/ui/AppListState.vue'
+import AppMobileCardList from '@/components/ui/AppMobileCardList.vue'
 import AppPage from '@/components/ui/AppPage.vue'
 import AppPageHeader from '@/components/ui/AppPageHeader.vue'
 import AppPanel from '@/components/ui/AppPanel.vue'
@@ -215,9 +244,11 @@ import {
   findSelectedFilterLabel,
 } from '../composables/activeFilterLabels'
 import { inFilter, textFilter, useDataTableFilters } from '../composables/useDataTableFilters'
+import { useBreakpoints } from '../composables/useBreakpoints'
 import { getFocusAccountKey, type FocusAccountKey } from '../utils/focusAccounts'
 
 const { t } = useI18n()
+const { isMobile } = useBreakpoints()
 const toast = useToast()
 
 const accounts = ref<AccountingAccount[]>([])

--- a/frontend/src/views/AccountingBalanceView.vue
+++ b/frontend/src/views/AccountingBalanceView.vue
@@ -64,7 +64,37 @@
         </div>
       </div>
 
+      <template v-if="isMobile">
+        <AppMobileCardList :items="balanceRows" :empty-message="t('accounting.balance.empty')">
+          <template #card="{ item: data }">
+            <div class="app-mobile-card-row app-mobile-card-row--between">
+              <span
+                class="app-mobile-card-value"
+                style="font-weight:700"
+                :class="{ 'balance-account-number--focus': data.focus_key }"
+              >{{ data.account_number }}</span>
+              <span class="app-mobile-card-value">{{ t(`accounting.account_types.${data.account_type}`) }}</span>
+            </div>
+            <div class="app-mobile-card-row">
+              <span class="app-mobile-card-value">{{ data.account_label }}</span>
+            </div>
+            <div class="app-mobile-card-row app-mobile-card-row--between">
+              <span class="app-mobile-card-label">{{ t('accounting.balance.total_debit') }}</span>
+              <span class="app-mobile-card-value">{{ data.total_debit_value.toFixed(2) }}</span>
+            </div>
+            <div class="app-mobile-card-row app-mobile-card-row--between">
+              <span class="app-mobile-card-label">{{ t('accounting.balance.total_credit') }}</span>
+              <span class="app-mobile-card-value">{{ data.total_credit_value.toFixed(2) }}</span>
+            </div>
+            <div class="app-mobile-card-row app-mobile-card-row--between">
+              <span class="app-mobile-card-label">{{ t('accounting.balance.solde') }}</span>
+              <span class="app-mobile-card-value" style="font-weight:600">{{ formatAccountingAmount(data.solde_value) }}</span>
+            </div>
+          </template>
+        </AppMobileCardList>
+      </template>
       <DataTable
+        v-else
         v-model:filters="tableFilters"
         :value="balanceRows"
         :row-class="rowClass"
@@ -194,6 +224,7 @@ import InputText from 'primevue/inputtext'
 import Select from 'primevue/select'
 import AppDateInput from '../components/ui/AppDateInput.vue'
 import AppFilterMultiSelect from '../components/ui/AppFilterMultiSelect.vue'
+import AppMobileCardList from '../components/ui/AppMobileCardList.vue'
 import AppNumberRangeFilter from '../components/ui/AppNumberRangeFilter.vue'
 import AppPage from '../components/ui/AppPage.vue'
 import AppPageHeader from '../components/ui/AppPageHeader.vue'
@@ -205,6 +236,7 @@ import {
   textFilter,
   useDataTableFilters,
 } from '../composables/useDataTableFilters'
+import { useBreakpoints } from '../composables/useBreakpoints'
 import { useFiscalYearStore } from '../stores/fiscalYear'
 import { focusAccounts, getFocusAccountKey, type FocusAccountKey } from '../utils/focusAccounts'
 import { formatAccountingAmount } from '../utils/format'
@@ -218,6 +250,7 @@ type BalanceRowView = BalanceRow & {
 }
 
 const { t } = useI18n()
+const { isMobile } = useBreakpoints()
 const fiscalYearStore = useFiscalYearStore()
 
 const rows = ref<BalanceRow[]>([])

--- a/frontend/src/views/AccountingBilanView.vue
+++ b/frontend/src/views/AccountingBilanView.vue
@@ -28,7 +28,21 @@
     <div v-else-if="bilan" class="bilan-grid">
       <!-- Actif -->
       <AppPanel :title="t('bilan.actif')" dense>
+        <template v-if="isMobile">
+          <AppMobileCardList :items="bilan.actif" :empty-message="t('bilan.empty')">
+            <template #card="{ item: data }">
+              <div class="app-mobile-card-row app-mobile-card-row--between">
+                <span class="app-mobile-card-value" style="font-weight:700">{{ data.account_number }}</span>
+                <span class="app-mobile-card-value" style="font-weight:600">{{ formatAccountingAmount(data.solde) }} €</span>
+              </div>
+              <div class="app-mobile-card-row">
+                <span class="app-mobile-card-value">{{ data.account_label }}</span>
+              </div>
+            </template>
+          </AppMobileCardList>
+        </template>
         <DataTable
+          v-else
           :value="bilan.actif"
           class="app-data-table"
           striped-rows
@@ -60,7 +74,21 @@
 
       <!-- Passif -->
       <AppPanel :title="t('bilan.passif')" dense>
+        <template v-if="isMobile">
+          <AppMobileCardList :items="bilan.passif" :empty-message="t('bilan.empty')">
+            <template #card="{ item: data }">
+              <div class="app-mobile-card-row app-mobile-card-row--between">
+                <span class="app-mobile-card-value" style="font-weight:700">{{ data.account_number }}</span>
+                <span class="app-mobile-card-value" style="font-weight:600">{{ formatAccountingAmount(data.solde) }} €</span>
+              </div>
+              <div class="app-mobile-card-row">
+                <span class="app-mobile-card-value">{{ data.account_label }}</span>
+              </div>
+            </template>
+          </AppMobileCardList>
+        </template>
         <DataTable
+          v-else
           :value="bilan.passif"
           class="app-data-table"
           striped-rows
@@ -110,15 +138,18 @@ import Column from 'primevue/column'
 import DataTable from 'primevue/datatable'
 import Select from 'primevue/select'
 import AppTableSkeleton from '../components/ui/AppTableSkeleton.vue'
+import AppMobileCardList from '../components/ui/AppMobileCardList.vue'
 import AppPage from '../components/ui/AppPage.vue'
 import AppPageHeader from '../components/ui/AppPageHeader.vue'
 import AppPanel from '../components/ui/AppPanel.vue'
 import { getBilanApi, getExportCsvUrl } from '../api/accounting'
 import type { BilanRead } from '../api/accounting'
 import { useFiscalYearStore } from '../stores/fiscalYear'
+import { useBreakpoints } from '../composables/useBreakpoints'
 import { formatAccountingAmount } from '../utils/format'
 
 const { t } = useI18n()
+const { isMobile } = useBreakpoints()
 const fiscalYearStore = useFiscalYearStore()
 
 const bilan = ref<BilanRead | null>(null)

--- a/frontend/src/views/AccountingJournalView.vue
+++ b/frontend/src/views/AccountingJournalView.vue
@@ -126,6 +126,53 @@
       </div>
 
       <AppTableSkeleton v-if="loading && !groups.length" :rows="8" :cols="5" />
+      <template v-else-if="isMobile">
+        <AppMobileCardList :items="journalRows" :empty-message="t('accounting.journal.empty')">
+          <template #card="{ item: data }">
+            <div class="app-mobile-card-row app-mobile-card-row--between">
+              <span class="app-mobile-card-value">{{ formatDisplayDate(data.date) }}</span>
+              <Tag
+                v-if="data.source_type"
+                :value="t(`accounting.journal.sources.${data.source_type}`)"
+                :severity="sourceSeverity(data.source_type)"
+              />
+              <span v-else>{{ t('accounting.journal.sources.manual') }}</span>
+            </div>
+            <div class="app-mobile-card-row">
+              <span class="app-mobile-card-value" style="font-weight:600">{{ data.label }}</span>
+            </div>
+            <div v-if="data.source_contact_name" class="app-mobile-card-row">
+              <span class="app-mobile-card-label">{{ t('accounting.journal.contact') }}</span>
+              <span class="app-mobile-card-value">{{ data.source_contact_name }}</span>
+            </div>
+            <div class="app-mobile-card-row app-mobile-card-row--between">
+              <span class="app-mobile-card-label">{{ t('accounting.journal.debit') }}</span>
+              <span class="app-mobile-card-value">{{ formatEntryAmount(data.total_debit) }}</span>
+            </div>
+            <div class="app-mobile-card-row app-mobile-card-row--between">
+              <span class="app-mobile-card-label">{{ t('accounting.journal.credit') }}</span>
+              <span class="app-mobile-card-value">{{ formatEntryAmount(data.total_credit) }}</span>
+            </div>
+            <div class="app-mobile-card-actions">
+              <Button
+                icon="pi pi-eye"
+                size="small"
+                severity="secondary"
+                text
+                @click="openDetailDialog(data)"
+              />
+              <Button
+                v-if="data.editable"
+                icon="pi pi-pencil"
+                size="small"
+                severity="secondary"
+                text
+                @click="openEditDialog(data)"
+              />
+            </div>
+          </template>
+        </AppMobileCardList>
+      </template>
       <DataTable
         v-else
         v-model:filters="tableFilters"
@@ -647,6 +694,7 @@ import AppPanel from '../components/ui/AppPanel.vue'
 import AppStatCard from '../components/ui/AppStatCard.vue'
 import AppAccountSelect from '../components/ui/AppAccountSelect.vue'
 import AppTableSkeleton from '../components/ui/AppTableSkeleton.vue'
+import AppMobileCardList from '../components/ui/AppMobileCardList.vue'
 import {
   dateRangeFilter,
   inFilter,
@@ -654,6 +702,7 @@ import {
   textFilter,
   useDataTableFilters,
 } from '../composables/useDataTableFilters'
+import { useBreakpoints } from '../composables/useBreakpoints'
 import { useFiscalYearStore } from '../stores/fiscalYear'
 import { formatDisplayDate } from '@/utils/format'
 
@@ -667,6 +716,7 @@ type JournalSourceInfo = Pick<
 >
 
 const { t } = useI18n()
+const { isMobile } = useBreakpoints()
 const toast = useToast()
 const router = useRouter()
 const fiscalYearStore = useFiscalYearStore()

--- a/frontend/src/views/AccountingLedgerView.vue
+++ b/frontend/src/views/AccountingLedgerView.vue
@@ -78,7 +78,30 @@
           <AppStatCard :label="t('accounting.journal.title')" :value="ledger.entries.length" />
         </section>
 
+        <template v-if="isMobile">
+          <AppMobileCardList :items="ledgerRows" :empty-message="t('accounting.ledger.empty')">
+            <template #card="{ item: data }">
+              <div class="app-mobile-card-row app-mobile-card-row--between">
+                <span class="app-mobile-card-value">{{ formatDisplayDate(data.date) }}</span>
+                <span class="app-mobile-card-value">
+                  <span v-if="data.debit !== '0.00'">{{ data.debit }} D</span>
+                  <span v-else-if="data.credit !== '0.00'">{{ data.credit }} C</span>
+                </span>
+              </div>
+              <div class="app-mobile-card-row">
+                <span class="app-mobile-card-label">{{ data.entry_number }}</span>
+                <span class="app-mobile-card-value">{{ data.label }}</span>
+              </div>
+              <div class="app-mobile-card-row app-mobile-card-row--between">
+                <span class="app-mobile-card-label">{{ t('accounting.balance.solde') }}</span>
+                <span class="app-mobile-card-value" style="font-weight:600">{{ formatAccountingAmount(data.running_balance_value) }}</span>
+              </div>
+            </template>
+          </AppMobileCardList>
+        </template>
+
         <DataTable
+          v-else
           v-model:filters="tableFilters"
           :value="ledgerRows"
           :loading="loading"
@@ -208,6 +231,7 @@ import AppNumberRangeFilter from '../components/ui/AppNumberRangeFilter.vue'
 import AppPage from '../components/ui/AppPage.vue'
 import AppPageHeader from '../components/ui/AppPageHeader.vue'
 import AppPanel from '../components/ui/AppPanel.vue'
+import AppMobileCardList from '../components/ui/AppMobileCardList.vue'
 import AppStatCard from '../components/ui/AppStatCard.vue'
 import { getLedgerApi, listAccountsApi, type AccountingAccount, type LedgerRead } from '../api/accounting'
 import {
@@ -216,10 +240,12 @@ import {
   textFilter,
   useDataTableFilters,
 } from '../composables/useDataTableFilters'
+import { useBreakpoints } from '../composables/useBreakpoints'
 import { useFiscalYearStore } from '../stores/fiscalYear'
 import { formatAccountingAmount, formatDisplayDate } from '@/utils/format'
 
 const { t } = useI18n()
+const { isMobile } = useBreakpoints()
 const fiscalYearStore = useFiscalYearStore()
 
 const ledger = ref<LedgerRead | null>(null)

--- a/frontend/src/views/AccountingResultatView.vue
+++ b/frontend/src/views/AccountingResultatView.vue
@@ -29,7 +29,21 @@
       <div v-if="resultat" class="resultat-grid">
         <!-- Charges -->
         <AppPanel :title="t('accounting.resultat.charges')" dense>
+          <template v-if="isMobile">
+            <AppMobileCardList :items="resultat.charges" :empty-message="t('accounting.resultat.empty_charges')">
+              <template #card="{ item: data }">
+                <div class="app-mobile-card-row app-mobile-card-row--between">
+                  <span class="app-mobile-card-value" style="font-weight:700">{{ data.account_number }}</span>
+                  <span class="app-mobile-card-value" style="font-weight:600">{{ formatAccountingAmount(data.solde) }}</span>
+                </div>
+                <div class="app-mobile-card-row">
+                  <span class="app-mobile-card-value">{{ data.account_label }}</span>
+                </div>
+              </template>
+            </AppMobileCardList>
+          </template>
           <DataTable
+            v-else
             :value="resultat.charges"
             :loading="loading"
             class="app-data-table"
@@ -61,7 +75,21 @@
 
         <!-- Produits -->
         <AppPanel :title="t('accounting.resultat.produits')" dense>
+          <template v-if="isMobile">
+            <AppMobileCardList :items="resultat.produits" :empty-message="t('accounting.resultat.empty_produits')">
+              <template #card="{ item: data }">
+                <div class="app-mobile-card-row app-mobile-card-row--between">
+                  <span class="app-mobile-card-value" style="font-weight:700">{{ data.account_number }}</span>
+                  <span class="app-mobile-card-value" style="font-weight:600">{{ formatAccountingAmount(data.solde) }}</span>
+                </div>
+                <div class="app-mobile-card-row">
+                  <span class="app-mobile-card-value">{{ data.account_label }}</span>
+                </div>
+              </template>
+            </AppMobileCardList>
+          </template>
           <DataTable
+            v-else
             :value="resultat.produits"
             :loading="loading"
             class="app-data-table"
@@ -120,13 +148,16 @@ import Column from 'primevue/column'
 import DataTable from 'primevue/datatable'
 import Select from 'primevue/select'
 import AppPage from '../components/ui/AppPage.vue'
+import AppMobileCardList from '../components/ui/AppMobileCardList.vue'
 import AppPageHeader from '../components/ui/AppPageHeader.vue'
 import AppPanel from '../components/ui/AppPanel.vue'
 import { getResultatApi, type ResultatRead } from '../api/accounting'
 import { useFiscalYearStore } from '../stores/fiscalYear'
+import { useBreakpoints } from '../composables/useBreakpoints'
 import { formatAccountingAmount } from '../utils/format'
 
 const { t } = useI18n()
+const { isMobile } = useBreakpoints()
 const fiscalYearStore = useFiscalYearStore()
 
 const resultat = ref<ResultatRead | null>(null)

--- a/frontend/src/views/AccountingRulesView.vue
+++ b/frontend/src/views/AccountingRulesView.vue
@@ -46,7 +46,52 @@
         </div>
       </div>
 
+      <template v-if="isMobile">
+        <AppMobileCardList :items="ruleRows" :empty-message="t('accounting.rules.empty')">
+          <template #card="{ item: data }">
+            <div class="app-mobile-card-row app-mobile-card-row--between">
+              <span class="app-mobile-card-value" style="font-weight:700">{{ data.name }}</span>
+              <Tag
+                :value="data.is_active ? t('common.active') : t('common.inactive')"
+                :severity="data.is_active ? 'success' : 'secondary'"
+              />
+            </div>
+            <div class="app-mobile-card-row">
+              <span class="app-mobile-card-label">{{ t('accounting.rules.trigger_type') }}</span>
+              <span class="app-mobile-card-value">{{ triggerLabel(data.trigger_type) }}</span>
+            </div>
+            <div v-if="data.description" class="app-mobile-card-row">
+              <span class="app-mobile-card-value" style="font-style:italic">{{ data.description }}</span>
+            </div>
+            <div class="app-mobile-card-row">
+              <span class="app-mobile-card-label">{{ t('accounting.rules.priority') }}</span>
+              <span class="app-mobile-card-value">{{ data.priority }}</span>
+            </div>
+            <div class="app-mobile-card-actions">
+              <Button
+                :icon="data.is_active ? 'pi pi-eye-slash' : 'pi pi-eye'"
+                :severity="data.is_active ? 'secondary' : 'success'"
+                text
+                rounded
+                size="small"
+                :title="data.is_active ? t('accounting.rules.deactivate') : t('accounting.rules.activate')"
+                @click="toggleRule(data)"
+              />
+              <Button
+                v-if="canManageApplication"
+                icon="pi pi-pencil"
+                text
+                rounded
+                size="small"
+                :title="t('accounting.rules.edit')"
+                @click="openEdit(data)"
+              />
+            </div>
+          </template>
+        </AppMobileCardList>
+      </template>
       <DataTable
+        v-else
         v-model:filters="tableFilters"
         :value="ruleRows"
         :loading="loading"
@@ -205,6 +250,7 @@ import { useToast } from 'primevue/usetoast'
 import AccountingRuleDialog from '../components/accounting/AccountingRuleDialog.vue'
 import AppFilterMultiSelect from '../components/ui/AppFilterMultiSelect.vue'
 import AppListState from '../components/ui/AppListState.vue'
+import AppMobileCardList from '../components/ui/AppMobileCardList.vue'
 import AppNumberRangeFilter from '../components/ui/AppNumberRangeFilter.vue'
 import AppPage from '../components/ui/AppPage.vue'
 import AppPageHeader from '../components/ui/AppPageHeader.vue'
@@ -222,9 +268,11 @@ import {
   textFilter,
   useDataTableFilters,
 } from '../composables/useDataTableFilters'
+import { useBreakpoints } from '../composables/useBreakpoints'
 import { useAuthStore } from '../stores/auth'
 
 const { t } = useI18n()
+const { isMobile } = useBreakpoints()
 const toast = useToast()
 const confirm = useConfirm()
 const { canManageApplication } = storeToRefs(useAuthStore())

--- a/frontend/src/views/BankView.vue
+++ b/frontend/src/views/BankView.vue
@@ -1479,6 +1479,7 @@ onMounted(async () => {
   display: flex;
   flex-direction: row;
   align-items: center;
+  justify-content: flex-end;
   flex-wrap: wrap;
   gap: var(--app-space-2);
   border-left: 2px solid var(--app-surface-border);

--- a/frontend/src/views/BankView.vue
+++ b/frontend/src/views/BankView.vue
@@ -1482,7 +1482,8 @@ onMounted(async () => {
   gap: 0.15rem;
   border-left: 2px solid var(--app-surface-border);
   padding-left: var(--app-space-3);
-  min-width: 5rem;
+  min-width: 8rem;
+  flex-shrink: 0;
 }
 
 .bank-pending-deposit-row__denom-line {

--- a/frontend/src/views/BankView.vue
+++ b/frontend/src/views/BankView.vue
@@ -1458,6 +1458,7 @@ onMounted(async () => {
 .bank-pending-deposit-row__btn {
   margin-left: auto;
   flex-shrink: 0;
+  white-space: nowrap;
 }
 
 .bank-pending-deposit-row__date {
@@ -1482,7 +1483,7 @@ onMounted(async () => {
   gap: 0.15rem;
   border-left: 2px solid var(--app-surface-border);
   padding-left: var(--app-space-3);
-  min-width: 8rem;
+  min-width: 6.5rem;
   flex-shrink: 0;
 }
 

--- a/frontend/src/views/BankView.vue
+++ b/frontend/src/views/BankView.vue
@@ -1469,7 +1469,7 @@ onMounted(async () => {
 .bank-pending-deposit-row__amount {
   font-weight: 700;
   font-size: 0.82rem;
-  margin-top: 0.4rem;
+  padding-top: 0.25rem;
   text-align: left;
   color: var(--p-green-500);
   white-space: nowrap;
@@ -1478,6 +1478,7 @@ onMounted(async () => {
 .bank-pending-deposit-row__denom {
   display: flex;
   flex-direction: column;
+  justify-content: center;
   gap: 0.15rem;
   border-left: 2px solid var(--app-surface-border);
   padding-left: var(--app-space-3);

--- a/frontend/src/views/BankView.vue
+++ b/frontend/src/views/BankView.vue
@@ -23,28 +23,54 @@
     </AppPageHeader>
 
     <section class="app-stat-grid">
-      <AppStatCard
-        :label="t('bank.current_balance')"
-        :value="displayBalanceValue"
-        :caption="currentBalanceCaption"
-      />
-      <AppStatCard
-        :label="t('bank.period_variation')"
-        :value="formatSignedAmount(displayedPeriodVariation)"
-        :caption="periodVariationCaption"
-        :tone="displayedPeriodVariationTone"
-      />
-      <AppStatCard
-        :label="t('bank.transactions_title')"
-        :value="displayedTransactions.length"
-        :caption="t('bank.metrics.transactions_total', { count: transactions.length })"
-      />
-      <AppStatCard
-        :label="t('bank.deposits_title')"
-        :value="displayedDeposits.length"
-        :caption="t('bank.metrics.pending_payments', { count: pendingDeposits.length })"
-        tone="warn"
-      />
+      <template v-if="pendingDeposits.length > 0">
+        <AppStatCard
+          :label="t('bank.deposits_title')"
+          :value="displayedDeposits.length"
+          :caption="t('bank.metrics.pending_payments', { count: pendingDeposits.length })"
+          tone="warn"
+        />
+        <AppStatCard
+          :label="t('bank.current_balance')"
+          :value="displayBalanceValue"
+          :caption="currentBalanceCaption"
+        />
+        <AppStatCard
+          :label="t('bank.period_variation')"
+          :value="formatSignedAmount(displayedPeriodVariation)"
+          :caption="periodVariationCaption"
+          :tone="displayedPeriodVariationTone"
+        />
+        <AppStatCard
+          :label="t('bank.transactions_title')"
+          :value="displayedTransactions.length"
+          :caption="t('bank.metrics.transactions_total', { count: transactions.length })"
+        />
+      </template>
+      <template v-else>
+        <AppStatCard
+          :label="t('bank.current_balance')"
+          :value="displayBalanceValue"
+          :caption="currentBalanceCaption"
+        />
+        <AppStatCard
+          :label="t('bank.period_variation')"
+          :value="formatSignedAmount(displayedPeriodVariation)"
+          :caption="periodVariationCaption"
+          :tone="displayedPeriodVariationTone"
+        />
+        <AppStatCard
+          :label="t('bank.transactions_title')"
+          :value="displayedTransactions.length"
+          :caption="t('bank.metrics.transactions_total', { count: transactions.length })"
+        />
+        <AppStatCard
+          :label="t('bank.deposits_title')"
+          :value="displayedDeposits.length"
+          :caption="t('bank.metrics.pending_payments', { count: pendingDeposits.length })"
+          tone="warn"
+        />
+      </template>
     </section>
 
     <AppPanel :title="t('bank.funds_chart_title')" dense>
@@ -68,31 +94,36 @@
           :key="deposit.id"
           class="bank-pending-deposit-row"
         >
-          <Tag
-            :value="t(`bank.deposit_types.${deposit.type}`)"
-            :severity="deposit.type === 'cheques' ? 'info' : 'warn'"
-            class="bank-pending-deposit-row__tag"
-          />
-          <span class="bank-pending-deposit-row__date">{{ formatDisplayDate(deposit.date) }}</span>
-          <span class="bank-pending-deposit-row__summary">
-            <template v-if="deposit.type === 'cheques'">
-              {{ t('bank.deposit_cheques_summary', { count: deposit.payment_ids.length }) }}
-            </template>
-            <template v-else>
-              {{ formatEspecesSummary(deposit.denomination_details) }}
-            </template>
-          </span>
-          <span class="bank-pending-deposit-row__amount app-money">
-            {{ formatAmount(deposit.total_amount) }}
-          </span>
-          <Button
-            :label="t('bank.deposit_confirm')"
-            icon="pi pi-check"
-            severity="success"
-            size="small"
-            :loading="confirmingDepositId === deposit.id"
-            @click="confirmDeposit(deposit)"
-          />
+          <div class="bank-pending-deposit-row__left">
+            <div class="bank-pending-deposit-row__top">
+              <Tag
+                :value="t(`bank.deposit_types.${deposit.type}`)"
+                :severity="deposit.type === 'cheques' ? 'info' : 'warn'"
+              />
+              <span class="bank-pending-deposit-row__date">{{ formatDisplayDate(deposit.date) }}</span>
+            </div>
+            <Button
+              :label="t('bank.deposit_confirm')"
+              icon="pi pi-check"
+              severity="success"
+              size="small"
+              class="bank-pending-deposit-row__btn"
+              :loading="confirmingDepositId === deposit.id"
+              @click="confirmDeposit(deposit)"
+            />
+          </div>
+          <div v-if="deposit.type !== 'cheques' && formatEspecesList(deposit.denomination_details).length" class="bank-pending-deposit-row__denom">
+            <span
+              v-for="line in formatEspecesList(deposit.denomination_details)"
+              :key="line"
+              class="bank-pending-deposit-row__denom-line"
+            >{{ line }}</span>
+            <span class="bank-pending-deposit-row__amount app-money">{{ formatAmount(deposit.total_amount) }}</span>
+          </div>
+          <div v-else-if="deposit.type === 'cheques'" class="bank-pending-deposit-row__denom">
+            <span class="bank-pending-deposit-row__denom-line">{{ t('bank.deposit_cheques_summary', { count: deposit.payment_ids.length }) }}</span>
+            <span class="bank-pending-deposit-row__amount app-money">{{ formatAmount(deposit.total_amount) }}</span>
+          </div>
         </div>
       </div>
     </AppPanel>
@@ -152,7 +183,91 @@
             <Message v-if="transactions.length >= 1000" severity="warn" :closable="false" class="mb-2">
               {{ t('common.api_limit_warning') }}
             </Message>
+            <template v-if="isMobile">
+              <AppMobileCardList :items="transactionRows" :empty-message="t('bank.transactions_empty')">
+                <template #card="{ item: data }">
+                  <div class="app-mobile-card-row app-mobile-card-row--between">
+                    <span class="app-mobile-card-label">{{ formatDisplayDate(data.date) }}</span>
+                    <span
+                      class="app-mobile-card-value"
+                      style="font-weight:700"
+                      :class="parseFloat(data.amount) >= 0 ? 'bank-positive' : 'bank-negative'"
+                    >{{ formatAmount(data.amount) }} €</span>
+                  </div>
+                  <div class="app-mobile-card-row">
+                    <span class="app-mobile-card-value">{{ data.description }}</span>
+                  </div>
+                  <div class="app-mobile-card-row app-mobile-card-row--between">
+                    <Tag
+                      :value="t(`bank.categories.${data.detected_category}`)"
+                      class="bank-detected-category-tag"
+                    />
+                    <Tag
+                      v-if="data.reconciled"
+                      :value="t('bank.tx_reconciled_yes')"
+                      severity="success"
+                    />
+                    <Button
+                      v-else
+                      :label="t('bank.tx_reconciled_no')"
+                      icon="pi pi-check"
+                      size="small"
+                      severity="secondary"
+                      outlined
+                      @click="reconcile(data)"
+                    />
+                  </div>
+                  <div class="app-mobile-card-actions">
+                    <Button
+                      v-if="canLinkExistingSupplierPayment(data)"
+                      icon="pi pi-link"
+                      size="small"
+                      severity="secondary"
+                      text
+                      :title="t('bank.link_supplier_payment')"
+                      @click="openExistingSupplierPaymentDialog(data)"
+                    />
+                    <Button
+                      v-if="canCreateSupplierPayment(data)"
+                      icon="pi pi-arrow-up-right"
+                      size="small"
+                      severity="secondary"
+                      text
+                      :title="t('bank.create_supplier_payment')"
+                      @click="openSupplierPaymentDialog(data)"
+                    />
+                    <Button
+                      v-if="canLinkExistingClientPayment(data)"
+                      icon="pi pi-link"
+                      size="small"
+                      severity="secondary"
+                      text
+                      :title="t('bank.link_client_payment')"
+                      @click="openExistingClientPaymentDialog(data)"
+                    />
+                    <Button
+                      v-if="canCreateClientPayment(data)"
+                      icon="pi pi-wallet"
+                      size="small"
+                      severity="secondary"
+                      text
+                      :title="t('bank.create_client_payment')"
+                      @click="openClientPaymentDialog(data)"
+                    />
+                    <Button
+                      icon="pi pi-pencil"
+                      size="small"
+                      text
+                      severity="secondary"
+                      :title="t('bank.edit_category_label')"
+                      @click="openCategoryEdit($event, data)"
+                    />
+                  </div>
+                </template>
+              </AppMobileCardList>
+            </template>
             <DataTable
+              v-else
               v-model:filters="transactionTableFilters"
               :value="transactionRows"
               :loading="loadingTx"
@@ -407,7 +522,33 @@
             <Message v-if="deposits.length >= 1000" severity="warn" :closable="false" class="mb-2">
               {{ t('common.api_limit_warning') }}
             </Message>
+            <template v-if="isMobile">
+              <AppMobileCardList :items="depositRows" :empty-message="t('bank.deposits_empty')">
+                <template #card="{ item: data }">
+                  <div class="app-mobile-card-row app-mobile-card-row--between">
+                    <span class="app-mobile-card-label">{{ formatDisplayDate(data.date) }}</span>
+                    <span class="app-mobile-card-value" style="font-weight:700">{{ formatAmount(data.total_amount) }} €</span>
+                  </div>
+                  <div class="app-mobile-card-row app-mobile-card-row--between">
+                    <Tag :value="t(`bank.deposit_types.${data.type}`)" />
+                    <Tag
+                      :value="data.confirmed ? t('bank.deposit_status.confirmed') : t('bank.deposit_status.pending')"
+                      :severity="data.confirmed ? 'success' : 'warn'"
+                    />
+                  </div>
+                  <div v-if="data.bank_reference" class="app-mobile-card-row">
+                    <span class="app-mobile-card-label">{{ t('bank.deposit_bank_ref') }} :</span>
+                    <span class="app-mobile-card-value">{{ data.bank_reference }}</span>
+                  </div>
+                  <div class="app-mobile-card-row">
+                    <span class="app-mobile-card-label">{{ t('bank.deposit_payments') }} :</span>
+                    <span class="app-mobile-card-value">{{ t('bank.metrics.deposit_payment_count', { count: data.payment_ids?.length || 0 }) }}</span>
+                  </div>
+                </template>
+              </AppMobileCardList>
+            </template>
             <DataTable
+              v-else
               v-model:filters="depositTableFilters"
               :value="depositRows"
               :loading="loadingDeposits"
@@ -664,6 +805,7 @@ import BankLinkClientPaymentDialog from '../components/bank/BankLinkClientPaymen
 import BankSupplierPaymentDialog from '../components/bank/BankSupplierPaymentDialog.vue'
 import BankLinkSupplierPaymentDialog from '../components/bank/BankLinkSupplierPaymentDialog.vue'
 import BankNewDepositDialog from '../components/bank/BankNewDepositDialog.vue'
+import AppMobileCardList from '../components/ui/AppMobileCardList.vue'
 import {
   getBankBalance,
   getBankFundsChart,
@@ -687,8 +829,10 @@ import {
   textFilter,
   useDataTableFilters,
 } from '../composables/useDataTableFilters'
+import { useBreakpoints } from '../composables/useBreakpoints'
 
 const { t } = useI18n()
+const { isMobile } = useBreakpoints()
 const toast = useToast()
 const fiscalYearStore = useFiscalYearStore()
 
@@ -888,17 +1032,15 @@ function formatAmount(value: string | number): string {
   return `${parseFloat(String(value)).toFixed(2)} €`
 }
 
-function formatEspecesSummary(denominationDetails: string | null): string {
-  if (!denominationDetails) return t('bank.deposit_especes_summary_no_denom')
+function formatEspecesList(denominationDetails: string | null): string[] {
+  if (!denominationDetails) return []
   try {
     const lines: { value: number; count: number }[] = JSON.parse(denominationDetails)
-    if (!lines.length) return t('bank.deposit_especes_summary_no_denom')
     return lines
       .filter((l) => l.count > 0)
-      .map((l) => `${l.count}×${l.value % 1 === 0 ? l.value : l.value.toFixed(2)} €`)
-      .join(' + ')
+      .map((l) => `${l.count}\u00d7${l.value % 1 === 0 ? l.value : l.value.toFixed(2)}\u00a0\u20ac`)
   } catch {
-    return t('bank.deposit_especes_summary_no_denom')
+    return []
   }
 }
 
@@ -1292,32 +1434,84 @@ onMounted(async () => {
 
 .bank-pending-deposit-row {
   display: flex;
-  align-items: center;
-  gap: var(--app-space-3);
+  align-items: stretch;
+  gap: var(--app-space-4);
   padding: var(--app-space-3) var(--app-space-4);
   background: var(--app-surface-muted);
   border: 1px solid var(--app-surface-border);
   border-radius: var(--app-radius);
 }
 
-.bank-pending-deposit-row__tag {
+.bank-pending-deposit-row__left {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: var(--app-space-3);
+  flex: 1;
+  min-width: 0;
+}
+
+.bank-pending-deposit-row__top {
+  display: contents;
+}
+
+.bank-pending-deposit-row__btn {
+  margin-left: auto;
   flex-shrink: 0;
 }
 
 .bank-pending-deposit-row__date {
   font-variant-numeric: tabular-nums;
-  min-width: 6rem;
-}
-
-.bank-pending-deposit-row__summary {
-  flex: 1;
+  font-size: 0.85rem;
   color: var(--p-text-muted-color);
-  font-size: 0.9rem;
 }
 
 .bank-pending-deposit-row__amount {
-  font-weight: 600;
-  min-width: 7rem;
-  text-align: right;
+  font-weight: 700;
+  font-size: 0.82rem;
+  margin-top: 0.4rem;
+  text-align: left;
+  color: var(--p-green-500);
+  white-space: nowrap;
+}
+
+.bank-pending-deposit-row__denom {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  border-left: 2px solid var(--app-surface-border);
+  padding-left: var(--app-space-3);
+  min-width: 5rem;
+}
+
+.bank-pending-deposit-row__denom-line {
+  font-size: 0.82rem;
+  font-variant-numeric: tabular-nums;
+  color: var(--p-text-muted-color);
+  white-space: nowrap;
+}
+
+@media (max-width: 767px) {
+  .bank-pending-deposit-row__left {
+    flex-direction: column;
+    align-items: stretch;
+    gap: var(--app-space-2);
+  }
+
+  .bank-pending-deposit-row__top {
+    display: flex;
+    align-items: center;
+    gap: var(--app-space-2);
+    flex-wrap: wrap;
+  }
+
+  .bank-pending-deposit-row__btn {
+    margin-left: 0;
+  }
+
+  .bank-pending-deposit-row__btn :deep(.p-button) {
+    width: 100%;
+    justify-content: center;
+  }
 }
 </style>

--- a/frontend/src/views/BankView.vue
+++ b/frontend/src/views/BankView.vue
@@ -1470,7 +1470,6 @@ onMounted(async () => {
 .bank-pending-deposit-row__amount {
   font-weight: 700;
   font-size: 0.82rem;
-  padding-top: 0.25rem;
   text-align: left;
   color: var(--p-green-500);
   white-space: nowrap;
@@ -1478,12 +1477,12 @@ onMounted(async () => {
 
 .bank-pending-deposit-row__denom {
   display: flex;
-  flex-direction: column;
-  justify-content: center;
-  gap: 0.15rem;
+  flex-direction: row;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--app-space-2);
   border-left: 2px solid var(--app-surface-border);
   padding-left: var(--app-space-3);
-  min-width: 6.5rem;
   flex-shrink: 0;
 }
 
@@ -1515,6 +1514,18 @@ onMounted(async () => {
   .bank-pending-deposit-row__btn :deep(.p-button) {
     width: 100%;
     justify-content: center;
+  }
+
+  .bank-pending-deposit-row__denom {
+    flex-direction: column;
+    align-items: flex-start;
+    flex-wrap: nowrap;
+    gap: 0.15rem;
+    min-width: 6.5rem;
+  }
+
+  .bank-pending-deposit-row__amount {
+    padding-top: 0.25rem;
   }
 }
 </style>

--- a/frontend/src/views/BankView.vue
+++ b/frontend/src/views/BankView.vue
@@ -1483,7 +1483,7 @@ onMounted(async () => {
   gap: var(--app-space-2);
   border-left: 2px solid var(--app-surface-border);
   padding-left: var(--app-space-3);
-  flex-shrink: 0;
+  flex: 0 0 16rem;
 }
 
 .bank-pending-deposit-row__denom-line {
@@ -1521,6 +1521,7 @@ onMounted(async () => {
     align-items: flex-start;
     flex-wrap: nowrap;
     gap: 0.15rem;
+    flex: 0 0 auto;
     min-width: 6.5rem;
   }
 

--- a/frontend/src/views/BankView.vue
+++ b/frontend/src/views/BankView.vue
@@ -120,6 +120,9 @@
             >{{ line }}</span>
             <span class="bank-pending-deposit-row__amount app-money">{{ formatAmount(deposit.total_amount) }}</span>
           </div>
+          <div v-else-if="deposit.type !== 'cheques'" class="bank-pending-deposit-row__denom">
+            <span class="bank-pending-deposit-row__amount app-money">{{ formatAmount(deposit.total_amount) }}</span>
+          </div>
           <div v-else-if="deposit.type === 'cheques'" class="bank-pending-deposit-row__denom">
             <span class="bank-pending-deposit-row__denom-line">{{ t('bank.deposit_cheques_summary', { count: deposit.payment_ids.length }) }}</span>
             <span class="bank-pending-deposit-row__amount app-money">{{ formatAmount(deposit.total_amount) }}</span>

--- a/frontend/src/views/BankView.vue
+++ b/frontend/src/views/BankView.vue
@@ -1483,7 +1483,7 @@ onMounted(async () => {
   gap: var(--app-space-2);
   border-left: 2px solid var(--app-surface-border);
   padding-left: var(--app-space-3);
-  flex: 0 0 16rem;
+  flex: 0 0 22rem;
 }
 
 .bank-pending-deposit-row__denom-line {

--- a/frontend/src/views/CashView.vue
+++ b/frontend/src/views/CashView.vue
@@ -75,7 +75,64 @@
 
         <TabPanels>
           <TabPanel value="journal">
+            <template v-if="isMobile">
+              <AppMobileCardList :items="entryRows" :empty-message="t('cash.journal_empty')">
+                <template #card="{ item: data }">
+                  <div class="app-mobile-card-row app-mobile-card-row--between">
+                    <span class="app-mobile-card-label">{{ formatDisplayDate(data.date) }}</span>
+                    <span
+                      class="app-mobile-card-value"
+                      style="font-weight:700"
+                      :class="data.type === 'out' ? 'cash-negative' : 'cash-positive'"
+                    >{{ data.type === 'out' ? '-' : '+' }}{{ formatAmount(data.amount) }} €</span>
+                  </div>
+                  <div class="app-mobile-card-row">
+                    <Tag
+                      :value="t(`cash.movements.${data.type}`)"
+                      :severity="data.type === 'in' ? 'success' : 'danger'"
+                    />
+                    <Tag
+                      v-if="data.origin_label"
+                      :value="data.origin_label"
+                      :severity="data.source === 'payment' ? 'success' : 'info'"
+                    />
+                  </div>
+                  <div v-if="data.description" class="app-mobile-card-row">
+                    <span class="app-mobile-card-value">{{ data.description }}</span>
+                  </div>
+                  <div class="app-mobile-card-row app-mobile-card-row--between">
+                    <span class="app-mobile-card-label">{{ t('cash.balance_after') }} :</span>
+                    <span class="app-mobile-card-value">{{ formatAmount(data.balance_after) }} €</span>
+                  </div>
+                  <div class="app-mobile-card-actions">
+                    <Button
+                      icon="pi pi-eye"
+                      size="small"
+                      severity="secondary"
+                      text
+                      @click="openDetailDialog(data)"
+                    />
+                    <Button
+                      icon="pi pi-pencil"
+                      size="small"
+                      severity="secondary"
+                      text
+                      @click="openEditDialog(data)"
+                    />
+                    <Button
+                      v-if="data.source === 'manual' && !data.payment_id"
+                      icon="pi pi-trash"
+                      size="small"
+                      severity="danger"
+                      text
+                      @click="confirmDeleteEntry(data)"
+                    />
+                  </div>
+                </template>
+              </AppMobileCardList>
+            </template>
             <DataTable
+              v-else
               v-model:filters="entryTableFilters"
               :value="entryRows"
               :loading="loadingEntries"
@@ -247,7 +304,52 @@
           </TabPanel>
 
           <TabPanel value="counts">
+            <template v-if="isMobile">
+              <AppMobileCardList :items="countRows" :empty-message="t('cash.counts_empty')">
+                <template #card="{ item: data }">
+                  <div class="app-mobile-card-row app-mobile-card-row--between">
+                    <span class="app-mobile-card-label">{{ formatDisplayDate(data.date) }}</span>
+                    <span class="app-mobile-card-value" style="font-weight:700">{{ formatAmount(data.total_counted) }} €</span>
+                  </div>
+                  <div class="app-mobile-card-row app-mobile-card-row--between">
+                    <span class="app-mobile-card-label">{{ t('cash.count_expected') }} : {{ formatAmount(data.balance_expected) }} €</span>
+                    <span
+                      class="app-mobile-card-value"
+                      style="font-weight:600"
+                      :class="
+                        parseFloat(data.difference) < 0
+                          ? 'cash-negative'
+                          : parseFloat(data.difference) > 0
+                            ? 'cash-warn'
+                            : 'cash-positive'
+                      "
+                    >Écart : {{ formatAmount(data.difference) }} €</span>
+                  </div>
+                  <div v-if="data.notes" class="app-mobile-card-row">
+                    <span class="app-mobile-card-label">{{ data.notes }}</span>
+                  </div>
+                  <div class="app-mobile-card-actions">
+                    <Button
+                      icon="pi pi-eye"
+                      size="small"
+                      severity="secondary"
+                      text
+                      @click="selectedCount = data; countDetailDialogVisible = true"
+                    />
+                    <Button
+                      icon="pi pi-inbox"
+                      size="small"
+                      severity="secondary"
+                      text
+                      :label="t('cash.count_create_deposit')"
+                      @click="openDepositFromCount(data)"
+                    />
+                  </div>
+                </template>
+              </AppMobileCardList>
+            </template>
             <DataTable
+              v-else
               v-model:filters="countTableFilters"
               :value="countRows"
               :loading="loadingCounts"
@@ -648,6 +750,7 @@ import AppNumberRangeFilter from '../components/ui/AppNumberRangeFilter.vue'
 import AppPage from '../components/ui/AppPage.vue'
 import AppPageHeader from '../components/ui/AppPageHeader.vue'
 import AppPanel from '../components/ui/AppPanel.vue'
+import AppMobileCardList from '../components/ui/AppMobileCardList.vue'
 import AppStatCard from '../components/ui/AppStatCard.vue'
 import BankNewDepositDialog from '../components/bank/BankNewDepositDialog.vue'
 import { useFiscalYearStore } from '../stores/fiscalYear'
@@ -669,6 +772,7 @@ import {
 } from '@/api/cash'
 import { formatDisplayDate } from '@/utils/format'
 import { type CashCountPrefill } from '@/api/bank'
+import { useBreakpoints } from '../composables/useBreakpoints'
 import {
   dateRangeFilter,
   inFilter,
@@ -678,6 +782,7 @@ import {
 } from '../composables/useDataTableFilters'
 
 const { t } = useI18n()
+const { isMobile } = useBreakpoints()
 const route = useRoute()
 const router = useRouter()
 const toast = useToast()

--- a/frontend/src/views/ClientInvoicesView.vue
+++ b/frontend/src/views/ClientInvoicesView.vue
@@ -133,6 +133,75 @@
         {{ t('common.api_limit_warning') }}
       </Message>
       <AppTableSkeleton v-if="loading && !invoices.length" :rows="8" :cols="5" />
+      <template v-else-if="isMobile">
+        <AppMobileCardList :items="invoiceRows" :empty-message="t('invoices.client.empty')">
+          <template #card="{ item: data }">
+            <div class="app-mobile-card-row app-mobile-card-row--between">
+              <span class="app-mobile-card-value" style="font-weight: 700">{{ data.number }}</span>
+              <Tag
+                :value="t(`invoices.statuses.${data.status}`)"
+                :severity="statusSeverity(data.status)"
+              />
+            </div>
+            <div class="app-mobile-card-row">
+              <span class="app-mobile-card-label">{{ t('invoices.contact') }} :</span>
+              <span class="app-mobile-card-value">{{ contactName(data.contact_id) }}</span>
+            </div>
+            <div class="app-mobile-card-row app-mobile-card-row--between">
+              <span class="app-mobile-card-label">{{ formatDisplayDate(data.date) }}</span>
+              <span class="app-mobile-card-value" style="font-weight: 600">{{ formatAmount(data.total_amount) }} €</span>
+            </div>
+            <div v-if="data.label" class="app-mobile-card-row">
+              <Tag :value="t(`invoices.labels.${data.label}`)" severity="info" size="small" />
+            </div>
+            <div class="app-mobile-card-actions">
+              <Button
+                icon="pi pi-eye"
+                size="small"
+                severity="secondary"
+                text
+                :title="t('invoices.history')"
+                @click="openHistory(data)"
+              />
+              <Button
+                v-if="canRecordPayment(data)"
+                icon="pi pi-wallet"
+                size="small"
+                severity="success"
+                text
+                :title="t('invoices.record_payment')"
+                @click="openPaymentDialog(data)"
+              />
+              <Button
+                v-if="isInvoiceEditable(data)"
+                icon="pi pi-pencil"
+                size="small"
+                severity="secondary"
+                text
+                :title="t('invoices.edit')"
+                @click="openEditDialog(data)"
+              />
+              <Button
+                icon="pi pi-file-pdf"
+                size="small"
+                severity="secondary"
+                text
+                :title="t('invoices.generate_pdf')"
+                @click="openPdf(data)"
+              />
+              <Button
+                v-if="data.status === 'draft'"
+                icon="pi pi-trash"
+                size="small"
+                severity="danger"
+                text
+                :title="t('common.delete')"
+                @click="confirmDelete(data)"
+              />
+            </div>
+          </template>
+        </AppMobileCardList>
+      </template>
       <DataTable
         v-else
         v-model:filters="tableFilters"
@@ -387,7 +456,7 @@
       v-model:visible="writeOffDialogVisible"
       :header="t('invoices.write_off_confirm_title')"
       modal
-      :style="{ width: '30rem' }"
+      :style="{ width: 'min(30rem, 100vw)' }"
     >
       <div class="write-off-dialog-body">
         <p>{{ t('invoices.write_off_confirm_msg') }}</p>
@@ -671,9 +740,11 @@ import {
   type Invoice,
   type InvoiceStatus,
 } from '../api/invoices'
-import { createPayment, listPayments, type Payment } from '../api/payments'
+import { createPayment, listPayments, suggestChequeNumber, type Payment } from '../api/payments'
 import ClientInvoiceForm from '../components/ClientInvoiceForm.vue'
 import InvoiceEmailDialog from '../components/InvoiceEmailDialog.vue'
+import AppMobileCardList from '../components/ui/AppMobileCardList.vue'
+import { useBreakpoints } from '../composables/useBreakpoints'
 import { useKeyboardShortcuts } from '../composables/useKeyboardShortcuts'
 import { useUnsavedChangesGuard } from '../composables/useUnsavedChangesGuard'
 import AppDateRangeFilter from '../components/ui/AppDateRangeFilter.vue'
@@ -707,6 +778,7 @@ import { formatDisplayDate } from '@/utils/format'
 import { getErrorDetail } from '@/utils/errorUtils'
 
 const { t } = useI18n()
+const { isMobile } = useBreakpoints()
 const confirm = useConfirm()
 const route = useRoute()
 const router = useRouter()
@@ -759,6 +831,19 @@ const paymentForm = ref({
   reference: '',
   notes: '',
 })
+
+watch(
+  () => paymentForm.value.method,
+  (method) => {
+    if (method === 'cheque' && !paymentForm.value.cheque_number) {
+      void suggestChequeNumber().then((n) => {
+        if (paymentForm.value.method === 'cheque' && !paymentForm.value.cheque_number) {
+          paymentForm.value.cheque_number = n
+        }
+      })
+    }
+  },
+)
 const historyPaymentRows = computed(() =>
   historyPayments.value.map((payment) => ({
     ...payment,
@@ -1108,6 +1193,11 @@ function openPaymentDialog(invoice: Invoice) {
     notes: '',
   }
   paymentDialogVisible.value = true
+  void suggestChequeNumber().then((n) => {
+    if (paymentForm.value.method === 'cheque' && !paymentForm.value.cheque_number) {
+      paymentForm.value.cheque_number = n
+    }
+  })
 }
 
 async function submitPayment() {

--- a/frontend/src/views/ClientInvoicesView.vue
+++ b/frontend/src/views/ClientInvoicesView.vue
@@ -851,7 +851,10 @@ const paymentForm = ref({
 watch(
   () => paymentForm.value.method,
   (method) => {
-    if (method === 'cheque' && !paymentForm.value.cheque_number) {
+    // Guard: only fire when dialog is already open (i.e. user toggled method inside the dialog).
+    // When openPaymentDialog resets the form, the dialog is not yet visible so this watch is skipped;
+    // the direct suggestChequeNumber() call in openPaymentDialog handles the initial suggestion.
+    if (paymentDialogVisible.value && method === 'cheque' && !paymentForm.value.cheque_number) {
       void suggestChequeNumber().then((n) => {
         if (paymentForm.value.method === 'cheque' && !paymentForm.value.cheque_number) {
           paymentForm.value.cheque_number = n

--- a/frontend/src/views/ClientInvoicesView.vue
+++ b/frontend/src/views/ClientInvoicesView.vue
@@ -535,6 +535,22 @@
             <div v-else-if="historyPayments.length === 0" class="app-empty-state">
               {{ t('invoices.no_payments') }}
             </div>
+            <AppMobileCardList v-else-if="isMobile" :items="historyPaymentRows" :empty-message="t('invoices.no_payments')">
+              <template #card="{ item: data }">
+                <div class="app-mobile-card-row app-mobile-card-row--between">
+                  <span class="app-mobile-card-label">{{ formatDisplayDate(data.date) }}</span>
+                  <span class="app-mobile-card-value" style="font-weight:700">{{ parseFloat(data.amount).toFixed(2) }} €</span>
+                </div>
+                <div class="app-mobile-card-row">
+                  <span class="app-mobile-card-label">{{ t('payments.method') }} :</span>
+                  <span class="app-mobile-card-value">{{ t(`payments.methods.${data.method}`) }}</span>
+                </div>
+                <div v-if="data.cheque_number" class="app-mobile-card-row">
+                  <span class="app-mobile-card-label">{{ t('payments.cheque_number') }} :</span>
+                  <span class="app-mobile-card-value">{{ data.cheque_number }}</span>
+                </div>
+              </template>
+            </AppMobileCardList>
             <DataTable
               v-else
               v-model:filters="historyTableFilters"

--- a/frontend/src/views/ContactsView.vue
+++ b/frontend/src/views/ContactsView.vue
@@ -76,6 +76,57 @@
         {{ t('common.api_limit_warning') }}
       </Message>
       <AppTableSkeleton v-if="loading && !contacts.length" :rows="8" :cols="5" />
+      <template v-else-if="isMobile">
+        <AppMobileCardList :items="contactRows" :empty-message="t('contacts.empty')">
+          <template #card="{ item: data }">
+            <div class="app-mobile-card-row app-mobile-card-row--between">
+              <div style="display:flex;align-items:center;gap:0.4rem">
+                <span class="app-mobile-card-value" style="font-weight:700">{{ data.nom }} {{ data.prenom }}</span>
+                <Tag v-if="data.blocked" :value="t('contacts.blocked_badge')" severity="danger" />
+              </div>
+              <Tag :value="t(`contacts.types.${data.type}`)" :severity="typeSeverity(data.type)" />
+            </div>
+            <div v-if="data.email" class="app-mobile-card-row">
+              <span class="app-mobile-card-label">{{ t('contacts.email') }} :</span>
+              <span class="app-mobile-card-value">{{ data.email }}</span>
+            </div>
+            <div v-if="data.telephone" class="app-mobile-card-row">
+              <span class="app-mobile-card-label">{{ t('contacts.telephone') }} :</span>
+              <span class="app-mobile-card-value">{{ data.telephone }}</span>
+            </div>
+            <div v-if="data.last_invoice_ref" class="app-mobile-card-row">
+              <span class="app-mobile-card-label">{{ t('contacts.last_invoice') }} :</span>
+              <span class="app-mobile-card-value">{{ data.last_invoice_ref }} &mdash; {{ formatDisplayDate(data.last_invoice_date) }}</span>
+            </div>
+            <div class="app-mobile-card-actions">
+              <Button
+                icon="pi pi-history"
+                size="small"
+                severity="info"
+                text
+                :title="t('contact_history.title')"
+                @click="openHistoryDialog(data.id)"
+              />
+              <Button
+                icon="pi pi-pencil"
+                size="small"
+                severity="secondary"
+                text
+                :title="t('contacts.edit')"
+                @click="openEditDialog(data)"
+              />
+              <Button
+                icon="pi pi-trash"
+                size="small"
+                severity="danger"
+                text
+                :title="t('common.delete')"
+                @click="confirmDelete(data)"
+              />
+            </div>
+          </template>
+        </AppMobileCardList>
+      </template>
       <DataTable
         v-else
         v-model:filters="tableFilters"
@@ -366,6 +417,7 @@ import { computed, onMounted, nextTick, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import AppFilterMultiSelect from '@/components/ui/AppFilterMultiSelect.vue'
 import AppListState from '@/components/ui/AppListState.vue'
+import AppMobileCardList from '@/components/ui/AppMobileCardList.vue'
 import AppPage from '@/components/ui/AppPage.vue'
 import AppPageHeader from '@/components/ui/AppPageHeader.vue'
 import AppPanel from '@/components/ui/AppPanel.vue'
@@ -378,6 +430,7 @@ import ContactForm from '@/components/ContactForm.vue'
 import ContactHistoryDialog from '@/components/ContactHistoryDialog.vue'
 import { useKeyboardShortcuts } from '@/composables/useKeyboardShortcuts'
 import { useUnsavedChangesGuard } from '@/composables/useUnsavedChangesGuard'
+import { useBreakpoints } from '@/composables/useBreakpoints'
 import {
   collectActiveFilterLabels,
 } from '../composables/activeFilterLabels'
@@ -385,6 +438,7 @@ import { inFilter, textFilter, useDataTableFilters } from '../composables/useDat
 import { formatDisplayDate } from '@/utils/format'
 
 const { t } = useI18n()
+const { isMobile } = useBreakpoints()
 const confirm = useConfirm()
 const toast = useToast()
 

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -683,7 +683,7 @@ html.dark-mode .dashboard-action-card__icon {
   gap: var(--app-space-2);
   border-left: 2px solid var(--app-surface-border);
   padding-left: var(--app-space-3);
-  flex: 0 0 16rem;
+  flex: 0 0 22rem;
 }
 
 .bank-pending-deposit-row__denom-line {

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -679,6 +679,7 @@ html.dark-mode .dashboard-action-card__icon {
   display: flex;
   flex-direction: row;
   align-items: center;
+  justify-content: flex-end;
   flex-wrap: wrap;
   gap: var(--app-space-2);
   border-left: 2px solid var(--app-surface-border);

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -658,6 +658,7 @@ html.dark-mode .dashboard-action-card__icon {
 .bank-pending-deposit-row__btn {
   margin-left: auto;
   flex-shrink: 0;
+  white-space: nowrap;
 }
 
 .bank-pending-deposit-row__date {
@@ -682,7 +683,7 @@ html.dark-mode .dashboard-action-card__icon {
   gap: 0.15rem;
   border-left: 2px solid var(--app-surface-border);
   padding-left: var(--app-space-3);
-  min-width: 8rem;
+  min-width: 6.5rem;
   flex-shrink: 0;
 }
 

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -44,6 +44,9 @@
               >{{ line }}</span>
               <span class="bank-pending-deposit-row__amount app-money">{{ formatAmount(parseFloat(deposit.total_amount)) }}</span>
             </div>
+            <div v-else-if="deposit.type !== 'cheques'" class="bank-pending-deposit-row__denom">
+              <span class="bank-pending-deposit-row__amount app-money">{{ formatAmount(parseFloat(deposit.total_amount)) }}</span>
+            </div>
             <div v-else-if="deposit.type === 'cheques'" class="bank-pending-deposit-row__denom">
               <span class="bank-pending-deposit-row__denom-line">{{ t('bank.deposit_cheques_summary', { count: deposit.payment_ids.length }) }}</span>
               <span class="bank-pending-deposit-row__amount app-money">{{ formatAmount(parseFloat(deposit.total_amount)) }}</span>

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -682,7 +682,8 @@ html.dark-mode .dashboard-action-card__icon {
   gap: 0.15rem;
   border-left: 2px solid var(--app-surface-border);
   padding-left: var(--app-space-3);
-  min-width: 5rem;
+  min-width: 8rem;
+  flex-shrink: 0;
 }
 
 .bank-pending-deposit-row__denom-line {

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -7,6 +7,51 @@
     </section>
 
     <template v-else>
+      <AppPanel
+        v-if="pendingDeposits.length > 0"
+        :title="t('bank.pending_deposits_title')"
+        :subtitle="t('bank.pending_deposits_subtitle')"
+      >
+        <div class="bank-pending-deposits">
+          <div
+            v-for="deposit in pendingDeposits"
+            :key="deposit.id"
+            class="bank-pending-deposit-row"
+          >
+            <div class="bank-pending-deposit-row__left">
+              <div class="bank-pending-deposit-row__top">
+                <Tag
+                  :value="t(`bank.deposit_types.${deposit.type}`)"
+                  :severity="deposit.type === 'cheques' ? 'info' : 'warn'"
+                />
+                <span class="bank-pending-deposit-row__date">{{ formatDisplayDate(deposit.date) }}</span>
+              </div>
+              <Button
+                :label="t('bank.deposit_confirm')"
+                icon="pi pi-check"
+                severity="success"
+                size="small"
+                class="bank-pending-deposit-row__btn"
+                :loading="confirmingDepositId === deposit.id"
+                @click="doConfirmDeposit(deposit)"
+              />
+            </div>
+            <div v-if="deposit.type !== 'cheques' && formatEspecesList(deposit.denomination_details).length" class="bank-pending-deposit-row__denom">
+              <span
+                v-for="line in formatEspecesList(deposit.denomination_details)"
+                :key="line"
+                class="bank-pending-deposit-row__denom-line"
+              >{{ line }}</span>
+              <span class="bank-pending-deposit-row__amount app-money">{{ formatAmount(parseFloat(deposit.total_amount)) }}</span>
+            </div>
+            <div v-else-if="deposit.type === 'cheques'" class="bank-pending-deposit-row__denom">
+              <span class="bank-pending-deposit-row__denom-line">{{ t('bank.deposit_cheques_summary', { count: deposit.payment_ids.length }) }}</span>
+              <span class="bank-pending-deposit-row__amount app-money">{{ formatAmount(parseFloat(deposit.total_amount)) }}</span>
+            </div>
+          </div>
+        </div>
+      </AppPanel>
+
       <section class="dashboard-quick-actions" :aria-label="t('dashboard.quick_actions_title')">
         <button class="dashboard-action-card" @click="invoiceWizardVisible = true">
           <span class="dashboard-action-card__icon">
@@ -42,6 +87,13 @@
 
       <section class="app-stat-grid">
         <AppStatCard
+          v-if="(kpis?.undeposited_count ?? 0) > 0"
+          :label="t('dashboard.undeposited')"
+          :value="kpis ? kpis.undeposited_count : '—'"
+          tone="warn"
+          :to="{ name: 'payments', query: { undeposited: '1' } }"
+        />
+        <AppStatCard
           :label="t('dashboard.bank_balance')"
           :value="kpis ? formatAmount(kpis.bank_balance) : '—'"
           :to="{ name: 'bank' }"
@@ -65,6 +117,7 @@
           :to="{ name: 'invoices-client', query: { status: 'overdue' } }"
         />
         <AppStatCard
+          v-if="(kpis?.undeposited_count ?? 0) === 0"
           :label="t('dashboard.undeposited')"
           :value="kpis ? kpis.undeposited_count : '—'"
           :to="{ name: 'payments', query: { undeposited: '1' } }"
@@ -159,46 +212,6 @@
         </AppPanel>
       </div>
     </template>
-
-    <AppPanel
-      v-if="pendingDeposits.length > 0"
-      :title="t('bank.pending_deposits_title')"
-      :subtitle="t('bank.pending_deposits_subtitle')"
-    >
-      <div class="bank-pending-deposits">
-        <div
-          v-for="deposit in pendingDeposits"
-          :key="deposit.id"
-          class="bank-pending-deposit-row"
-        >
-          <Tag
-            :value="t(`bank.deposit_types.${deposit.type}`)"
-            :severity="deposit.type === 'cheques' ? 'info' : 'warn'"
-            class="bank-pending-deposit-row__tag"
-          />
-          <span class="bank-pending-deposit-row__date">{{ formatDisplayDate(deposit.date) }}</span>
-          <span class="bank-pending-deposit-row__summary">
-            <template v-if="deposit.type === 'cheques'">
-              {{ t('bank.deposit_cheques_summary', { count: deposit.payment_ids.length }) }}
-            </template>
-            <template v-else>
-              {{ formatEspecesSummary(deposit.denomination_details) }}
-            </template>
-          </span>
-          <span class="bank-pending-deposit-row__amount app-money">
-            {{ formatAmount(parseFloat(deposit.total_amount)) }}
-          </span>
-          <Button
-            :label="t('bank.deposit_confirm')"
-            icon="pi pi-check"
-            severity="success"
-            size="small"
-            :loading="confirmingDepositId === deposit.id"
-            @click="doConfirmDeposit(deposit)"
-          />
-        </div>
-      </div>
-    </AppPanel>
 
     <QuickPaymentWizard v-model:visible="paymentWizardVisible" />
     <QuickInvoiceWizard v-model:visible="invoiceWizardVisible" />
@@ -305,17 +318,15 @@ function formatAmount(v: number | null | undefined): string {
   return new Intl.NumberFormat('fr-FR', { style: 'currency', currency: 'EUR' }).format(v)
 }
 
-function formatEspecesSummary(denominationDetails: string | null): string {
-  if (!denominationDetails) return t('bank.deposit_especes_summary_no_denom')
+function formatEspecesList(denominationDetails: string | null): string[] {
+  if (!denominationDetails) return []
   try {
     const lines: { value: number; count: number }[] = JSON.parse(denominationDetails)
-    if (!lines.length) return t('bank.deposit_especes_summary_no_denom')
     return lines
       .filter((l) => l.count > 0)
-      .map((l) => `${l.count}×${l.value % 1 === 0 ? l.value : l.value.toFixed(2)} €`)
-      .join(' + ')
+      .map((l) => `${l.count}\u00d7${l.value % 1 === 0 ? l.value : l.value.toFixed(2)}\u00a0\u20ac`)
   } catch {
-    return t('bank.deposit_especes_summary_no_denom')
+    return []
   }
 }
 
@@ -623,32 +634,84 @@ html.dark-mode .dashboard-action-card__icon {
 
 .bank-pending-deposit-row {
   display: flex;
-  align-items: center;
-  gap: var(--app-space-3);
+  align-items: stretch;
+  gap: var(--app-space-4);
   padding: var(--app-space-3) var(--app-space-4);
   background: var(--app-surface-muted);
   border: 1px solid var(--app-surface-border);
   border-radius: var(--app-radius);
 }
 
-.bank-pending-deposit-row__tag {
+.bank-pending-deposit-row__left {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: var(--app-space-3);
+  flex: 1;
+  min-width: 0;
+}
+
+.bank-pending-deposit-row__top {
+  display: contents;
+}
+
+.bank-pending-deposit-row__btn {
+  margin-left: auto;
   flex-shrink: 0;
 }
 
 .bank-pending-deposit-row__date {
   font-variant-numeric: tabular-nums;
-  min-width: 6rem;
-}
-
-.bank-pending-deposit-row__summary {
-  flex: 1;
+  font-size: 0.85rem;
   color: var(--p-text-muted-color);
-  font-size: 0.9rem;
 }
 
 .bank-pending-deposit-row__amount {
-  font-weight: 600;
-  min-width: 7rem;
-  text-align: right;
+  font-weight: 700;
+  font-size: 0.82rem;
+  margin-top: 0.4rem;
+  text-align: left;
+  color: var(--p-green-500);
+  white-space: nowrap;
+}
+
+.bank-pending-deposit-row__denom {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  border-left: 2px solid var(--app-surface-border);
+  padding-left: var(--app-space-3);
+  min-width: 5rem;
+}
+
+.bank-pending-deposit-row__denom-line {
+  font-size: 0.82rem;
+  font-variant-numeric: tabular-nums;
+  color: var(--p-text-muted-color);
+  white-space: nowrap;
+}
+
+@media (max-width: 767px) {
+  .bank-pending-deposit-row__left {
+    flex-direction: column;
+    align-items: stretch;
+    gap: var(--app-space-2);
+  }
+
+  .bank-pending-deposit-row__top {
+    display: flex;
+    align-items: center;
+    gap: var(--app-space-2);
+    flex-wrap: wrap;
+  }
+
+  .bank-pending-deposit-row__btn {
+    margin-left: 0;
+  }
+
+  .bank-pending-deposit-row__btn :deep(.p-button) {
+    width: 100%;
+    justify-content: center;
+  }
 }
 </style>

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -670,7 +670,6 @@ html.dark-mode .dashboard-action-card__icon {
 .bank-pending-deposit-row__amount {
   font-weight: 700;
   font-size: 0.82rem;
-  padding-top: 0.25rem;
   text-align: left;
   color: var(--p-green-500);
   white-space: nowrap;
@@ -678,12 +677,12 @@ html.dark-mode .dashboard-action-card__icon {
 
 .bank-pending-deposit-row__denom {
   display: flex;
-  flex-direction: column;
-  justify-content: center;
-  gap: 0.15rem;
+  flex-direction: row;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--app-space-2);
   border-left: 2px solid var(--app-surface-border);
   padding-left: var(--app-space-3);
-  min-width: 6.5rem;
   flex-shrink: 0;
 }
 
@@ -715,6 +714,18 @@ html.dark-mode .dashboard-action-card__icon {
   .bank-pending-deposit-row__btn :deep(.p-button) {
     width: 100%;
     justify-content: center;
+  }
+
+  .bank-pending-deposit-row__denom {
+    flex-direction: column;
+    align-items: flex-start;
+    flex-wrap: nowrap;
+    gap: 0.15rem;
+    min-width: 6.5rem;
+  }
+
+  .bank-pending-deposit-row__amount {
+    padding-top: 0.25rem;
   }
 }
 </style>

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -669,7 +669,7 @@ html.dark-mode .dashboard-action-card__icon {
 .bank-pending-deposit-row__amount {
   font-weight: 700;
   font-size: 0.82rem;
-  margin-top: 0.4rem;
+  padding-top: 0.25rem;
   text-align: left;
   color: var(--p-green-500);
   white-space: nowrap;
@@ -678,6 +678,7 @@ html.dark-mode .dashboard-action-card__icon {
 .bank-pending-deposit-row__denom {
   display: flex;
   flex-direction: column;
+  justify-content: center;
   gap: 0.15rem;
   border-left: 2px solid var(--app-surface-border);
   padding-left: var(--app-space-3);

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -683,7 +683,7 @@ html.dark-mode .dashboard-action-card__icon {
   gap: var(--app-space-2);
   border-left: 2px solid var(--app-surface-border);
   padding-left: var(--app-space-3);
-  flex-shrink: 0;
+  flex: 0 0 16rem;
 }
 
 .bank-pending-deposit-row__denom-line {
@@ -721,6 +721,7 @@ html.dark-mode .dashboard-action-card__icon {
     align-items: flex-start;
     flex-wrap: nowrap;
     gap: 0.15rem;
+    flex: 0 0 auto;
     min-width: 6.5rem;
   }
 

--- a/frontend/src/views/EmployeesView.vue
+++ b/frontend/src/views/EmployeesView.vue
@@ -51,6 +51,55 @@
       </div>
 
       <AppTableSkeleton v-if="loading && !employees.length" :rows="6" :cols="4" />
+      <template v-else-if="isMobile">
+        <AppMobileCardList :items="employeeRows" :empty-message="t('employees.empty')">
+          <template #card="{ item: data }">
+            <div class="app-mobile-card-row app-mobile-card-row--between">
+              <span class="app-mobile-card-value" style="font-weight:700">{{ data.nom }}<template v-if="data.prenom"> {{ data.prenom }}</template></span>
+              <Tag
+                :value="data.is_active ? t('common.active') : t('common.inactive')"
+                :severity="data.is_active ? 'success' : 'secondary'"
+              />
+            </div>
+            <div v-if="data.email" class="app-mobile-card-row">
+              <span class="app-mobile-card-label">{{ t('employees.email') }} :</span>
+              <span class="app-mobile-card-value">{{ data.email }}</span>
+            </div>
+            <div v-if="data.telephone" class="app-mobile-card-row">
+              <span class="app-mobile-card-label">{{ t('employees.telephone') }} :</span>
+              <span class="app-mobile-card-value">{{ data.telephone }}</span>
+            </div>
+            <div class="app-mobile-card-actions">
+              <Button
+                icon="pi pi-pencil"
+                size="small"
+                severity="secondary"
+                text
+                :title="t('employees.edit')"
+                @click="openEditDialog(data)"
+              />
+              <Button
+                v-if="data.is_active"
+                icon="pi pi-ban"
+                size="small"
+                severity="warn"
+                text
+                :title="t('employees.confirm_deactivate', { nom: data.nom })"
+                @click="confirmToggleActive(data)"
+              />
+              <Button
+                v-else
+                icon="pi pi-check-circle"
+                size="small"
+                severity="success"
+                text
+                :title="t('employees.confirm_reactivate', { nom: data.nom })"
+                @click="confirmToggleActive(data)"
+              />
+            </div>
+          </template>
+        </AppMobileCardList>
+      </template>
       <DataTable
         v-else
         v-model:filters="tableFilters"
@@ -354,10 +403,13 @@ import AppPage from '@/components/ui/AppPage.vue'
 import AppPageHeader from '@/components/ui/AppPageHeader.vue'
 import AppPanel from '@/components/ui/AppPanel.vue'
 import AppStatCard from '@/components/ui/AppStatCard.vue'
+import AppMobileCardList from '@/components/ui/AppMobileCardList.vue'
 import AppTableSkeleton from '@/components/ui/AppTableSkeleton.vue'
 import { textFilter, useDataTableFilters } from '../composables/useDataTableFilters'
+import { useBreakpoints } from '../composables/useBreakpoints'
 
 const { t } = useI18n()
+const { isMobile } = useBreakpoints()
 const confirm = useConfirm()
 const toast = useToast()
 

--- a/frontend/src/views/FiscalYearView.vue
+++ b/frontend/src/views/FiscalYearView.vue
@@ -41,7 +41,47 @@
         </div>
       </div>
 
+      <template v-if="isMobile">
+        <AppMobileCardList :items="fiscalYearRows" :empty-message="t('accounting.fiscalYear.empty')">
+          <template #card="{ item: data }">
+            <div class="app-mobile-card-row app-mobile-card-row--between">
+              <span class="app-mobile-card-value" style="font-weight:700">{{ data.name }}</span>
+              <Tag
+                :value="t(`accounting.fiscalYear.statuses.${data.status}`)"
+                :severity="statusSeverity(data.status)"
+              />
+            </div>
+            <div class="app-mobile-card-row">
+              <span class="app-mobile-card-label">{{ t('accounting.fiscalYear.start_date') }}</span>
+              <span class="app-mobile-card-value">{{ formatDisplayDate(data.start_date) }}</span>
+            </div>
+            <div class="app-mobile-card-row">
+              <span class="app-mobile-card-label">{{ t('accounting.fiscalYear.end_date') }}</span>
+              <span class="app-mobile-card-value">{{ formatDisplayDate(data.end_date) }}</span>
+            </div>
+            <div v-if="data.status === 'open'" class="app-mobile-card-actions">
+              <Button
+                :label="t('accounting.fiscalYear.close_administrative')"
+                icon="pi pi-box"
+                severity="warn"
+                text
+                size="small"
+                @click="confirmAdministrativeClose(data)"
+              />
+              <Button
+                :label="t('accounting.fiscalYear.close')"
+                icon="pi pi-lock"
+                severity="danger"
+                text
+                size="small"
+                @click="confirmClose(data)"
+              />
+            </div>
+          </template>
+        </AppMobileCardList>
+      </template>
       <DataTable
+        v-else
         v-model:filters="tableFilters"
         :value="fiscalYearRows"
         :loading="loading"
@@ -210,6 +250,7 @@ import { useToast } from 'primevue/usetoast'
 import AppListState from '../components/ui/AppListState.vue'
 import AppDateRangeFilter from '../components/ui/AppDateRangeFilter.vue'
 import AppFilterMultiSelect from '../components/ui/AppFilterMultiSelect.vue'
+import AppMobileCardList from '../components/ui/AppMobileCardList.vue'
 import AppPage from '../components/ui/AppPage.vue'
 import AppPageHeader from '../components/ui/AppPageHeader.vue'
 import AppPanel from '../components/ui/AppPanel.vue'
@@ -227,9 +268,11 @@ import {
   textFilter,
   useDataTableFilters,
 } from '../composables/useDataTableFilters'
+import { useBreakpoints } from '../composables/useBreakpoints'
 import { formatDisplayDate } from '@/utils/format'
 
 const { t } = useI18n()
+const { isMobile } = useBreakpoints()
 const toast = useToast()
 const confirm = useConfirm()
 

--- a/frontend/src/views/PaymentsView.vue
+++ b/frontend/src/views/PaymentsView.vue
@@ -68,6 +68,37 @@
         {{ t('common.api_limit_warning') }}
       </Message>
       <AppTableSkeleton v-if="loading && !payments.length" :rows="8" :cols="5" />
+      <template v-else-if="isMobile">
+        <AppMobileCardList :items="paymentRows" :empty-message="t('payments.empty')">
+          <template #card="{ item: data }">
+            <div class="app-mobile-card-row app-mobile-card-row--between">
+              <span class="app-mobile-card-label">{{ formatDisplayDate(data.date) }}</span>
+              <span class="app-mobile-card-value" style="font-weight:700">{{ formatAmount(data.amount) }} €</span>
+            </div>
+            <div class="app-mobile-card-row">
+              <Tag :value="t(`payments.methods.${data.method}`)" />
+              <span v-if="data.reference_value" class="app-mobile-card-value">{{ data.reference_value }}</span>
+              <span v-if="data.cheque_number" class="app-mobile-card-label">({{ data.cheque_number }})</span>
+            </div>
+            <div class="app-mobile-card-row">
+              <span class="app-mobile-card-label">{{ t('payments.deposited') }} :</span>
+              <i v-if="data.deposited" class="pi pi-check text-green-500" />
+              <span v-else-if="data.in_deposit" class="payments-status--transit"><i class="pi pi-clock" /> {{ t('payments.deposit_status_in_transit') }}</span>
+              <i v-else class="pi pi-times text-red-400" />
+            </div>
+            <div class="app-mobile-card-actions">
+              <Button
+                icon="pi pi-pencil"
+                size="small"
+                severity="secondary"
+                text
+                :title="t('common.edit')"
+                @click="openEditDialog(data)"
+              />
+            </div>
+          </template>
+        </AppMobileCardList>
+      </template>
       <DataTable
         v-else
         v-model:filters="tableFilters"
@@ -313,10 +344,12 @@ import AppPageHeader from '@/components/ui/AppPageHeader.vue'
 import AppPanel from '@/components/ui/AppPanel.vue'
 import AppStatCard from '@/components/ui/AppStatCard.vue'
 import AppTableSkeleton from '@/components/ui/AppTableSkeleton.vue'
+import AppMobileCardList from '@/components/ui/AppMobileCardList.vue'
 import Message from 'primevue/message'
 import { useFiscalYearStore } from '@/stores/fiscalYear'
 import { formatDisplayDate } from '@/utils/format'
 import { collectActiveFilterLabels } from '../composables/activeFilterLabels'
+import { useBreakpoints } from '../composables/useBreakpoints'
 import {
   dateRangeFilter,
   inFilter,
@@ -326,6 +359,7 @@ import {
 } from '../composables/useDataTableFilters'
 
 const { t } = useI18n()
+const { isMobile } = useBreakpoints()
 const route = useRoute()
 const toast = useToast()
 const fiscalYearStore = useFiscalYearStore()

--- a/frontend/src/views/SalaryView.vue
+++ b/frontend/src/views/SalaryView.vue
@@ -71,7 +71,48 @@
       <Message v-if="salaries.length >= 1000" severity="warn" :closable="false" class="mb-2">
         {{ t('common.api_limit_warning') }}
       </Message>
+      <template v-if="isMobile">
+        <AppMobileCardList :items="salaryRows" :empty-message="t('salary.empty')">
+          <template #card="{ item: data }">
+            <div class="app-mobile-card-row app-mobile-card-row--between">
+              <span class="app-mobile-card-value" style="font-weight:700">{{ data.employee_name }}</span>
+              <span class="app-mobile-card-label">{{ formatDisplayMonth(data.month) }}</span>
+            </div>
+            <div class="app-mobile-card-row app-mobile-card-row--between">
+              <span class="app-mobile-card-label">{{ t('salary.gross') }} :</span>
+              <span class="app-mobile-card-value">{{ formatAmount(data.gross) }}</span>
+            </div>
+            <div class="app-mobile-card-row app-mobile-card-row--between">
+              <span class="app-mobile-card-label">{{ t('salary.net_pay') }} :</span>
+              <span class="app-mobile-card-value" style="font-weight:600">{{ formatAmount(data.net_pay) }}</span>
+            </div>
+            <div class="app-mobile-card-row app-mobile-card-row--between">
+              <span class="app-mobile-card-label">{{ t('salary.hours') }} :</span>
+              <span class="app-mobile-card-value">{{ data.hours }}</span>
+            </div>
+            <div class="app-mobile-card-actions">
+              <Button
+                icon="pi pi-pencil"
+                size="small"
+                severity="secondary"
+                text
+                :title="t('salary.edit')"
+                @click="openEditDialog(data)"
+              />
+              <Button
+                icon="pi pi-trash"
+                size="small"
+                severity="danger"
+                text
+                :title="t('common.delete')"
+                @click="confirmDelete(data)"
+              />
+            </div>
+          </template>
+        </AppMobileCardList>
+      </template>
       <DataTable
+        v-else
         v-model:filters="salaryTableFilters"
         :value="salaryRows"
         :loading="loading"
@@ -218,7 +259,30 @@
     </AppPanel>
 
     <AppPanel :title="t('salary.summary_title')" dense>
+      <template v-if="isMobile">
+        <AppMobileCardList :items="summaryRows" :empty-message="t('salary.empty')">
+          <template #card="{ item: data }">
+            <div class="app-mobile-card-row app-mobile-card-row--between">
+              <span class="app-mobile-card-value" style="font-weight:700">{{ formatDisplayMonth(data.month) }}</span>
+              <span class="app-mobile-card-label"># {{ data.count }}</span>
+            </div>
+            <div class="app-mobile-card-row app-mobile-card-row--between">
+              <span class="app-mobile-card-label">{{ t('salary.gross') }} :</span>
+              <span class="app-mobile-card-value">{{ formatAmount(data.total_gross) }}</span>
+            </div>
+            <div class="app-mobile-card-row app-mobile-card-row--between">
+              <span class="app-mobile-card-label">{{ t('salary.net_pay') }} :</span>
+              <span class="app-mobile-card-value" style="font-weight:600">{{ formatAmount(data.total_net_pay) }}</span>
+            </div>
+            <div class="app-mobile-card-row app-mobile-card-row--between">
+              <span class="app-mobile-card-label">{{ t('salary.total_cost') }} :</span>
+              <span class="app-mobile-card-value">{{ formatAmount(data.total_cost) }}</span>
+            </div>
+          </template>
+        </AppMobileCardList>
+      </template>
       <DataTable
+        v-else
         v-model:filters="summaryTableFilters"
         :value="summaryRows"
         :loading="summaryLoading"
@@ -367,7 +431,30 @@
           </div>
         </div>
       </div>
+      <template v-if="isMobile">
+        <AppMobileCardList :items="workforceSummaryByMonth" :empty-message="t('salary.workforce_empty')">
+          <template #card="{ item: data }">
+            <div class="app-mobile-card-row app-mobile-card-row--between">
+              <span class="app-mobile-card-value" style="font-weight:700">{{ formatDisplayMonth(data.month) }}</span>
+              <span class="app-mobile-card-value">{{ formatAmount(data.total) }}</span>
+            </div>
+            <div v-if="data.cdi > 0" class="app-mobile-card-row app-mobile-card-row--between">
+              <span class="app-mobile-card-label">{{ t('salary.workforce_type_cdi') }} :</span>
+              <span class="app-mobile-card-value">{{ formatAmount(data.cdi) }}</span>
+            </div>
+            <div v-if="data.cdd > 0" class="app-mobile-card-row app-mobile-card-row--between">
+              <span class="app-mobile-card-label">{{ t('salary.workforce_type_cdd') }} :</span>
+              <span class="app-mobile-card-value">{{ formatAmount(data.cdd) }}</span>
+            </div>
+            <div v-if="data.ae > 0" class="app-mobile-card-row app-mobile-card-row--between">
+              <span class="app-mobile-card-label">{{ t('salary.workforce_type_ae') }} :</span>
+              <span class="app-mobile-card-value">{{ formatAmount(data.ae) }}</span>
+            </div>
+          </template>
+        </AppMobileCardList>
+      </template>
       <DataTable
+        v-if="!isMobile"
         :value="workforceSummaryByMonth"
         :loading="workforceLoading"
         class="app-data-table"
@@ -617,6 +704,7 @@ import AppNumberRangeFilter from '../components/ui/AppNumberRangeFilter.vue'
 import AppPage from '../components/ui/AppPage.vue'
 import AppPageHeader from '../components/ui/AppPageHeader.vue'
 import AppPanel from '../components/ui/AppPanel.vue'
+import AppMobileCardList from '../components/ui/AppMobileCardList.vue'
 import AppStatCard from '../components/ui/AppStatCard.vue'
 import {
   listSalariesApi,
@@ -638,10 +726,12 @@ import {
   useDataTableFilters,
 } from '../composables/useDataTableFilters'
 import { useUnsavedChangesGuard } from '../composables/useUnsavedChangesGuard'
+import { useBreakpoints } from '../composables/useBreakpoints'
 import { useFiscalYearStore } from '../stores/fiscalYear'
 import { formatDisplayMonth } from '../utils/format'
 
 const { t } = useI18n()
+const { isMobile } = useBreakpoints()
 const confirm = useConfirm()
 const toast = useToast()
 const fiscalYearStore = useFiscalYearStore()

--- a/frontend/src/views/SupplierInvoicesView.vue
+++ b/frontend/src/views/SupplierInvoicesView.vue
@@ -529,6 +529,18 @@
             <div v-else-if="previewPayments.length === 0" class="app-empty-state">
               {{ t('invoices.no_payments') }}
             </div>
+            <AppMobileCardList v-else-if="isMobile" :items="previewPayments" :empty-message="t('invoices.no_payments')">
+              <template #card="{ item: data }">
+                <div class="app-mobile-card-row app-mobile-card-row--between">
+                  <span class="app-mobile-card-label">{{ formatDisplayDate(data.date) }}</span>
+                  <span class="app-mobile-card-value" style="font-weight:700">{{ parseFloat(data.amount).toFixed(2) }} €</span>
+                </div>
+                <div class="app-mobile-card-row">
+                  <span class="app-mobile-card-label">{{ t('payments.method') }} :</span>
+                  <span class="app-mobile-card-value">{{ t(`payments.methods.${data.method}`) }}</span>
+                </div>
+              </template>
+            </AppMobileCardList>
             <DataTable
               v-else
               :value="previewPayments"

--- a/frontend/src/views/SupplierInvoicesView.vue
+++ b/frontend/src/views/SupplierInvoicesView.vue
@@ -878,7 +878,10 @@ const paymentForm = ref({
 watch(
   () => paymentForm.value.method,
   (method) => {
-    if (method === 'cheque' && !paymentForm.value.cheque_number) {
+    // Guard: only fire when dialog is already open (i.e. user toggled method inside the dialog).
+    // When openPaymentDialog resets the form, the dialog is not yet visible so this watch is skipped;
+    // the direct suggestChequeNumber() call in openPaymentDialog handles the initial suggestion.
+    if (paymentDialogVisible.value && method === 'cheque' && !paymentForm.value.cheque_number) {
       void suggestChequeNumber().then((n) => {
         if (paymentForm.value.method === 'cheque' && !paymentForm.value.cheque_number) {
           paymentForm.value.cheque_number = n

--- a/frontend/src/views/SupplierInvoicesView.vue
+++ b/frontend/src/views/SupplierInvoicesView.vue
@@ -78,7 +78,81 @@
       <Message v-if="invoices.length >= 1000" severity="warn" :closable="false" class="mb-2">
         {{ t('common.api_limit_warning') }}
       </Message>
+      <template v-if="isMobile">
+        <AppMobileCardList :items="invoiceRows" :empty-message="t('invoices.supplier.empty')">
+          <template #card="{ item: data }">
+            <div class="app-mobile-card-row app-mobile-card-row--between">
+              <span class="app-mobile-card-value" style="font-weight: 700">{{ data.number }}</span>
+              <Tag
+                :value="t(`invoices.statuses.${data.status}`)"
+                :severity="statusSeverity(data.status)"
+              />
+            </div>
+            <div class="app-mobile-card-row">
+              <span class="app-mobile-card-label">{{ t('invoices.contact') }} :</span>
+              <span class="app-mobile-card-value">{{ contactName(data.contact_id) }}</span>
+            </div>
+            <div class="app-mobile-card-row app-mobile-card-row--between">
+              <span class="app-mobile-card-label">{{ formatDisplayDate(data.date) }}</span>
+              <span class="app-mobile-card-value" style="font-weight: 600">{{ formatAmount(data.total_amount) }} €</span>
+            </div>
+            <div v-if="data.reference" class="app-mobile-card-row">
+              <span class="app-mobile-card-label">{{ t('invoices.reference') }} :</span>
+              <span class="app-mobile-card-value">{{ data.reference }}</span>
+            </div>
+            <div class="app-mobile-card-row">
+              <i v-if="data.file_path" class="pi pi-paperclip" style="font-size: 0.9rem; color: var(--p-primary-color)" />
+            </div>
+            <div class="app-mobile-card-actions">
+              <Button
+                icon="pi pi-pencil"
+                size="small"
+                severity="secondary"
+                text
+                :title="t('invoices.edit')"
+                @click="openEditDialog(data)"
+              />
+              <Button
+                v-if="data.file_path"
+                icon="pi pi-eye"
+                size="small"
+                severity="secondary"
+                text
+                :title="t('invoices.supplier.preview_file')"
+                @click="openPreviewDialog(data)"
+              />
+              <Button
+                icon="pi pi-upload"
+                size="small"
+                severity="secondary"
+                text
+                :title="t('invoices.upload_file')"
+                @click="openUploadDialog(data)"
+              />
+              <Button
+                v-if="canRecordPayment(data)"
+                icon="pi pi-wallet"
+                size="small"
+                severity="success"
+                text
+                :title="t('invoices.record_payment')"
+                @click="openPaymentDialog(data)"
+              />
+              <Button
+                v-if="data.status === 'draft'"
+                icon="pi pi-trash"
+                size="small"
+                severity="danger"
+                text
+                :title="t('common.delete')"
+                @click="confirmDelete(data)"
+              />
+            </div>
+          </template>
+        </AppMobileCardList>
+      </template>
       <DataTable
+        v-else
         v-model:filters="tableFilters"
         :value="invoiceRows"
         :loading="loading"
@@ -614,6 +688,8 @@ import AppPageHeader from '../components/ui/AppPageHeader.vue'
 import AppPanel from '../components/ui/AppPanel.vue'
 import AppStatCard from '../components/ui/AppStatCard.vue'
 import AppTableSkeleton from '../components/ui/AppTableSkeleton.vue'
+import AppMobileCardList from '../components/ui/AppMobileCardList.vue'
+import { useBreakpoints } from '../composables/useBreakpoints'
 
 import AppDatePicker from '../components/ui/AppDatePicker.vue'
 import { listContactsApi, type Contact } from '../api/contacts'
@@ -625,7 +701,7 @@ import {
   type Invoice,
   type InvoiceStatus,
 } from '../api/invoices'
-import { createPayment, listPayments, type Payment } from '../api/payments'
+import { createPayment, listPayments, suggestChequeNumber, type Payment } from '../api/payments'
 import SupplierInvoiceForm from '../components/SupplierInvoiceForm.vue'
 import {
   dateRangeFilter,
@@ -650,6 +726,7 @@ const route = useRoute()
 const router = useRouter()
 const toast = useToast()
 const fiscalYearStore = useFiscalYearStore()
+const { isMobile } = useBreakpoints()
 
 const invoices = ref<Invoice[]>([])
 const contacts = ref<Contact[]>([])
@@ -786,6 +863,19 @@ const paymentForm = ref({
   notes: '',
 })
 
+watch(
+  () => paymentForm.value.method,
+  (method) => {
+    if (method === 'cheque' && !paymentForm.value.cheque_number) {
+      void suggestChequeNumber().then((n) => {
+        if (paymentForm.value.method === 'cheque' && !paymentForm.value.cheque_number) {
+          paymentForm.value.cheque_number = n
+        }
+      })
+    }
+  },
+)
+
 const paymentRemaining = computed(() => {
   if (!paymentInvoice.value) return 0
   return parseFloat(paymentInvoice.value.total_amount) - parseFloat(paymentInvoice.value.paid_amount)
@@ -808,6 +898,11 @@ function openPaymentDialog(invoice: Invoice) {
     notes: '',
   }
   paymentDialogVisible.value = true
+  void suggestChequeNumber().then((n) => {
+    if (paymentForm.value.method === 'cheque' && !paymentForm.value.cheque_number) {
+      paymentForm.value.cheque_number = n
+    }
+  })
 }
 
 async function submitPayment() {

--- a/frontend/src/views/UsersView.vue
+++ b/frontend/src/views/UsersView.vue
@@ -70,7 +70,44 @@
         </div>
       </div>
 
+      <template v-if="isMobile">
+        <AppMobileCardList :items="userRows" :empty-message="t('users.empty')">
+          <template #card="{ item: data }">
+            <div class="app-mobile-card-row app-mobile-card-row--between">
+              <span class="app-mobile-card-value" style="font-weight:700">{{ data.username }}</span>
+              <Tag :value="roleLabel(data.role)" :severity="roleSeverity(data.role)" />
+            </div>
+            <div class="app-mobile-card-row">
+              <span class="app-mobile-card-value">{{ data.email }}</span>
+            </div>
+            <div class="app-mobile-card-row app-mobile-card-row--between">
+              <Tag
+                :value="data.is_active ? t('users.status_values.active') : t('users.status_values.inactive')"
+                :severity="data.is_active ? 'success' : 'contrast'"
+              />
+            </div>
+            <div class="app-mobile-card-actions">
+              <Button
+                icon="pi pi-pencil"
+                size="small"
+                severity="secondary"
+                text
+                @click="openEditDialog(data)"
+              />
+              <Button
+                icon="pi pi-key"
+                size="small"
+                severity="secondary"
+                text
+                :disabled="data.id === auth.user?.id"
+                @click="openResetDialog(data)"
+              />
+            </div>
+          </template>
+        </AppMobileCardList>
+      </template>
       <DataTable
+        v-else
         v-model:filters="tableFilters"
         :value="userRows"
         :loading="loading"
@@ -384,6 +421,7 @@ import { useToast } from 'primevue/usetoast'
 import AppDateRangeFilter from '@/components/ui/AppDateRangeFilter.vue'
 import AppFilterMultiSelect from '@/components/ui/AppFilterMultiSelect.vue'
 import AppListState from '@/components/ui/AppListState.vue'
+import AppMobileCardList from '@/components/ui/AppMobileCardList.vue'
 import AppPage from '@/components/ui/AppPage.vue'
 import AppPageHeader from '@/components/ui/AppPageHeader.vue'
 import AppPanel from '@/components/ui/AppPanel.vue'
@@ -398,6 +436,7 @@ import {
   textFilter,
   useDataTableFilters,
 } from '../composables/useDataTableFilters'
+import { useBreakpoints } from '../composables/useBreakpoints'
 
 interface CreateUserForm {
   username: string
@@ -427,6 +466,7 @@ interface ApiErrorDetail {
 }
 
 const { t } = useI18n()
+const { isMobile } = useBreakpoints()
 const toast = useToast()
 const auth = useAuthStore()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "solde"
-version = "1.4.1"
+version = "1.4.3"
 description = "Web app for French non-profit accounting — invoicing, payments, cash management and double-entry bookkeeping."
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Summary

Completes BIZ-164: adds `AppMobileCardList` mobile card views to all remaining list screens in the application.

## Changes

### New mobile card views added
- **AccountingAccountsView** — account number + type, label, edit button
- **AccountingBalanceView** — account number + type, label, debit/credit/balance rows
- **AccountingBilanView** — actif and passif tables (account number + balance, label)
- **AccountingResultatView** — charges and produits tables (account number + balance, label)
- **AccountingRulesView** — name + active status, trigger type + description, priority, toggle/edit buttons
- **AccountingLedgerView** — date + debit/credit indicator, entry number + label, running balance
- **AccountingJournalView** — date + source tag, label, contact (conditional), debit/credit, action buttons
- **FiscalYearView** — name + status tag, start/end dates, close actions
- **UsersView** — username + role tag, email, active status, edit/password buttons
- **SupplierInvoicesView** (payments section in preview dialog) — date + amount, payment method
- **ClientInvoicesView** (payments section in history dialog) — date + amount, method, cheque number

### AppMobileCardList component
Made generic (`generic="T"`) with `defineSlots` to eliminate TypeScript errors in slot templates.

## Testing
- 1021 backend tests passing
- 144 frontend Vitest tests passing
- 0 ESLint errors
- 0 vue-tsc errors

## Ticket
BIZ-164