### PR TITLE
feat: Lot CR2 — Finitions post-MOB (v1.4.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Ce projet respecte le [Versionnage sémantique](https://semver.org/lang/fr/).
 - **BIZ-164** — Paramètre `cheque_number_template` dans les réglages (champ `{date}.{seq}` par défaut, validé côté backend)
 - **BIZ-164** — Migration Alembic `0049` : colonne `cheque_number_template` dans `app_settings`
 - **BIZ-165** — Boutons de navigation Précédent / Suivant dans le dialog d'historique des factures client (parité avec la vue factures fournisseur)
+- **BIZ-166** — Vue Contacts : onglet « Clients » actif par défaut (ordre : Clients > Fournisseurs > Tout) ; contacts triés par récence de dernière facture (< 6 mois en tête) puis ordre alphabétique
 - **CHR-078** — Fichier `frontend/src/i18n/en.ts` créé : squelette de localisation anglaise avec `app`, `auth` et `common` traduits ; enregistré dans `vue-i18n` avec `fallbackLocale: 'fr'`
 
 ### Amélioré

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Ce projet respecte le [Versionnage sémantique](https://semver.org/lang/fr/).
 - **BIZ-164** — Tuile dépôt espèces : `total_amount` affiché même si `denomination_details` est vide ou invalide (fallback `v-else-if`)
 - **BIZ-164** — Suppression du double appel API de suggestion de numéro de chèque à l'ouverture du dialog (guard `paymentDialogVisible` dans le `watch`)
 - **BIZ-164** — Annotation de type `payment_date: date | None` dans `GET /api/payments/suggest_cheque_number` (était `date` alors que le paramètre est optionnel)
+- **BIZ-167** — Bouton « Passer en créance douteuse » masqué pour les contacts de type Fournisseur (n'a de sens que pour les clients)
 
 ### Tests
 - **TEC-158** — 5 nouveaux tests d'intégration pour `GET /api/payments/suggest_cheque_number` : statut 200 + format, date par défaut (aujourd'hui), incrément séquentiel, 401 sans auth, 403 pour `readonly`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,12 +19,16 @@ Ce projet respecte le [Versionnage sémantique](https://semver.org/lang/fr/).
 - **BIZ-164** — Endpoint `GET /api/payments/suggest_cheque_number` (sans effet de bord) et service `suggest_cheque_number` côté backend
 - **BIZ-164** — Paramètre `cheque_number_template` dans les réglages (champ `{date}.{seq}` par défaut, validé côté backend)
 - **BIZ-164** — Migration Alembic `0049` : colonne `cheque_number_template` dans `app_settings`
+- **BIZ-165** — Boutons de navigation Précédent / Suivant dans le dialog d'historique des factures client (parité avec la vue factures fournisseur)
+- **CHR-078** — Fichier `frontend/src/i18n/en.ts` créé : squelette de localisation anglaise avec `app`, `auth` et `common` traduits ; enregistré dans `vue-i18n` avec `fallbackLocale: 'fr'`
 
 ### Amélioré
 - **BIZ-164** — Dialogs pleine largeur sur mobile (`app-dialog`, `app-dialog--medium`, `app-dialog--large`, `app-dialog--xlarge`) : 100 vw et hauteur max 95 dvh en dessous de 767 px
 - **BIZ-164** — Styles utilitaires mobiles ajoutés dans `main.css` : `app-mobile-card-row`, `app-mobile-card-label`, `app-mobile-card-value`, `app-mobile-card-actions`
 - **BIZ-164** — Tuile dépôt en attente : liste de coupures espèces ou comptage chèques en colonne de droite alignée ; layout desktop (1 ligne, coupures à droite alignées, bouton en bout de ligne) et layout mobile (empilé) séparés
 - **BIZ-164** — Grille de stat cards : 2 colonnes sur mobile
+- **TEC-157** — `AppMobileCardList` : message vide par défaut remplacé par la clé i18n `common.empty` (suppression de la chaîne en dur `'Aucune donnée'`)
+- **TEC-157** — `CashView` : libellé `'Écart :'` des comptages remplacé par la clé i18n `cash.count_diff`
 
 ### Corrigé
 - **BIZ-164** — Mock `window.matchMedia` ajouté dans le setup de tests Vitest pour éviter des erreurs jsdom dans les composants utilisant `useBreakpoints`
@@ -32,6 +36,10 @@ Ce projet respecte le [Versionnage sémantique](https://semver.org/lang/fr/).
 - **BIZ-164** — Tuile dépôt espèces : `total_amount` affiché même si `denomination_details` est vide ou invalide (fallback `v-else-if`)
 - **BIZ-164** — Suppression du double appel API de suggestion de numéro de chèque à l'ouverture du dialog (guard `paymentDialogVisible` dans le `watch`)
 - **BIZ-164** — Annotation de type `payment_date: date | None` dans `GET /api/payments/suggest_cheque_number` (était `date` alors que le paramètre est optionnel)
+
+### Tests
+- **TEC-158** — 5 nouveaux tests d'intégration pour `GET /api/payments/suggest_cheque_number` : statut 200 + format, date par défaut (aujourd'hui), incrément séquentiel, 401 sans auth, 403 pour `readonly`
+- **TEC-159** — 4 nouveaux tests d'intégration pour `cheque_number_template` dans settings API : valeur par défaut renvoyée, mise à jour valide, rejet sans `{seq}`, rejet avec placeholder non supporté
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Ce projet respecte le [Versionnage sémantique](https://semver.org/lang/fr/).
 - **BIZ-164** — Suppression du double appel API de suggestion de numéro de chèque à l'ouverture du dialog (guard `paymentDialogVisible` dans le `watch`)
 - **BIZ-164** — Annotation de type `payment_date: date | None` dans `GET /api/payments/suggest_cheque_number` (était `date` alors que le paramètre est optionnel)
 - **BIZ-167** — Bouton « Passer en créance douteuse » masqué pour les contacts de type Fournisseur (n'a de sens que pour les clients)
+- **BIZ-168** — Barre de navigation Précédent / Suivant dupliquée en bas des dialogs preview factures client et fournisseur ; le défilement est conservé en bas du dialog lors de la navigation depuis la barre du bas (pour faciliter la consultation du PDF attaché)
 
 ### Tests
 - **TEC-158** — 5 nouveaux tests d'intégration pour `GET /api/payments/suggest_cheque_number` : statut 200 + format, date par défaut (aujourd'hui), incrément séquentiel, 401 sans auth, 403 pour `readonly`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,10 +39,17 @@ Ce projet respecte le [Versionnage sémantique](https://semver.org/lang/fr/).
 - **BIZ-164** — Annotation de type `payment_date: date | None` dans `GET /api/payments/suggest_cheque_number` (était `date` alors que le paramètre est optionnel)
 - **BIZ-167** — Bouton « Passer en créance douteuse » masqué pour les contacts de type Fournisseur (n'a de sens que pour les clients)
 - **BIZ-168** — Barre de navigation Précédent / Suivant dupliquée en bas des dialogs preview factures client et fournisseur ; le défilement est conservé en bas du dialog lors de la navigation depuis la barre du bas (pour faciliter la consultation du PDF attaché)
+- **CR-077** — CSS dupliqué supprimé dans `SupplierInvoicesView` (bloc `.preview-nav-bar--bottom` en double)
+- **CR-077** — Fuite mémoire Blob URL corrigée dans `ClientInvoicesView` : l'ancienne URL est révoquée avant d'en créer une nouvelle à l'ouverture de l'historique
+- **CR-077** — Bouton « Passer en créance douteuse » désormais masqué pour les contacts de type `les_deux` (visible uniquement pour `type === 'client'`)
+- **CR-077** — Commentaire d'en-tête de `frontend/src/i18n/en.ts` corrigé : précise que les sections absentes tombent en fallback French via `fallbackLocale: 'fr'`
 
 ### Tests
 - **TEC-158** — 5 nouveaux tests d'intégration pour `GET /api/payments/suggest_cheque_number` : statut 200 + format, date par défaut (aujourd'hui), incrément séquentiel, 401 sans auth, 403 pour `readonly`
 - **TEC-159** — 4 nouveaux tests d'intégration pour `cheque_number_template` dans settings API : valeur par défaut renvoyée, mise à jour valide, rejet sans `{seq}`, rejet avec placeholder non supporté
+- **CR-077** — Tests de régression renforcés sur `suggest_cheque_number` : vérification du format exact `YYYYMMDD.NN` et de la date d'aujourd'hui utilisée en fallback
+- **CR-077** — 2 nouveaux tests Vitest pour la navigation Précédent / Suivant du dialog historique (`ClientInvoicesView`)
+- **CR-077** — 2 nouveaux tests Vitest pour la navigation Précédent / Suivant du dialog preview facture fournisseur, barre du bas (`SupplierInvoicesView`)
 
 ---
 

--- a/doc/backlog-archive.md
+++ b/doc/backlog-archive.md
@@ -1,0 +1,501 @@
+<!-- markdownlint-disable MD033 -->
+# Backlog — Archive — Solde ⚖️
+
+Lots et tickets terminés avant le 2026-05-02.
+Voir [backlog.md](backlog.md) pour les tickets actifs et les travaux récents.
+
+---
+
+## Lots terminés
+
+| Lot | Nom | Version | Tickets | Terminé | Est. Copilot | Réel Copilot |
+| --- | --- | --- | --- | --- | --- | --- |
+| 1 | Quick wins P3 | v0.2 | CHR-064, CHR-062, TEC-066, TEC-063 | 2026-04-22 | — | — |
+| 2 | Tests au vert | v0.2 | TEC-048 | 2026-04-22 | — | — |
+| 3 | Sécurité sans impact structurel | v0.2 | TEC-047, TEC-052, TEC-055, TEC-060, TEC-051 | 2026-04-22 | — | — |
+| 4 | Qualité backend sans impact API | v0.2 | TEC-065, TEC-057, TEC-059 | 2026-04-22 | — | — |
+| 5 | Sécurité auth (full-stack) | v0.2 | TEC-045, BIZ-053, TEC-046 | 2026-04-22 | — | — |
+| 6 | DevOps Docker | v0.2 | CHR-054, CHR-061 | 2026-04-22 | — | — |
+| 7 | Refactoring structurel | v0.2 | TEC-050, TEC-058 | 2026-04-22 | — | — |
+| 8 | Chantiers longs | v0.2 | BIZ-056, TEC-049 | 2026-04-22 | — | — |
+| A | Backend rapide | v0.3 | TEC-085 | 2026-04-23 | — | — |
+| B | UX quick wins | v0.3 | BIZ-070, BIZ-072, BIZ-074, BIZ-084, BIZ-042 | 2026-04-23 | — | — |
+| C | Dashboard interactif | v0.3 | BIZ-075, BIZ-073 | 2026-04-23 | — | — |
+| D | Polish UI | v0.3 | BIZ-071, BIZ-043 | 2026-04-23 | — | — |
+| F | Tests | v0.4 | TEC-079, TEC-080, TEC-081 | 2026-04-24 | — | — |
+| G | Refactoring frontend | v0.5 | TEC-077 | 2026-04-24 | — | — |
+| I | Polish UI & contacts | v0.5 | BIZ-035, BIZ-037, CHR-038, BIZ-040 | 2026-04-24 | — | — |
+| J | CI GitHub Actions | v0.5 | CHR-086, CHR-087 | 2026-04-24 | — | — |
+| K | Documentation & Swagger | v0.5 | CHR-019, CHR-082 | 2026-04-24 | — | — |
+| L | Gestion employés | v0.6 | BIZ-088 | 2026-04-25 | — | — |
+| M | Sécurité applicative | v0.6 | TEC-091, TEC-092, TEC-093 | 2026-04-25 | — | — |
+| N | UX & formulaires | v0.7 | BIZ-094, BIZ-095, BIZ-096, BIZ-097 | 2026-04-25 | — | — |
+| Q | Recette post-merge N | v0.7 | voir doc/recette.md (REC-001..REC-015) | 2026-04-26 | — | — |
+| R | Supervision système & audit | v0.8 | BIZ-108, BIZ-109 | 2026-04-26 | — | — |
+| O | Qualité technique backend | v0.7 | TEC-098, TEC-099, TEC-100 | 2026-04-26 | — | — |
+| P | Qualité technique frontend | v0.7 | TEC-101, TEC-102, TEC-103, TEC-104 | 2026-04-26 | — | — |
+| S | Documentation & i18n | v0.8 | TEC-106, CHR-021, CHR-020, CHR-079 | 2026-04-27 | — | — |
+| T | Chatbot IA + refactor Paramètres | v1.0 | BIZ-125, BIZ-126 | 2026-04-27 | — | — |
+| H-UX | Améliorations UX (lot H) | v1.1 | settings gestionnaires, dialogue paiement, champs famille contacts, date facture, commentaires, PDF règlement, verrou édition | 2026-04-28 | — | — |
+| I-BNK | UX Banque | v1.2 | BIZ-133, BIZ-134, BIZ-135, BIZ-136, BIZ-137 | 2026-05-01 | — | — |
+
+Tickets fermés hors lots : TEC-067, TEC-068, BIZ-069, BIZ-076, CHR-083, BIZ-036, BIZ-041, BIZ-033, BIZ-088, BIZ-089, BIZ-090, TEC-105, TEC-039, BIZ-106, BIZ-107, TEC-110, BIZ-108, BIZ-109, BIZ-112, BIZ-113, BIZ-114, BIZ-115, BIZ-116, BIZ-118, BIZ-121, BIZ-117, **BIZ-119**, **BIZ-123**, **BIZ-124**, **BIZ-122**, **BIZ-111**, **BIZ-138**, **BIZ-139**, **BIZ-140**, **BIZ-141**, **TEC-142**, **TEC-143**, **TEC-146**, **TEC-152**, **TEC-153**, **TEC-154**, **BIZ-155**, **BIZ-156**, **BIZ-148**.
+Tickets fermés pré-audit : CHR-001, CHR-002, BIZ-003 – BIZ-018, BIZ-022 – BIZ-023.
+
+---
+
+## Détails
+
+<details>
+<summary>Lot S — Documentation & i18n (2026-04-27)</summary>
+
+### TEC-106 — Audit et complétion des clés i18n manquantes
+
+Audit complet des 1 096 clés `t('...')` utilisées dans le frontend (1 358 appels bruts filtrés). Résultat : 2 clés manquantes (`common.active`, `common.inactive`) utilisées dans `EmployeesView.vue` — ajoutées dans `fr.ts`.
+
+### CHR-020 — Documentation de contribution
+
+`doc/dev/contributing.md` : setup local, `dev.ps1`, quality gate backend/frontend, conventions Git et workflow. Validé via PR #54.
+
+### CHR-021 — Manuel utilisateur illustré
+
+Manuel FR `doc/user/manuel.md` + référence LLM `doc/llm/reference.md`. Version textuelle complète, structure par rôle et parcours métier. Illustrations (captures annotées) reportées à une future itération.
+
+### CHR-079 — Restructuration et nettoyage de la documentation
+
+Restructuration complète du répertoire `doc/` : nouvelles arborescences `doc/admin/`, `doc/dev/`, `doc/user/`, `doc/llm/` ; suppression de 25 fichiers obsolètes ; README par section ; split des docs bilingues en fichiers par langue (`*.fr.md` / `*.en.md`). Corrections factuelles : `DATABASE_URL`, Vue Router 5, fixtures de test, durée de session, rôles règles comptables, version sync.
+
+</details>
+
+<details>
+<summary>Lot T — Chatbot IA + refactor Paramètres (2026-04-28)</summary>
+
+### BIZ-125 — Chatbot IA + page Aide
+
+- **Terminé** : 2026-04-27
+- **Livré** : sidebar chatbot flottante (SSE, Gemini/OpenAI), bouton FAB dans AppLayout, annulation, rendu Markdown via `marked` ; page `/aide` affichant `doc/user/manuel.md` en HTML ; panneau admin `SettingsChatPanel` (provider, clé API, modèle) ; backend : endpoints `/api/chat`, `/api/chat/config`, `/api/chat/logs`, `/api/help/manual` ; migrations 0035 (colonnes chat dans `app_settings`) et 0036 (table `chat_log`).
+
+### BIZ-126 — Refactor UX écran Paramètres
+
+- **Terminé** : 2026-04-27
+- **Livré** : `SettingsAssociationSmtpPanel.vue` (413 lignes) scindé en `SettingsAssociationPanel.vue` (infos association + facturation) et `SettingsSmtpPanel.vue` (SMTP) ; chaque panneau sauvegarde indépendamment. Réalisé sur la même branche que BIZ-125.
+
+</details>
+
+<details>
+<summary>Tickets fermés hors lots — détails (BIZ-111, BIZ-117, BIZ-119, BIZ-122, BIZ-123, BIZ-124)</summary>
+
+### BIZ-111 — Import one-shot adresses postales depuis factures Word
+
+- **Terminé** : 2026-04-26
+- **Livré** : script `scripts/import_addresses_from_docx.py` — extrait les adresses postales depuis les factures Word historiques et enrichit `Contact.adresse` (dry-run par défaut, `--commit` pour appliquer). 48 contacts mis à jour. Dépendance `python-docx` ajoutée dans `pyproject.toml`. Amélioration associée : affichage de l'adresse dans le PDF facture + suppression du SIRET en doublon dans la section Émetteur.
+
+### BIZ-117 — Assistant IA intégré
+
+**Clôturé ❌ Non réalisable** — intégration d'un LLM tiers exclue pour raisons de confidentialité des données comptables ; modèle local incompatible avec la contrainte RAM ≤ 384 MB du NAS.
+
+### BIZ-119 — Tableau de bord avec cartes d'actions rapides
+
+- **Terminé** : 2026-04-26
+- **Livré** : panneau « Actions rapides » en haut du dashboard — 3 cartes (facture client, paiement, caisse) ouvrant des wizards de saisie inline ; wizard facture client avec confirmation et bouton « Saisir une autre ».
+
+### BIZ-122 — Intégrer description dans l'e-mail de facture
+
+- **Terminé** : 2026-04-26
+- **Livré** : paramètre description ajouté à mail_service.send_invoice_email ; si renseigné, l'objet du message devient Facture {numéro} — {description} ; routeur send-email passe invoice.description au service.
+
+### BIZ-123 — Prix par défaut par type de ligne de facture
+
+- **Terminé** : 2026-04-26
+- **Livré** : colonnes `default_price_cours`, `default_price_adhesion`, `default_price_autres` sur `AppSettings` (migration 0034) ; section « Prix unitaires par défaut » dans les paramètres ; pré-remplissage automatique au `addLine()` et au changement de `line_type` dans `ClientInvoiceForm` ; correction race-condition (`onMounted` async avant `addLine`).
+
+### BIZ-124 — Templates de numérotation configurables pour les factures
+
+- **Terminé** : 2026-04-26
+- **Livré** : `client_invoice_number_template` (`{year}`, `{seq}`) + `client_invoice_seq_digits` + `supplier_invoice_number_template` (strftime) sur `AppSettings` (migrations 0032, 0033) ; service `_next_number` avec regex ; endpoint `GET /api/invoices/next_number` (aperçu sans side-effect) ; affichage du numéro prévu dans le formulaire de création et dans la confirmation du wizard.
+
+</details>
+
+<details>
+<summary>Historique des estimations — lots techniques 1-8 (2026-04-22)</summary>
+
+Total estimé initial : ~40h — total révisé : ~55h.
+Principaux postes de dérapage : quality gates (~10 min/commit), tests d'intégration, migrations Alembic, refactoring TEC-050.
+
+### Lot 1 — Quick wins P3 — ~45 min
+
+| Ticket | Estimation | Détail |
+| --- | --- | --- |
+| CHR-064 | 5 min | Supprimer un fichier + vérifier qu'il n'est pas importé |
+| CHR-062 | 5 min | Changer une string dans `package.json` |
+| TEC-066 | 20 min | Remplacer le pattern `global` par `@lru_cache`, vérifier les tests |
+| TEC-063 | 15 min | Remplacer 2 noms dans les fixtures + migration Alembic si nécessaire |
+
+### Lot 2 — Tests au vert (TEC-048) — ~2h
+
+11 échecs dans `excel_import_parsers` / `excel_import_parsing` + 1 erreur API de test. Suite déjà au vert (739/739) après corrections antérieures.
+
+### Lot 3 — Sécurité sans impact structurel — ~4h
+
+| Ticket | Est. initiale | Est. révisée | Temps réel | Détail |
+| --- | --- | --- | --- | --- |
+| TEC-047 | 30 min | 1h | ~1h15 | Middleware 5 en-têtes + test CSP PrimeVue |
+| TEC-052 | 20 min | 30 min | ~40 min | Conditionner endpoint sur `settings.debug` |
+| TEC-055 | 20 min | 30 min | ~25 min | Paramètre `cors_allowed_origins` |
+| TEC-060 | 30 min | 45 min | ~30 min | Retirer `create_all` de `init_db()` |
+| TEC-051 | 50 min | 1h15 | ~50 min | `MAX(entry_number)` + lock + migration |
+
+### Lot 4 — Qualité backend sans impact API — ~6h
+
+| Ticket | Est. initiale | Est. révisée | Temps réel | Détail |
+| --- | --- | --- | --- | --- |
+| TEC-065 | 1h | 1h30 | ~1h30 | Déplacer attributs transients vers `PaymentRead` |
+| TEC-057 | 2h | 2h30 | ~3h30 | `TypeDecorator` Decimal + 63 occurrences |
+| TEC-059 | 1h30 | 2h | ~45 min | `limit=100` / `max=1000` sur tous les endpoints |
+
+### Lot 5 — Sécurité auth (full-stack) — ~10h
+
+| Ticket | Est. initiale | Est. révisée | Temps réel | Détail |
+| --- | --- | --- | --- | --- |
+| TEC-045 | 1h | 1h30 | ~1h | `slowapi` rate limiting sur `/auth/login` |
+| BIZ-053 | 2h | 3h | ~1h30 | Migration `must_change_password` + guard |
+| TEC-046 | 4h | 5h30 | — | Cookie `HttpOnly` + intercepteur Axios + `/auth/refresh` |
+
+### Lot 6 — DevOps Docker — ~1h30
+
+| Ticket | Est. initiale | Est. révisée | Détail |
+| --- | --- | --- | --- |
+| CHR-054 | 40 min | 50 min | `entrypoint.sh` avec gestion d'erreur |
+| CHR-061 | 20 min | 20 min | `HEALTHCHECK` Docker + docker-compose |
+
+### Lot 7 — Refactoring structurel — ~12h
+
+| Ticket | Est. initiale | Est. révisée | Détail |
+| --- | --- | --- | --- |
+| TEC-050 | 6h | 9h | Éclater `excel_import.py` (5 038 L) en package |
+| TEC-058 | 2h | 1h | Typer les `except Exception` |
+
+### Lot 8 — Chantiers longs
+
+| Ticket | Est. initiale | Est. révisée | Détail |
+| --- | --- | --- | --- |
+| BIZ-056 | 3-4h | 2h | Table d'audit + middleware + 4 types d'événements |
+| TEC-049 | 10-15h | 12-20h | Palier 34 % → 60 % couverture de test |
+
+</details>
+
+<details>
+<summary>Détails des sujets fermés — cliquer pour développer</summary>
+
+### CHR-001 — Stabiliser la méthode de triage du backlog
+
+- **Dates** : `created=2026-04-12`, `completed=2026-04-12`
+- **Livré** : backlog utilisé comme support versionné avec statuts, priorités et mises à jour récurrentes.
+
+### CHR-002 — Documentation utilisateur import/reset
+
+- **Dates** : `created=2026-04-12`, `completed=2026-04-12`
+- **Livré** : documentation rédigée dans `doc/user/import-excel-et-reinitialisation.md`.
+
+### BIZ-003 — Campagne de retest métier sur imports réels
+
+- **Dates** : `created=2026-04-12`, `completed=2026-04-12`
+- **Livré** : rejeu réel confirmé sans écart bloquant, procédure ajustée pour exercices/compteurs.
+
+### BIZ-004 — Historique d'import réversible
+
+- **Dates** : `created=2026-04-12`, `started=2026-04-20`, `completed=2026-04-20`
+- **Livré** : backend `runs`, `operations`, `effects` réversibles, API cycle `prepare → execute → undo/redo`, UI prévisualisation + historique. Stabilisation rapprochement paiement/facture intra-run.
+
+### BIZ-005 — Politique de coexistence import / écritures existantes
+
+- **Dates** : `created=2026-04-12`, `started=2026-04-19`, `completed=2026-04-19`
+- **Livré** : politique explicitée dans `doc/dev/BIZ-005-politique-coexistence-imports.md`, trois diagnostics : `entry-existing`, `entry-covered-by-solde`, `entry-near-manual`.
+
+### CHR-006 — Warnings de dépréciation FastAPI
+
+- **Dates** : `created=2026-04-12`, `started=2026-04-21`, `completed=2026-04-21`
+- **Livré** : `HTTP_422_UNPROCESSABLE_ENTITY` → `HTTP_422_UNPROCESSABLE_CONTENT`, zéro warning.
+
+### CHR-007 — Source de vérité backlog vs issues GitHub
+
+- **Dates** : `created=2026-04-12`, `completed=2026-04-13`
+- **Livré** : convention actée — `doc/backlog.md` = source de vérité.
+
+### BIZ-008 — Import Excel comme validation itérative de convergence
+
+- **Dates** : `created=2026-04-12`, `started=2026-04-18`, `completed=2026-04-18`
+- **Livré** : modes `convergence globale` et `validation moteur Gestion`, preview bidirectionnelle, script `scripts/run_excel_convergence_preview.py`. Documentation dans `doc/dev/BIZ-008-recette-convergence.md`.
+- **Détail** : grille de contrôle par domaine (factures, paiements, banque, caisse, comptes pivots), politique d'écarts résiduels, périmètre asymétrique `Solde ↔ Excel` par exercice.
+
+### BIZ-009 — Enrichir le plan comptable par défaut
+
+- **Dates** : `created=2026-04-12`, `completed=2026-04-12`
+- **Livré** : seed enrichi avec comptes réels, sous-comptes historiques conservés inactifs.
+
+### BIZ-010 — Stratégie de clôture des exercices historiques
+
+- **Dates** : `created=2026-04-12`, `completed=2026-04-12`
+- **Livré** : exercices historiques ouverts pendant reprise, clôture administrative sans écritures de clôture.
+
+### BIZ-011 — Exercice courant global
+
+- **Dates** : `created=2026-04-12`, `completed=2026-04-12`
+- **Livré** : store global d'exercice + sélecteur partagé + filtrage métier par défaut.
+
+### BIZ-012 — Liste des paiements : référence et édition
+
+- **Dates** : `created=2026-04-12`, `completed=2026-04-12`
+- **Livré** : colonne Référence + bouton d'édition par ligne + dialogue `PUT /payments/{id}`.
+
+### BIZ-013 — Journal de caisse : référence, détail et édition
+
+- **Dates** : `created=2026-04-12`, `completed=2026-04-12`
+- **Livré** : référence visible, panneau de détail, édition directe, recalcul soldes après modification.
+
+### BIZ-014 — Journal comptable : lisibilité et navigation
+
+- **Dates** : `created=2026-04-12`, `completed=2026-04-12`
+- **Livré** : libellés comptes, références métier, tiers, détail, édition manuelles, navigation factures.
+
+### BIZ-015 — Reset sélectif orienté reprise d'import
+
+- **Dates** : `created=2026-04-13`, `started=2026-04-20`, `completed=2026-04-20`
+- **Livré** : reset sélectif par type d'import + exercice avec prévisualisation, UI dans Paramètres, suppression des dépendances métier dérivées.
+
+### BIZ-016 — Harmonisation i18n et microcopie UI
+
+- **Dates** : `created=2026-04-13`, `started=2026-04-14`, `completed=2026-04-14`
+- **Livré** : clés i18n cohérentes sur Banque, Caisse, Salaires (compteurs, états vides, libellés).
+
+### BIZ-017 — Formats de dates et périodes en français
+
+- **Dates** : `created=2026-04-13`, `started=2026-04-14`, `completed=2026-04-14`
+- **Livré** : helper partagé pour mois en français, appliqué sur Salaires et Dashboard mensuel.
+
+### BIZ-018 — Lisibilité des écrans de liste
+
+- **Dates** : `created=2026-04-13`, `started=2026-04-14`, `completed=2026-04-14`
+- **Livré** : socle DataTable partagé (filtres texte/dates/intervalles/multi-sélection, compteurs, tri, saisie date FR/ISO).
+
+### BIZ-022 — Gestion des utilisateurs, rôles et sécurité
+
+- **Dates** : `created=2026-04-13`, `started=2026-04-13`, `completed=2026-04-19`
+- **Livré** : cycle de vie complet : rôles métier, administration comptes, profil, changement MDP, réinitialisation admin, invalidation jetons.
+
+### BIZ-023 — Matrice d'autorisations par rôle
+
+- **Dates** : `created=2026-04-13`, `started=2026-04-14`, `completed=2026-04-14`
+- **Livré** : séparation Gestion/Comptabilité dans la navigation, guards frontend par domaine, renommage Gestionnaire/Comptable, permissions backend alignées.
+
+### BIZ-036 — Carte « restant en retard » cliquable
+
+- **Dates** : `created=2026-04-21`, `completed=2026-04-23`
+- **Livré** : absorbé par BIZ-075 (KPI dashboard cliquables).
+
+### BIZ-041 — Carte « non remis » cliquable
+
+- **Dates** : `created=2026-04-21`, `completed=2026-04-23`
+- **Livré** : absorbé par BIZ-075 (KPI dashboard cliquables).
+
+### BIZ-042 — Bouton reset filtres tables
+
+- **Dates** : `created=2026-04-21`, `completed=2026-04-23`
+- **Livré** : bouton reset sur tous les filtres de toutes les tables.
+
+### BIZ-043 — Combos comptes comptables couleur
+
+- **Dates** : `created=2026-04-21`, `completed=2026-04-23`
+- **Livré** : combos affichant numéro, nom et couleur des comptes suivis.
+
+### TEC-045 — Rate limiting `/auth/login`
+
+- **Dates** : `created=2026-04-22`, `completed=2026-04-23`
+- **Livré** : middleware `slowapi` 5 req/min par IP, bypass configurable pour tests.
+
+### TEC-046 — Refresh token cookie HttpOnly
+
+- **Dates** : `created=2026-04-22`, `completed=2026-04-22`
+- **Livré** : cookie `HttpOnly`/`Secure`/`SameSite=Strict`, endpoint `POST /auth/logout`, intercepteur Axios `withCredentials: true`, 6 tests dédiés.
+
+### TEC-047 — En-têtes de sécurité HTTP
+
+- **Dates** : `created=2026-04-22`, `completed=2026-04-22`
+- **Livré** : middleware CSP, HSTS, X-Content-Type-Options, X-Frame-Options. `dark-mode-init.js` extrait pour CSP `script-src 'self'`.
+
+### TEC-048 — Corriger les tests en échec
+
+- **Dates** : `created=2026-04-22`, `completed=2026-04-22`
+- **Livré** : suite 739/739 au vert. Test API adapté pour `@lru_cache` (TEC-066).
+
+### TEC-049 — Remonter la couverture de test
+
+- **Dates** : `created=2026-04-22`, `completed=2026-04-22`
+- **Livré** : +44 tests (812 → 856), couverture 29% → 71%. Services critiques ≥ 90% : accounting_engine 92%, invoice 93%, payment 90%, fiscal_year ~95%, salary ~95%.
+
+### TEC-050 — Refactorer `excel_import.py` en package
+
+- **Dates** : `created=2026-04-22`, `completed=2026-04-22`
+- **Livré** : monolith 5 567 lignes éclaté en 16 sous-modules + `__init__.py` re-export. Aucune dépendance circulaire.
+
+### TEC-051 — Numérotation des écritures thread-safe
+
+- **Dates** : `created=2026-04-22`, `completed=2026-04-22`
+- **Livré** : `COUNT(*)` → `MAX(entry_number)` + lock, migration, tests de concurrence.
+
+### TEC-052 — Désactiver `reset-db` en production
+
+- **Dates** : `created=2026-04-22`, `completed=2026-04-22`
+- **Livré** : endpoint conditionné à `settings.debug`.
+
+### BIZ-053 — Changement MDP obligatoire au premier login
+
+- **Dates** : `created=2026-04-22`, `completed=2026-04-23`
+- **Livré** : champ `must_change_password` (migration 0022), middleware 403, redirection frontend, 11 tests intégration + 2 tests frontend.
+
+### CHR-054 — Séparer migrations du démarrage Uvicorn
+
+- **Dates** : `created=2026-04-22`, `completed=2026-04-22`
+- **Livré** : `entrypoint.sh` avec `set -e`, Dockerfile mis à jour avec `ENTRYPOINT`.
+
+### TEC-055 — CORS configurable pour la production
+
+- **Dates** : `created=2026-04-22`, `completed=2026-04-22`
+- **Livré** : paramètre `cors_allowed_origins` dans les settings.
+
+### BIZ-056 — Journal d'audit structuré
+
+- **Dates** : `created=2026-04-22`, `completed=2026-04-23`
+- **Livré** : modèle `AuditLog` + service `record_audit` + migration 0023. Événements : auth (login/logout/password), admin (user CRUD, reset_db, selective_reset). 14 tests.
+
+### TEC-057 — TypeDecorator Decimal pour l'ORM
+
+- **Dates** : `created=2026-04-22`, `completed=2026-04-22`
+- **Livré** : `DecimalType(TypeDecorator)` sur toutes les colonnes monétaires, ~63 casts `Decimal(str())` retirés.
+
+### TEC-058 — Typer les exceptions de l'import Excel
+
+- **Dates** : `created=2026-04-22`, `completed=2026-04-22`
+- **Livré** : `ImportFileOpenError`, `ImportSheetError` dans `_exceptions.py`, mapping typé dans routeur. 10 tests ajoutés.
+
+### TEC-059 — Pagination bornée par défaut
+
+- **Dates** : `created=2026-04-22`, `completed=2026-04-22`
+- **Livré** : `limit=100` / `max=1000` sur tous les endpoints de liste. Frontend et tests adaptés.
+
+### TEC-060 — Retirer `create_all` de `init_db()`
+
+- **Dates** : `created=2026-04-22`, `completed=2026-04-22`
+- **Livré** : `create_all` conservé uniquement dans `conftest.py`, Alembic seul en prod.
+
+### CHR-061 — Docker HEALTHCHECK
+
+- **Dates** : `created=2026-04-22`, `completed=2026-04-22`
+- **Livré** : `GET /api/health` (200), `HEALTHCHECK` dans Dockerfile, `healthcheck:` dans docker-compose.
+
+### CHR-062 — Synchroniser les versions frontend / backend
+
+- **Dates** : `created=2026-04-22`, `completed=2026-04-22`
+- **Livré** : `frontend/package.json` aligné sur `0.1.0`.
+
+### TEC-063 — Retirer les noms personnels du plan comptable (RGPD)
+
+- **Dates** : `created=2026-04-22`, `completed=2026-04-22`
+- **Livré** : noms remplacés par `Client litigieux 1/2`. Seed ne touche pas les données existantes.
+
+### CHR-064 — Supprimer `stores/counter.ts`
+
+- **Dates** : `created=2026-04-22`, `completed=2026-04-22`
+- **Livré** : fichier supprimé, aucune référence dans le code.
+
+### TEC-065 — Éliminer `__allow_unmapped__` de Payment
+
+- **Dates** : `created=2026-04-22`, `completed=2026-04-22`
+- **Livré** : attributs transients déplacés vers `PaymentRead` via `_to_payment_read()`.
+
+### TEC-066 — Settings singleton `@lru_cache`
+
+- **Dates** : `created=2026-04-22`, `completed=2026-04-22`
+- **Livré** : `@lru_cache(maxsize=1)` sur `get_settings()`, variable globale supprimée.
+
+### TEC-067 — Gestionnaire d'erreurs global FastAPI
+
+- **Dates** : `created=2026-04-23`, `completed=2026-04-23`
+- **Livré** : middleware `UnhandledExceptionMiddleware` → JSON 500 `{"detail": ..., "code": "INTERNAL_SERVER_ERROR"}`, log serveur. 5 tests.
+
+### TEC-068 — Désactiver Swagger/ReDoc en production
+
+- **Dates** : `created=2026-04-23`, `completed=2026-04-23`
+- **Livré** : `docs_url`, `redoc_url`, `openapi_url` conditionnés à `cfg.debug`.
+
+### BIZ-069 — Endpoint de sauvegarde SQLite
+
+- **Dates** : `created=2026-04-23`, `completed=2026-04-23`
+- **Livré** : `POST /api/settings/backup` avec `sqlite3.backup()` + rotation 5 fichiers.
+
+### BIZ-070 — Page 404 dédiée
+
+- **Dates** : `created=2026-04-23`, `completed=2026-04-23`
+- **Livré** : `NotFoundView.vue` avec icône, titre i18n, bouton retour. Catch-all router remplacé.
+
+### BIZ-071 — Skeleton loaders
+
+- **Dates** : `created=2026-04-23`, `completed=2026-04-23`
+- **Livré** : `<Skeleton>` PrimeVue sur les écrans de liste principaux.
+
+### BIZ-072 — Fil d'Ariane (Breadcrumb)
+
+- **Dates** : `created=2026-04-23`, `completed=2026-04-23`
+- **Livré** : composable `useBreadcrumb` + `<Breadcrumb>` PrimeVue via meta routes `label`/`breadcrumbParent`.
+
+### BIZ-073 — Raccourcis clavier
+
+- **Dates** : `created=2026-04-23`, `completed=2026-04-23`
+- **Livré** : composable `useKeyboardShortcuts` (Ctrl+N, Ctrl+S, Escape).
+
+### BIZ-074 — Bandeau connexion perdue
+
+- **Dates** : `created=2026-04-23`, `completed=2026-04-23`
+- **Livré** : composable `useNetworkStatus` + `AppOfflineBanner.vue` (events online/offline + intercepteur Axios).
+
+### BIZ-075 — Dashboard KPI cliquables
+
+- **Dates** : `created=2026-04-23`, `completed=2026-04-23`
+- **Livré** : KPI cliquables vers listes filtrées. Complète BIZ-036 et BIZ-041.
+
+### BIZ-076 — Styles d'impression comptable
+
+- **Dates** : `created=2026-04-23`, `completed=2026-04-23`
+- **Livré** : `@media print` sur journal, balance, grand livre, bilan, résultat. Sidebar/filtres/boutons masqués, en-tête imprimable.
+
+### TEC-079 — Tests composables frontend
+
+- **Dates** : `created=2026-04-23`, `completed=2026-04-24`
+- **Livré** : 15 tests Vitest — `useDarkMode` (4), `useTableFilter` (8), `activeFilterLabels` (10). Suite 126/126 au vert.
+
+### TEC-080 — Smoke test E2E Playwright
+
+- **Dates** : `created=2026-04-23`, `completed=2026-04-24`
+- **Livré** : `playwright.config.ts` (webServer auto-start, DB E2E dédiée). Smoke test : login → MDP obligatoire → dashboard → contacts → factures → paiements.
+
+### TEC-081 — Tests d'intégration API manquants
+
+- **Dates** : `created=2026-04-23`, `completed=2026-04-24`
+- **Livré** : `test_accounting_rules_api.py` (11), `test_fiscal_year_api.py` (10), `test_salary_api.py` (+7), `test_dashboard_api.py` (+1). 52 tests intégration au vert.
+
+### CHR-083 — Guide de migration Synology
+
+- **Dates** : `created=2026-04-23`, `completed=2026-04-23`
+- **Livré** : guide FR+EN dans `doc/user/` couvrant mise à jour Docker, vérification post-migration, rollback.
+
+### BIZ-084 — Notification expiration session
+
+- **Dates** : `created=2026-04-23`, `completed=2026-05-03`
+- **Livré** : composable `useSessionExpiry` (décode expiry JWT, avertissement T−5 min) + `AppSessionWarning.vue` avec bouton « Prolonger la session ».
+
+### TEC-085 — Politique de complexité MDP
+
+- **Dates** : `created=2026-04-23`, `completed=2026-04-23`
+- **Livré** : validateur `_validate_password_complexity` (8 chars, majuscule, chiffre). 14 tests unitaires.
+
+</details>

--- a/doc/backlog.md
+++ b/doc/backlog.md
@@ -51,7 +51,7 @@ Décisions métier nécessaires avant implémentation.
 
 | Lot | Nom | Version | Tickets | Terminé | Est. Copilot | Réel Copilot |
 | --- | --- | --- | --- | --- | --- | --- |
-| CR2 | Correctifs & finitions post-MOB | v1.5 | TEC-157, TEC-158, TEC-159, BIZ-165, BIZ-166, CHR-078 | 2026-05-04 | ~80 min | ~25 min |
+| CR2 | Correctifs & finitions post-MOB | v1.5 | TEC-157, TEC-158, TEC-159, BIZ-165, BIZ-166, BIZ-167, CHR-078 | 2026-05-04 | ~85 min | ~27 min |
 | Wizard | Wizard factures & Contacts | v1.2 | BIZ-144, BIZ-145, BIZ-147, BIZ-151 | 2026-05-02 | — | — |
 | CR | Correctifs revue de code | v1.3.1 | TEC-133, TEC-134, TEC-135, TEC-136, TEC-137, TEC-138, TEC-139, TEC-140, TEC-141, TEC-155 | 2026-05-02 | — | — |
 | DOC | Documentation utilisateur | v1.5 | BIZ-161, BIZ-162, BIZ-163 | 2026-05-03 | ~115 min | ~45 min |

--- a/doc/backlog.md
+++ b/doc/backlog.md
@@ -11,27 +11,19 @@ Quand un sujet est livré, mettre à jour `CHANGELOG.md` et passer le ticket en 
 
 ## Calibration estimations
 
-Facteur de marge actuel : **1,00** (0%) — raméné après Lot UI (voir ci-dessous).
+Facteur de marge actuel : **1,00** (0%) — inchangé (voir note CR2).
 
 | Lot | Estimé Copilot | Réel Copilot | Ratio | Estimé gestion | Réel gestion | Ajustement |
 | --- | --- | --- | --- | --- | --- | --- |
 | UI | ~65 min | ~30 min | **0,46** | 15 min | ? | ↓ facteur → 1,00 |
+| CR2 | ~70 min | ~20 min | **0,29** | — | — | voir note |
 
-> Lot UI : estimations 2x trop élevées. Les tickets UI/bulk-replace et les vérifications de tickets "déjà fait" ont été surestimés. Pour les prochains lots, utiliser les réels de ce lot comme calibration : bulk-replace ~3 min, ajout d’une fonction simple ~7 min, mise à jour de N routeurs/vues ~18 min.
+> Lot UI : estimations 2x trop élevées. Les tickets UI/bulk-replace et les vérifications de tickets "déjà fait" ont été surestimés.
+> Lot CR2 : ratio 0,29 — très inférieur à 1,15. Cependant ces tickets étaient tous très petits (i18n, tests, nav, squelette) et le facteur 1,00 reflète déjà une marge nulle. Plutôt que d'abaisser le facteur en dessous de 1,00 (ce qui serait contre-productif), la leçon est : **pour les tickets de finition/tests simples, l'estimation de référence doit être 3–5 min, pas 10–20 min**. Facteur maintenu à 1,00 ; calibration des estimations unitaires à revoir pour ces catégories.
 
 ---
 
 ## Lots actifs
-
-### Lot CR2 — Correctifs & finitions post-MOB
-
-| ID | Titre | Prio | Est. | Créé | Démarré | Terminé |
-| --- | --- | --- | --- | --- | --- | --- |
-| TEC-157 | i18n : supprimer chaînes en dur dans AppMobileCardList + CashView | P3 | ~10 min | 2026-05-03 | 2026-05-04 | 2026-05-04 |
-| TEC-158 | Tests intégration suggest_cheque_number (statut, date, incrément, accès) | P2 | ~20 min | 2026-05-03 | 2026-05-04 | 2026-05-04 |
-| TEC-159 | Tests validation cheque_number_template dans settings API | P2 | ~15 min | 2026-05-03 | 2026-05-04 | 2026-05-04 |
-| BIZ-165 | Navigation précédent/suivant sur preview factures client | P2 | ~10 min | 2026-05-03 | 2026-05-04 | 2026-05-04 |
-| CHR-078 | Squelette i18n anglais | P3 | ~15 min | 2026-04-23 | 2026-05-04 | 2026-05-04 |
 
 ### Hors lots
 
@@ -42,6 +34,11 @@ Facteur de marge actuel : **1,00** (0%) — raméné après Lot UI (voir ci-dess
 ---
 
 ## Détails
+
+### BIZ-166 — Vue contacts : onglet clients par défaut + tri par récence
+
+Onglet "Clients" activé par défaut (ordre : Clients > Fournisseurs > Tout).
+Tri synthétique : facture < 6 mois en tête, puis ordre alphabétique (nom, prénom).
 
 ### BIZ-034 — Support multi-compte banque
 
@@ -54,7 +51,7 @@ Décisions métier nécessaires avant implémentation.
 
 | Lot | Nom | Version | Tickets | Terminé | Est. Copilot | Réel Copilot |
 | --- | --- | --- | --- | --- | --- | --- |
-| CR2 | Correctifs & finitions post-MOB | v1.5 | TEC-157, TEC-158, TEC-159, BIZ-165, CHR-078 | 2026-05-04 | ~70 min | — |
+| CR2 | Correctifs & finitions post-MOB | v1.5 | TEC-157, TEC-158, TEC-159, BIZ-165, BIZ-166, CHR-078 | 2026-05-04 | ~80 min | ~25 min |
 | Wizard | Wizard factures & Contacts | v1.2 | BIZ-144, BIZ-145, BIZ-147, BIZ-151 | 2026-05-02 | — | — |
 | CR | Correctifs revue de code | v1.3.1 | TEC-133, TEC-134, TEC-135, TEC-136, TEC-137, TEC-138, TEC-139, TEC-140, TEC-141, TEC-155 | 2026-05-02 | — | — |
 | DOC | Documentation utilisateur | v1.5 | BIZ-161, BIZ-162, BIZ-163 | 2026-05-03 | ~115 min | ~45 min |
@@ -66,12 +63,12 @@ Décisions métier nécessaires avant implémentation.
 
 | Ticket | Titre | Est. | Réel |
 | --- | --- | --- | --- |
-| TEC-157 | i18n AppMobileCardList + CashView | ~10 min | — |
-| TEC-158 | Tests intégration suggest_cheque_number (5 tests) | ~20 min | — |
-| TEC-159 | Tests cheque_number_template settings API (4 tests) | ~15 min | — |
-| BIZ-165 | Navigation prev/next preview factures client | ~10 min | — |
-| CHR-078 | Squelette i18n anglais (en.ts) | ~15 min | — |
-| **Total** | | **~70 min** | **—** |
+| TEC-157 | i18n AppMobileCardList + CashView | ~10 min | ~3 min |
+| TEC-158 | Tests intégration suggest_cheque_number (5 tests) | ~20 min | ~5 min |
+| TEC-159 | Tests cheque_number_template settings API (4 tests) | ~15 min | ~4 min |
+| BIZ-165 | Navigation prev/next preview factures client | ~10 min | ~5 min |
+| CHR-078 | Squelette i18n anglais (en.ts) | ~15 min | ~3 min |
+| **Total** | | **~70 min** | **~20 min** |
 
 ### Détail
 

--- a/doc/backlog.md
+++ b/doc/backlog.md
@@ -51,7 +51,7 @@ Décisions métier nécessaires avant implémentation.
 
 | Lot | Nom | Version | Tickets | Terminé | Est. Copilot | Réel Copilot |
 | --- | --- | --- | --- | --- | --- | --- |
-| CR2 | Correctifs & finitions post-MOB | v1.5 | TEC-157, TEC-158, TEC-159, BIZ-165, BIZ-166, BIZ-167, CHR-078 | 2026-05-04 | ~85 min | ~27 min |
+| CR2 | Correctifs & finitions post-MOB | v1.5 | TEC-157, TEC-158, TEC-159, BIZ-165, BIZ-166, BIZ-167, BIZ-168, CHR-078 | 2026-05-04 | ~95 min | ~30 min |
 | Wizard | Wizard factures & Contacts | v1.2 | BIZ-144, BIZ-145, BIZ-147, BIZ-151 | 2026-05-02 | — | — |
 | CR | Correctifs revue de code | v1.3.1 | TEC-133, TEC-134, TEC-135, TEC-136, TEC-137, TEC-138, TEC-139, TEC-140, TEC-141, TEC-155 | 2026-05-02 | — | — |
 | DOC | Documentation utilisateur | v1.5 | BIZ-161, BIZ-162, BIZ-163 | 2026-05-03 | ~115 min | ~45 min |

--- a/doc/backlog.md
+++ b/doc/backlog.md
@@ -5,6 +5,8 @@ Backlog produit pour Solde ⚖️ — gestion comptable associative.
 Quand le travail démarre sur un sujet, créer une branche `feature/` depuis `develop`.
 Quand un sujet est livré, mettre à jour `CHANGELOG.md` et passer le ticket en ✅ Fait ici.
 
+> Lots terminés depuis plus de 3 jours → [backlog-archive.md](backlog-archive.md)
+
 ---
 
 ## Calibration estimations
@@ -21,90 +23,65 @@ Facteur de marge actuel : **1,00** (0%) — raméné après Lot UI (voir ci-dess
 
 ## Lots actifs
 
+### Lot CR2 — Correctifs & finitions post-MOB
+
+| ID | Titre | Prio | Est. | Créé | Démarré | Terminé |
+| --- | --- | --- | --- | --- | --- | --- |
+| TEC-157 | i18n : supprimer chaînes en dur dans AppMobileCardList + CashView | P3 | ~10 min | 2026-05-03 | 2026-05-04 | 2026-05-04 |
+| TEC-158 | Tests intégration suggest_cheque_number (statut, date, incrément, accès) | P2 | ~20 min | 2026-05-03 | 2026-05-04 | 2026-05-04 |
+| TEC-159 | Tests validation cheque_number_template dans settings API | P2 | ~15 min | 2026-05-03 | 2026-05-04 | 2026-05-04 |
+| BIZ-165 | Navigation précédent/suivant sur preview factures client | P2 | ~10 min | 2026-05-03 | 2026-05-04 | 2026-05-04 |
+| CHR-078 | Squelette i18n anglais | P3 | ~15 min | 2026-04-23 | 2026-05-04 | 2026-05-04 |
+
 ### Hors lots
 
 | ID | Titre | Prio | Est. | Créé | Démarré | Terminé |
 | --- | --- | --- | --- | --- | --- | --- |
-| TEC-156 | Fix token auth chat (localStorage → Pinia) | P1 | — | 2026-05-03 | 2026-05-03 | 2026-05-03 |
-| TEC-157 | i18n : supprimer chaînes en dur dans AppMobileCardList + CashView | P3 | ~10 min | 2026-05-03 | | |
-| TEC-158 | Tests intégration suggest_cheque_number (statut, date, incrément, accès) | P2 | ~20 min | 2026-05-03 | | |
-| TEC-159 | Tests validation cheque_number_template dans settings API | P2 | ~15 min | 2026-05-03 | | |
-| BIZ-165 | Navigation précédent/suivant sur preview factures client | P2 | ~10 min | 2026-05-03 | | |
-| CHR-078 | Squelette i18n anglais | P3 | ~15 min | 2026-04-23 | | |
 | BIZ-034 | Support multi-compte banque | P3 | ~60 min | 2026-04-21 | | |
 
 ---
 
 ## Détails
 
-### BIZ-165 — Navigation précédent/suivant sur preview factures client
-
-La preview des factures fournisseur dispose de boutons « ◀ Précédent / Suivant ▶ » permettant de naviguer dans la liste sans fermer le dialogue. Cette fonctionnalité est absente de la preview des factures client. Uniformiser les deux en ajoutant la même navigation dans `ClientInvoicesView.vue` / le composant de prévisualisation des factures client.
-
 ### BIZ-034 — Support multi-compte banque
 
 Distinguer compte courant et compte épargne dans les données, imports et écrans.
 Décisions métier nécessaires avant implémentation.
 
-### TEC-156 — Fix token auth chat (localStorage → Pinia)
-
-`streamChat` dans `api/chat.ts` lisait `localStorage.getItem('access_token')` — toujours `null` car le token est stocké uniquement en mémoire Pinia (mitigation XSS). Chaque `POST /api/chat` retournait 401. Corrigé en lisant `useAuthStore().accessToken`. Découvert lors du test du Lot DOC (2026-05-03). ✅ Fait
-
-### CHR-078 — Squelette i18n anglais
-
-Créer `en.ts` avec les clés structurelles pour préparer la localisation anglaise.
-
-### TEC-157 — i18n : supprimer chaînes en dur dans AppMobileCardList + CashView
-
-Suite à la revue Copilot de la PR #76 : `emptyMessage: 'Aucune donnée'` dans `AppMobileCardList.vue` et `"Écart :"` dans `CashView.vue` sont des chaînes UI codées en dur. Les remplacer par des clés i18n (ou exposer via slot `#empty`), cohérent avec le reste de l'app.
-
-### TEC-158 — Tests intégration suggest_cheque_number
-
-Suite à la revue Copilot de la PR #76 : l'endpoint `GET /api/payments/suggest_cheque_number` n'a pas de tests dans `tests/integration/test_payments_api.py`. Couvrir : statut 200 + format de retour, `payment_date` explicite vs défaut, incrément quand des paiements chèque existent, contrôle d'accès.
-
-### TEC-159 — Tests validation cheque_number_template dans settings API
-
-Suite à la revue Copilot de la PR #76 : `cheque_number_template` dans `AppSettingsUpdate` n'est pas testé dans `tests/integration/test_settings_api.py`. Couvrir : valeur par défaut renvoyée par `GET /api/settings/`, cas invalides (sans `{seq}`, placeholders non supportés).
-
 ---
 
-## Lots terminés
+## Lots terminés récents (≤ 3 jours)
 
 | Lot | Nom | Version | Tickets | Terminé | Est. Copilot | Réel Copilot |
 | --- | --- | --- | --- | --- | --- | --- |
-| DOC | Documentation utilisateur | v1.5 | BIZ-161, BIZ-162, BIZ-163 | 2026-05-03 | ~115 min | ~45 min |
-| 1 | Quick wins P3 | v0.2 | CHR-064, CHR-062, TEC-066, TEC-063 | 2026-04-22 | — | — |
-| 2 | Tests au vert | v0.2 | TEC-048 | 2026-04-22 | — | — |
-| 3 | Sécurité sans impact structurel | v0.2 | TEC-047, TEC-052, TEC-055, TEC-060, TEC-051 | 2026-04-22 | — | — |
-| 4 | Qualité backend sans impact API | v0.2 | TEC-065, TEC-057, TEC-059 | 2026-04-22 | — | — |
-| 5 | Sécurité auth (full-stack) | v0.2 | TEC-045, BIZ-053, TEC-046 | 2026-04-22 | — | — |
-| 6 | DevOps Docker | v0.2 | CHR-054, CHR-061 | 2026-04-22 | — | — |
-| 7 | Refactoring structurel | v0.2 | TEC-050, TEC-058 | 2026-04-22 | — | — |
-| 8 | Chantiers longs | v0.2 | BIZ-056, TEC-049 | 2026-04-22 | — | — |
-| A | Backend rapide | v0.3 | TEC-085 | 2026-04-23 | — | — |
-| B | UX quick wins | v0.3 | BIZ-070, BIZ-072, BIZ-074, BIZ-084, BIZ-042 | 2026-04-23 | — | — |
-| C | Dashboard interactif | v0.3 | BIZ-075, BIZ-073 | 2026-04-23 | — | — |
-| D | Polish UI | v0.3 | BIZ-071, BIZ-043 | 2026-04-23 | — | — |
-| F | Tests | v0.4 | TEC-079, TEC-080, TEC-081 | 2026-04-24 | — | — |
-| G | Refactoring frontend | v0.5 | TEC-077 | 2026-04-24 | — | — |
-| I | Polish UI & contacts | v0.5 | BIZ-035, BIZ-037, CHR-038, BIZ-040 | 2026-04-24 | — | — |
-| J | CI GitHub Actions | v0.5 | CHR-086, CHR-087 | 2026-04-24 | — | — |
-| K | Documentation & Swagger | v0.5 | CHR-019, CHR-082 | 2026-04-24 | — | — |
-| L | Gestion employés | v0.6 | BIZ-088 | 2026-04-25 | — | — |
-| M | Sécurité applicative | v0.6 | TEC-091, TEC-092, TEC-093 | 2026-04-25 | — | — |
-| N | UX & formulaires | v0.7 | BIZ-094, BIZ-095, BIZ-096, BIZ-097 | 2026-04-25 | — | — |
-| Q | Recette post-merge N | v0.7 | voir doc/recette.md (REC-001..REC-015) | 2026-04-26 | — | — |
-| R | Supervision système & audit | v0.8 | BIZ-108, BIZ-109 | 2026-04-26 | — | — |
-| O | Qualité technique backend | v0.7 | TEC-098, TEC-099, TEC-100 | 2026-04-26 | — | — |
-| P | Qualité technique frontend | v0.7 | TEC-101, TEC-102, TEC-103, TEC-104 | 2026-04-26 | — | — |
-| S | Documentation & i18n | v0.8 | TEC-106, CHR-021, CHR-020, CHR-079 | 2026-04-27 | — | — |
-| T | Chatbot IA + refactor Paramètres | v1.0 | BIZ-125, BIZ-126 | 2026-04-27 | — | — |
-| H-UX | Améliorations UX (lot H) | v1.1 | settings gestionnaires, dialogue paiement, champs famille contacts, date facture, commentaires, PDF règlement, verrou édition | 2026-04-28 | — | — |
-| I-BNK | UX Banque | v1.2 | BIZ-133, BIZ-134, BIZ-135, BIZ-136, BIZ-137 | 2026-05-01 | — | — |
+| CR2 | Correctifs & finitions post-MOB | v1.5 | TEC-157, TEC-158, TEC-159, BIZ-165, CHR-078 | 2026-05-04 | ~70 min | — |
 | Wizard | Wizard factures & Contacts | v1.2 | BIZ-144, BIZ-145, BIZ-147, BIZ-151 | 2026-05-02 | — | — |
 | CR | Correctifs revue de code | v1.3.1 | TEC-133, TEC-134, TEC-135, TEC-136, TEC-137, TEC-138, TEC-139, TEC-140, TEC-141, TEC-155 | 2026-05-02 | — | — |
+| DOC | Documentation utilisateur | v1.5 | BIZ-161, BIZ-162, BIZ-163 | 2026-05-03 | ~115 min | ~45 min |
 | UI | Améliorations UI & saisie | v1.4 | BIZ-149, BIZ-150, BIZ-157, BIZ-158 | 2026-05-03 | ~65 min | ~30 min |
 | MOB | Mode téléphone | v1.5 | BIZ-164 | 2026-05-03 | ~90 min | — |
+
+<details>
+<summary>Lot CR2 — Correctifs &amp; finitions post-MOB (2026-05-04)</summary>
+
+| Ticket | Titre | Est. | Réel |
+| --- | --- | --- | --- |
+| TEC-157 | i18n AppMobileCardList + CashView | ~10 min | — |
+| TEC-158 | Tests intégration suggest_cheque_number (5 tests) | ~20 min | — |
+| TEC-159 | Tests cheque_number_template settings API (4 tests) | ~15 min | — |
+| BIZ-165 | Navigation prev/next preview factures client | ~10 min | — |
+| CHR-078 | Squelette i18n anglais (en.ts) | ~15 min | — |
+| **Total** | | **~70 min** | **—** |
+
+### Détail
+
+- **TEC-157** : `AppMobileCardList.vue` — prop `emptyMessage` default migré vers `t('common.empty')` + import `useI18n`. `CashView.vue` — `'Écart :'` remplacé par `t('cash.count_diff')`. Clé `common.empty: 'Aucune donnée.'` ajoutée dans `fr.ts`.
+- **TEC-158** : 5 tests dans `test_payments_api.py` : statut 200, string non vide, pas de date → aujourd'hui, incrément après un chèque existant, 401 sans auth, 403 readonly.
+- **TEC-159** : 4 tests dans `test_settings_api.py` (dans `TestUpdateSettings`) : valeur par défaut `{date}.{seq}`, update valide, 422 sans `{seq}`, 422 avec placeholder inconnu.
+- **BIZ-165** : `ClientInvoicesView.vue` — `historyIndex` ref, `openHistory` indexe dans `displayedInvoices`, barre nav ◀ N/total ▶ dans le dialog, `goToPrevHistory` / `goToNextHistory`, styles `.preview-nav-bar`.
+- **CHR-078** : `frontend/src/i18n/en.ts` créé — sections `app`, `auth`, `common` traduits en anglais. Enregistré dans `index.ts` (messages: `{ fr, en }`).
+
+</details>
 
 <details>
 <summary>Lot MOB — Mode téléphone (2026-05-03)</summary>
@@ -182,76 +159,16 @@ Purge des clés expirées toutes les 100 tentatives dans `rate_limiter.py`.
 
 </details>
 
-<details>
-<summary>Lot S — Documentation & i18n (2026-04-27)</summary>
+Tickets fermés hors lots récents : **BIZ-127**, **BIZ-128**, **BIZ-129**, **BIZ-130**, **BIZ-131**, **BIZ-132**, **TEC-156**.
 
-### TEC-106 — Audit et complétion des clés i18n manquantes
-
-Audit complet des 1 096 clés `t('...')` utilisées dans le frontend (1 358 appels bruts filtrés). Résultat : 2 clés manquantes (`common.active`, `common.inactive`) utilisées dans `EmployeesView.vue` — ajoutées dans `fr.ts`.
-
-### CHR-020 — Documentation de contribution
-
-`doc/dev/contributing.md` : setup local, `dev.ps1`, quality gate backend/frontend, conventions Git et workflow. Validé via PR #54.
-
-### CHR-021 — Manuel utilisateur illustré
-
-Manuel FR `doc/user/manuel.md` + référence LLM `doc/llm/reference.md`. Version textuelle complète, structure par rôle et parcours métier. Illustrations (captures annotées) reportées à une future itération.
-
-### CHR-079 — Restructuration et nettoyage de la documentation
-
-Restructuration complète du répertoire `doc/` : nouvelles arborescences `doc/admin/`, `doc/dev/`, `doc/user/`, `doc/llm/` ; suppression de 25 fichiers obsolètes ; README par section ; split des docs bilingues en fichiers par langue (`*.fr.md` / `*.en.md`). Corrections factuelles : `DATABASE_URL`, Vue Router 5, fixtures de test, durée de session, rôles règles comptables, version sync.
-
-</details>
-
-Tickets fermés hors lots : TEC-067, TEC-068, BIZ-069, BIZ-076, CHR-083, BIZ-036, BIZ-041, BIZ-033, BIZ-088, BIZ-089, BIZ-090, TEC-105, TEC-039, BIZ-106, BIZ-107, TEC-110, BIZ-108, BIZ-109, BIZ-112, BIZ-113, BIZ-114, BIZ-115, BIZ-116, BIZ-118, BIZ-121, BIZ-117, **BIZ-119**, **BIZ-123**, **BIZ-124**, **BIZ-122**, **BIZ-111**, **BIZ-127**, **BIZ-128**, **BIZ-129**, **BIZ-130**, **BIZ-131**, **BIZ-132**, **BIZ-138**, **BIZ-139**, **BIZ-140**, **BIZ-141**, **TEC-142**, **TEC-143**, **TEC-146**, **TEC-152**, **TEC-153**, **TEC-154**, **BIZ-155**, **BIZ-156**, **BIZ-148**.
-Tickets fermés pré-audit : CHR-001, CHR-002, BIZ-003 – BIZ-018, BIZ-022 – BIZ-023.
+> Lots et tickets plus anciens → [backlog-archive.md](backlog-archive.md)
 
 <details>
-<summary>Tickets fermés hors lots — détails (BIZ-111, BIZ-117, BIZ-119, BIZ-123, BIZ-124)</summary>
+<summary>TEC-156 — Fix token auth chat (2026-05-03)</summary>
 
-### BIZ-111 — Import one-shot adresses postales depuis factures Word
+### TEC-156 — Fix token auth chat (localStorage → Pinia)
 
-- **Terminé** : 2026-04-26
-- **Livré** : script `scripts/import_addresses_from_docx.py` — extrait les adresses postales depuis les factures Word historiques et enrichit `Contact.adresse` (dry-run par défaut, `--commit` pour appliquer). 48 contacts mis à jour. Dépendance `python-docx` ajoutée dans `pyproject.toml`. Amélioration associée : affichage de l'adresse dans le PDF facture + suppression du SIRET en doublon dans la section Émetteur.
-
-### BIZ-117 — Assistant IA intégré
-
-**Clôturé ❌ Non réalisable** — intégration d'un LLM tiers exclue pour raisons de confidentialité des données comptables ; modèle local incompatible avec la contrainte RAM ≤ 384 MB du NAS.
-
-### BIZ-119 — Tableau de bord avec cartes d'actions rapides
-
-- **Terminé** : 2026-04-26
-- **Livré** : panneau « Actions rapides » en haut du dashboard — 3 cartes (facture client, paiement, caisse) ouvrant des wizards de saisie inline ; wizard facture client avec confirmation et bouton « Saisir une autre ».
-
-### BIZ-123 — Prix par défaut par type de ligne de facture
-
-- **Terminé** : 2026-04-26
-- **Livré** : colonnes `default_price_cours`, `default_price_adhesion`, `default_price_autres` sur `AppSettings` (migration 0034) ; section « Prix unitaires par défaut » dans les paramètres ; pré-remplissage automatique au `addLine()` et au changement de `line_type` dans `ClientInvoiceForm` ; correction race-condition (`onMounted` async avant `addLine`).
-
-### BIZ-122 — Intégrer description dans l’e-mail de facture
-
-- **Terminé** : 2026-04-26
-- **Livré** : paramètre description ajouté à mail_service.send_invoice_email ; si renseigné, l’objet du message devient Facture {numéro} — {description} ; routeur send-email passe invoice.description au service.
-
-### BIZ-124 — Templates de numérotation configurables pour les factures
-
-- **Terminé** : 2026-04-26
-- **Livré** : `client_invoice_number_template` (`{year}`, `{seq}`) + `client_invoice_seq_digits` + `supplier_invoice_number_template` (strftime) sur `AppSettings` (migrations 0032, 0033) ; service `_next_number` avec regex ; endpoint `GET /api/invoices/next_number` (aperçu sans side-effect) ; affichage du numéro prévu dans le formulaire de création et dans la confirmation du wizard.
-
-</details>
-
-<details>
-<summary>Lot T — Chatbot IA + refactor Paramètres (2026-04-28)</summary>
-
-### BIZ-125 — Chatbot IA + page Aide
-
-- **Terminé** : 2026-04-27
-- **Livré** : sidebar chatbot flottante (SSE, Gemini/OpenAI), bouton FAB dans AppLayout, annulation, rendu Markdown via `marked` ; page `/aide` affichant `doc/user/manuel.md` en HTML ; panneau admin `SettingsChatPanel` (provider, clé API, modèle) ; backend : endpoints `/api/chat`, `/api/chat/config`, `/api/chat/logs`, `/api/help/manual` ; migrations 0035 (colonnes chat dans `app_settings`) et 0036 (table `chat_log`).
-
-### BIZ-126 — Refactor UX écran Paramètres
-
-- **Terminé** : 2026-04-27
-- **Livré** : `SettingsAssociationSmtpPanel.vue` (413 lignes) scindé en `SettingsAssociationPanel.vue` (infos association + facturation) et `SettingsSmtpPanel.vue` (SMTP) ; chaque panneau sauvegarde indépendamment. Réalisé sur la même branche que BIZ-125.
+`streamChat` dans `api/chat.ts` lisait `localStorage.getItem('access_token')` — toujours `null` car le token est stocké uniquement en mémoire Pinia (mitigation XSS). Chaque `POST /api/chat` retournait 401. Corrigé en lisant `useAuthStore().accessToken`. Découvert lors du test du Lot DOC (2026-05-03).
 
 </details>
 
@@ -288,390 +205,6 @@ Tickets fermés pré-audit : CHR-001, CHR-002, BIZ-003 – BIZ-018, BIZ-022 – 
   - Vue Banque : panneau « Dépôts en attente de confirmation » (visible si ≥ 1 dépôt non confirmé) — résumé nb chèques / nb encaissements + montant + bouton confirmer ; colonne « Statut » dans le tableau des dépôts avec filtre
   - Vue Paiements : deux métriques séparées « Chèques à remettre » et « Espèces à déposer » remplacent le compteur unique « Non remis »
   - 4 nouveaux tests d'intégration (`test_confirm_deposit`, déjà confirmé → 422, non trouvé → 404, filtre confirmed)
-
-</details>
-
-<details>
-<summary>Historique des estimations — lots techniques 1-8 (2026-04-22)</summary>
-
-Total estimé initial : ~40h — total révisé : ~55h.
-Principaux postes de dérapage : quality gates (~10 min/commit), tests d'intégration, migrations Alembic, refactoring TEC-050.
-
-### Lot 1 — Quick wins P3 — ~45 min
-
-| Ticket | Estimation | Détail |
-| --- | --- | --- |
-| CHR-064 | 5 min | Supprimer un fichier + vérifier qu'il n'est pas importé |
-| CHR-062 | 5 min | Changer une string dans `package.json` |
-| TEC-066 | 20 min | Remplacer le pattern `global` par `@lru_cache`, vérifier les tests |
-| TEC-063 | 15 min | Remplacer 2 noms dans les fixtures + migration Alembic si nécessaire |
-
-### Lot 2 — Tests au vert (TEC-048) — ~2h
-
-11 échecs dans `excel_import_parsers` / `excel_import_parsing` + 1 erreur API de test. Suite déjà au vert (739/739) après corrections antérieures.
-
-### Lot 3 — Sécurité sans impact structurel — ~4h
-
-| Ticket | Est. initiale | Est. révisée | Temps réel | Détail |
-| --- | --- | --- | --- | --- |
-| TEC-047 | 30 min | 1h | ~1h15 | Middleware 5 en-têtes + test CSP PrimeVue |
-| TEC-052 | 20 min | 30 min | ~40 min | Conditionner endpoint sur `settings.debug` |
-| TEC-055 | 20 min | 30 min | ~25 min | Paramètre `cors_allowed_origins` |
-| TEC-060 | 30 min | 45 min | ~30 min | Retirer `create_all` de `init_db()` |
-| TEC-051 | 50 min | 1h15 | ~50 min | `MAX(entry_number)` + lock + migration |
-
-### Lot 4 — Qualité backend sans impact API — ~6h
-
-| Ticket | Est. initiale | Est. révisée | Temps réel | Détail |
-| --- | --- | --- | --- | --- |
-| TEC-065 | 1h | 1h30 | ~1h30 | Déplacer attributs transients vers `PaymentRead` |
-| TEC-057 | 2h | 2h30 | ~3h30 | `TypeDecorator` Decimal + 63 occurrences |
-| TEC-059 | 1h30 | 2h | ~45 min | `limit=100` / `max=1000` sur tous les endpoints |
-
-### Lot 5 — Sécurité auth (full-stack) — ~10h
-
-| Ticket | Est. initiale | Est. révisée | Temps réel | Détail |
-| --- | --- | --- | --- | --- |
-| TEC-045 | 1h | 1h30 | ~1h | `slowapi` rate limiting sur `/auth/login` |
-| BIZ-053 | 2h | 3h | ~1h30 | Migration `must_change_password` + guard |
-| TEC-046 | 4h | 5h30 | — | Cookie `HttpOnly` + intercepteur Axios + `/auth/refresh` |
-
-### Lot 6 — DevOps Docker — ~1h30
-
-| Ticket | Est. initiale | Est. révisée | Détail |
-| --- | --- | --- | --- |
-| CHR-054 | 40 min | 50 min | `entrypoint.sh` avec gestion d'erreur |
-| CHR-061 | 20 min | 20 min | `HEALTHCHECK` Docker + docker-compose |
-
-### Lot 7 — Refactoring structurel — ~12h
-
-| Ticket | Est. initiale | Est. révisée | Détail |
-| --- | --- | --- | --- |
-| TEC-050 | 6h | 9h | Éclater `excel_import.py` (5 038 L) en package |
-| TEC-058 | 2h | 1h | Typer les `except Exception` |
-
-### Lot 8 — Chantiers longs
-
-| Ticket | Est. initiale | Est. révisée | Détail |
-| --- | --- | --- | --- |
-| BIZ-056 | 3-4h | 2h | Table d'audit + middleware + 4 types d'événements |
-| TEC-049 | 10-15h | 12-20h | Palier 34 % → 60 % couverture de test |
-
-</details>
-
-<details>
-<summary>Détails des sujets fermés — cliquer pour développer</summary>
-
-### CHR-001 — Stabiliser la méthode de triage du backlog
-
-- **Dates** : `created=2026-04-12`, `completed=2026-04-12`
-- **Livré** : backlog utilisé comme support versionné avec statuts, priorités et mises à jour récurrentes.
-
-### CHR-002 — Documentation utilisateur import/reset
-
-- **Dates** : `created=2026-04-12`, `completed=2026-04-12`
-- **Livré** : documentation rédigée dans `doc/user/import-excel-et-reinitialisation.md`.
-
-### BIZ-003 — Campagne de retest métier sur imports réels
-
-- **Dates** : `created=2026-04-12`, `completed=2026-04-12`
-- **Livré** : rejeu réel confirmé sans écart bloquant, procédure ajustée pour exercices/compteurs.
-
-### BIZ-004 — Historique d'import réversible
-
-- **Dates** : `created=2026-04-12`, `started=2026-04-20`, `completed=2026-04-20`
-- **Livré** : backend `runs`, `operations`, `effects` réversibles, API cycle `prepare → execute → undo/redo`, UI prévisualisation + historique. Stabilisation rapprochement paiement/facture intra-run.
-
-### BIZ-005 — Politique de coexistence import / écritures existantes
-
-- **Dates** : `created=2026-04-12`, `started=2026-04-19`, `completed=2026-04-19`
-- **Livré** : politique explicitée dans `doc/dev/BIZ-005-politique-coexistence-imports.md`, trois diagnostics : `entry-existing`, `entry-covered-by-solde`, `entry-near-manual`.
-
-### CHR-006 — Warnings de dépréciation FastAPI
-
-- **Dates** : `created=2026-04-12`, `started=2026-04-21`, `completed=2026-04-21`
-- **Livré** : `HTTP_422_UNPROCESSABLE_ENTITY` → `HTTP_422_UNPROCESSABLE_CONTENT`, zéro warning.
-
-### CHR-007 — Source de vérité backlog vs issues GitHub
-
-- **Dates** : `created=2026-04-12`, `completed=2026-04-13`
-- **Livré** : convention actée — `doc/backlog.md` = source de vérité.
-
-### BIZ-008 — Import Excel comme validation itérative de convergence
-
-- **Dates** : `created=2026-04-12`, `started=2026-04-18`, `completed=2026-04-18`
-- **Livré** : modes `convergence globale` et `validation moteur Gestion`, preview bidirectionnelle, script `scripts/run_excel_convergence_preview.py`. Documentation dans `doc/dev/BIZ-008-recette-convergence.md`.
-- **Détail** : grille de contrôle par domaine (factures, paiements, banque, caisse, comptes pivots), politique d'écarts résiduels, périmètre asymétrique `Solde ↔ Excel` par exercice.
-
-### BIZ-009 — Enrichir le plan comptable par défaut
-
-- **Dates** : `created=2026-04-12`, `completed=2026-04-12`
-- **Livré** : seed enrichi avec comptes réels, sous-comptes historiques conservés inactifs.
-
-### BIZ-010 — Stratégie de clôture des exercices historiques
-
-- **Dates** : `created=2026-04-12`, `completed=2026-04-12`
-- **Livré** : exercices historiques ouverts pendant reprise, clôture administrative sans écritures de clôture.
-
-### BIZ-011 — Exercice courant global
-
-- **Dates** : `created=2026-04-12`, `completed=2026-04-12`
-- **Livré** : store global d'exercice + sélecteur partagé + filtrage métier par défaut.
-
-### BIZ-012 — Liste des paiements : référence et édition
-
-- **Dates** : `created=2026-04-12`, `completed=2026-04-12`
-- **Livré** : colonne Référence + bouton d'édition par ligne + dialogue `PUT /payments/{id}`.
-
-### BIZ-013 — Journal de caisse : référence, détail et édition
-
-- **Dates** : `created=2026-04-12`, `completed=2026-04-12`
-- **Livré** : référence visible, panneau de détail, édition directe, recalcul soldes après modification.
-
-### BIZ-014 — Journal comptable : lisibilité et navigation
-
-- **Dates** : `created=2026-04-12`, `completed=2026-04-12`
-- **Livré** : libellés comptes, références métier, tiers, détail, édition manuelles, navigation factures.
-
-### BIZ-015 — Reset sélectif orienté reprise d'import
-
-- **Dates** : `created=2026-04-13`, `started=2026-04-20`, `completed=2026-04-20`
-- **Livré** : reset sélectif par type d'import + exercice avec prévisualisation, UI dans Paramètres, suppression des dépendances métier dérivées.
-
-### BIZ-016 — Harmonisation i18n et microcopie UI
-
-- **Dates** : `created=2026-04-13`, `started=2026-04-14`, `completed=2026-04-14`
-- **Livré** : clés i18n cohérentes sur Banque, Caisse, Salaires (compteurs, états vides, libellés).
-
-### BIZ-017 — Formats de dates et périodes en français
-
-- **Dates** : `created=2026-04-13`, `started=2026-04-14`, `completed=2026-04-14`
-- **Livré** : helper partagé pour mois en français, appliqué sur Salaires et Dashboard mensuel.
-
-### BIZ-018 — Lisibilité des écrans de liste
-
-- **Dates** : `created=2026-04-13`, `started=2026-04-14`, `completed=2026-04-14`
-- **Livré** : socle DataTable partagé (filtres texte/dates/intervalles/multi-sélection, compteurs, tri, saisie date FR/ISO).
-
-### BIZ-022 — Gestion des utilisateurs, rôles et sécurité
-
-- **Dates** : `created=2026-04-13`, `started=2026-04-13`, `completed=2026-04-19`
-- **Livré** : cycle de vie complet : rôles métier, administration comptes, profil, changement MDP, réinitialisation admin, invalidation jetons.
-
-### BIZ-023 — Matrice d'autorisations par rôle
-
-- **Dates** : `created=2026-04-13`, `started=2026-04-14`, `completed=2026-04-14`
-- **Livré** : séparation Gestion/Comptabilité dans la navigation, guards frontend par domaine, renommage Gestionnaire/Comptable, permissions backend alignées.
-
-### BIZ-036 — Carte « restant en retard » cliquable
-
-- **Dates** : `created=2026-04-21`, `completed=2026-04-23`
-- **Livré** : absorbé par BIZ-075 (KPI dashboard cliquables).
-
-### BIZ-041 — Carte « non remis » cliquable
-
-- **Dates** : `created=2026-04-21`, `completed=2026-04-23`
-- **Livré** : absorbé par BIZ-075 (KPI dashboard cliquables).
-
-### BIZ-042 — Bouton reset filtres tables
-
-- **Dates** : `created=2026-04-21`, `completed=2026-04-23`
-- **Livré** : bouton reset sur tous les filtres de toutes les tables.
-
-### BIZ-043 — Combos comptes comptables couleur
-
-- **Dates** : `created=2026-04-21`, `completed=2026-04-23`
-- **Livré** : combos affichant numéro, nom et couleur des comptes suivis.
-
-### TEC-045 — Rate limiting `/auth/login`
-
-- **Dates** : `created=2026-04-22`, `completed=2026-04-23`
-- **Livré** : middleware `slowapi` 5 req/min par IP, bypass configurable pour tests.
-
-### TEC-046 — Refresh token cookie HttpOnly
-
-- **Dates** : `created=2026-04-22`, `completed=2026-04-22`
-- **Livré** : cookie `HttpOnly`/`Secure`/`SameSite=Strict`, endpoint `POST /auth/logout`, intercepteur Axios `withCredentials: true`, 6 tests dédiés.
-
-### TEC-047 — En-têtes de sécurité HTTP
-
-- **Dates** : `created=2026-04-22`, `completed=2026-04-22`
-- **Livré** : middleware CSP, HSTS, X-Content-Type-Options, X-Frame-Options. `dark-mode-init.js` extrait pour CSP `script-src 'self'`.
-
-### TEC-048 — Corriger les tests en échec
-
-- **Dates** : `created=2026-04-22`, `completed=2026-04-22`
-- **Livré** : suite 739/739 au vert. Test API adapté pour `@lru_cache` (TEC-066).
-
-### TEC-049 — Remonter la couverture de test
-
-- **Dates** : `created=2026-04-22`, `completed=2026-04-22`
-- **Livré** : +44 tests (812 → 856), couverture 29% → 71%. Services critiques ≥ 90% : accounting_engine 92%, invoice 93%, payment 90%, fiscal_year ~95%, salary ~95%.
-
-### TEC-050 — Refactorer `excel_import.py` en package
-
-- **Dates** : `created=2026-04-22`, `completed=2026-04-22`
-- **Livré** : monolith 5 567 lignes éclaté en 16 sous-modules + `__init__.py` re-export. Aucune dépendance circulaire.
-
-### TEC-051 — Numérotation des écritures thread-safe
-
-- **Dates** : `created=2026-04-22`, `completed=2026-04-22`
-- **Livré** : `COUNT(*)` → `MAX(entry_number)` + lock, migration, tests de concurrence.
-
-### TEC-052 — Désactiver `reset-db` en production
-
-- **Dates** : `created=2026-04-22`, `completed=2026-04-22`
-- **Livré** : endpoint conditionné à `settings.debug`.
-
-### BIZ-053 — Changement MDP obligatoire au premier login
-
-- **Dates** : `created=2026-04-22`, `completed=2026-04-23`
-- **Livré** : champ `must_change_password` (migration 0022), middleware 403, redirection frontend, 11 tests intégration + 2 tests frontend.
-
-### CHR-054 — Séparer migrations du démarrage Uvicorn
-
-- **Dates** : `created=2026-04-22`, `completed=2026-04-22`
-- **Livré** : `entrypoint.sh` avec `set -e`, Dockerfile mis à jour avec `ENTRYPOINT`.
-
-### TEC-055 — CORS configurable pour la production
-
-- **Dates** : `created=2026-04-22`, `completed=2026-04-22`
-- **Livré** : paramètre `cors_allowed_origins` dans les settings.
-
-### BIZ-056 — Journal d'audit structuré
-
-- **Dates** : `created=2026-04-22`, `completed=2026-04-23`
-- **Livré** : modèle `AuditLog` + service `record_audit` + migration 0023. Événements : auth (login/logout/password), admin (user CRUD, reset_db, selective_reset). 14 tests.
-
-### TEC-057 — TypeDecorator Decimal pour l'ORM
-
-- **Dates** : `created=2026-04-22`, `completed=2026-04-22`
-- **Livré** : `DecimalType(TypeDecorator)` sur toutes les colonnes monétaires, ~63 casts `Decimal(str())` retirés.
-
-### TEC-058 — Typer les exceptions de l'import Excel
-
-- **Dates** : `created=2026-04-22`, `completed=2026-04-22`
-- **Livré** : `ImportFileOpenError`, `ImportSheetError` dans `_exceptions.py`, mapping typé dans routeur. 10 tests ajoutés.
-
-### TEC-059 — Pagination bornée par défaut
-
-- **Dates** : `created=2026-04-22`, `completed=2026-04-22`
-- **Livré** : `limit=100` / `max=1000` sur tous les endpoints de liste. Frontend et tests adaptés.
-
-### TEC-060 — Retirer `create_all` de `init_db()`
-
-- **Dates** : `created=2026-04-22`, `completed=2026-04-22`
-- **Livré** : `create_all` conservé uniquement dans `conftest.py`, Alembic seul en prod.
-
-### CHR-061 — Docker HEALTHCHECK
-
-- **Dates** : `created=2026-04-22`, `completed=2026-04-22`
-- **Livré** : `GET /api/health` (200), `HEALTHCHECK` dans Dockerfile, `healthcheck:` dans docker-compose.
-
-### CHR-062 — Synchroniser les versions frontend / backend
-
-- **Dates** : `created=2026-04-22`, `completed=2026-04-22`
-- **Livré** : `frontend/package.json` aligné sur `0.1.0`.
-
-### TEC-063 — Retirer les noms personnels du plan comptable (RGPD)
-
-- **Dates** : `created=2026-04-22`, `completed=2026-04-22`
-- **Livré** : noms remplacés par `Client litigieux 1/2`. Seed ne touche pas les données existantes.
-
-### CHR-064 — Supprimer `stores/counter.ts`
-
-- **Dates** : `created=2026-04-22`, `completed=2026-04-22`
-- **Livré** : fichier supprimé, aucune référence dans le code.
-
-### TEC-065 — Éliminer `__allow_unmapped__` de Payment
-
-- **Dates** : `created=2026-04-22`, `completed=2026-04-22`
-- **Livré** : attributs transients déplacés vers `PaymentRead` via `_to_payment_read()`.
-
-### TEC-066 — Settings singleton `@lru_cache`
-
-- **Dates** : `created=2026-04-22`, `completed=2026-04-22`
-- **Livré** : `@lru_cache(maxsize=1)` sur `get_settings()`, variable globale supprimée.
-
-### TEC-067 — Gestionnaire d'erreurs global FastAPI
-
-- **Dates** : `created=2026-04-23`, `completed=2026-04-23`
-- **Livré** : middleware `UnhandledExceptionMiddleware` → JSON 500 `{"detail": ..., "code": "INTERNAL_SERVER_ERROR"}`, log serveur. 5 tests.
-
-### TEC-068 — Désactiver Swagger/ReDoc en production
-
-- **Dates** : `created=2026-04-23`, `completed=2026-04-23`
-- **Livré** : `docs_url`, `redoc_url`, `openapi_url` conditionnés à `cfg.debug`.
-
-### BIZ-069 — Endpoint de sauvegarde SQLite
-
-- **Dates** : `created=2026-04-23`, `completed=2026-04-23`
-- **Livré** : `POST /api/settings/backup` avec `sqlite3.backup()` + rotation 5 fichiers.
-
-### BIZ-070 — Page 404 dédiée
-
-- **Dates** : `created=2026-04-23`, `completed=2026-04-23`
-- **Livré** : `NotFoundView.vue` avec icône, titre i18n, bouton retour. Catch-all router remplacé.
-
-### BIZ-071 — Skeleton loaders
-
-- **Dates** : `created=2026-04-23`, `completed=2026-04-23`
-- **Livré** : `<Skeleton>` PrimeVue sur les écrans de liste principaux.
-
-### BIZ-072 — Fil d'Ariane (Breadcrumb)
-
-- **Dates** : `created=2026-04-23`, `completed=2026-04-23`
-- **Livré** : composable `useBreadcrumb` + `<Breadcrumb>` PrimeVue via meta routes `label`/`breadcrumbParent`.
-
-### BIZ-073 — Raccourcis clavier
-
-- **Dates** : `created=2026-04-23`, `completed=2026-04-23`
-- **Livré** : composable `useKeyboardShortcuts` (Ctrl+N, Ctrl+S, Escape).
-
-### BIZ-074 — Bandeau connexion perdue
-
-- **Dates** : `created=2026-04-23`, `completed=2026-04-23`
-- **Livré** : composable `useNetworkStatus` + `AppOfflineBanner.vue` (events online/offline + intercepteur Axios).
-
-### BIZ-075 — Dashboard KPI cliquables
-
-- **Dates** : `created=2026-04-23`, `completed=2026-04-23`
-- **Livré** : KPI cliquables vers listes filtrées. Complète BIZ-036 et BIZ-041.
-
-### BIZ-076 — Styles d'impression comptable
-
-- **Dates** : `created=2026-04-23`, `completed=2026-04-23`
-- **Livré** : `@media print` sur journal, balance, grand livre, bilan, résultat. Sidebar/filtres/boutons masqués, en-tête imprimable.
-
-### TEC-079 — Tests composables frontend
-
-- **Dates** : `created=2026-04-23`, `completed=2026-04-24`
-- **Livré** : 15 tests Vitest — `useDarkMode` (4), `useTableFilter` (8), `activeFilterLabels` (10). Suite 126/126 au vert.
-
-### TEC-080 — Smoke test E2E Playwright
-
-- **Dates** : `created=2026-04-23`, `completed=2026-04-24`
-- **Livré** : `playwright.config.ts` (webServer auto-start, DB E2E dédiée). Smoke test : login → MDP obligatoire → dashboard → contacts → factures → paiements.
-
-### TEC-081 — Tests d'intégration API manquants
-
-- **Dates** : `created=2026-04-23`, `completed=2026-04-24`
-- **Livré** : `test_accounting_rules_api.py` (11), `test_fiscal_year_api.py` (10), `test_salary_api.py` (+7), `test_dashboard_api.py` (+1). 52 tests intégration au vert.
-
-### CHR-083 — Guide de migration Synology
-
-- **Dates** : `created=2026-04-23`, `completed=2026-04-23`
-- **Livré** : guide FR+EN dans `doc/user/` couvrant mise à jour Docker, vérification post-migration, rollback.
-
-### BIZ-084 — Notification expiration session
-
-- **Dates** : `created=2026-04-23`, `completed=2026-05-03`
-- **Livré** : composable `useSessionExpiry` (décode expiry JWT, avertissement T−5 min) + `AppSessionWarning.vue` avec bouton « Prolonger la session ».
-
-### TEC-085 — Politique de complexité MDP
-
-- **Dates** : `created=2026-04-23`, `completed=2026-04-23`
-- **Livré** : validateur `_validate_password_complexity` (8 chars, majuscule, chiffre). 14 tests unitaires.
 
 </details>
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "private": true,
   "type": "module",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "private": true,
   "type": "module",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "private": true,
   "type": "module",
   "scripts": {

--- a/frontend/src/components/ContactHistoryContent.vue
+++ b/frontend/src/components/ContactHistoryContent.vue
@@ -15,7 +15,7 @@
         <div class="contact-history-actions">
           <Tag :value="t(`contacts.types.${history.contact.type}`)" />
           <Button
-            v-if="Number(history.total_due) > 0 && history.contact.type !== 'fournisseur'"
+            v-if="Number(history.total_due) > 0 && history.contact.type === 'client'"
             :label="t('contact_history.mark_douteux')"
             icon="pi pi-exclamation-triangle"
             severity="warn"

--- a/frontend/src/components/ContactHistoryContent.vue
+++ b/frontend/src/components/ContactHistoryContent.vue
@@ -15,7 +15,7 @@
         <div class="contact-history-actions">
           <Tag :value="t(`contacts.types.${history.contact.type}`)" />
           <Button
-            v-if="Number(history.total_due) > 0"
+            v-if="Number(history.total_due) > 0 && history.contact.type !== 'fournisseur'"
             :label="t('contact_history.mark_douteux')"
             icon="pi pi-exclamation-triangle"
             severity="warn"

--- a/frontend/src/components/ui/AppMobileCardList.vue
+++ b/frontend/src/components/ui/AppMobileCardList.vue
@@ -9,13 +9,17 @@
     </div>
     <div v-if="items.length === 0" class="app-mobile-card-list__empty">
       <slot name="empty">
-        <span>{{ emptyMessage }}</span>
+        <span>{{ emptyMessage ?? t('common.empty') }}</span>
       </slot>
     </div>
   </div>
 </template>
 
 <script setup lang="ts" generic="T = unknown">
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
+
 withDefaults(
   defineProps<{
     items: T[]
@@ -23,7 +27,7 @@ withDefaults(
     itemKey?: (item: T, index: number) => string | number
   }>(),
   {
-    emptyMessage: 'Aucune donnée',
+    emptyMessage: undefined,
     itemKey: undefined,
   },
 )

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1,11 +1,10 @@
 /**
  * English translations skeleton for Solde ⚖️
  *
- * Status: partial — only app / auth / common are fully translated.
- * All other sections are structural stubs (keys present, values in French).
- * Missing keys fall back to French via fallbackLocale: 'fr'.
+ * Status: partial — only app / auth / common are translated.
+ * All other sections are absent; missing keys fall back to French via fallbackLocale: 'fr'.
  *
- * CHR-078 — progressively replace French values with English.
+ * CHR-078 — progressively add and translate the remaining sections.
  */
 export default {
   app: {

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1,0 +1,81 @@
+/**
+ * English translations skeleton for Solde ⚖️
+ *
+ * Status: partial — only app / auth / common are fully translated.
+ * All other sections are structural stubs (keys present, values in French).
+ * Missing keys fall back to French via fallbackLocale: 'fr'.
+ *
+ * CHR-078 — progressively replace French values with English.
+ */
+export default {
+  app: {
+    name: 'Solde ⚖️',
+    active_fiscal_year: 'Active fiscal year',
+    all_fiscal_years: 'All fiscal years',
+  },
+  auth: {
+    login: {
+      title: 'Sign in',
+      subtitle: 'Non-profit accounting',
+      username: 'Username',
+      password: 'Password',
+      submit: 'Sign in',
+      reset_hint:
+        'Forgot your password? Ask an administrator to temporarily reset your access.',
+      error: {
+        invalid: 'Invalid username or password.',
+        network: 'Unable to reach the server. Please try again.',
+        unknown: 'An unexpected error occurred.',
+      },
+    },
+    logout: 'Sign out',
+    dark_mode: 'Dark mode',
+    light_mode: 'Light mode',
+    me: 'My account',
+  },
+  common: {
+    loading: 'Loading…',
+    save: 'Save',
+    search: 'Search',
+    cancel: 'Cancel',
+    discard: 'Discard changes',
+    unsaved_changes: 'Unsaved changes',
+    unsaved_changes_confirm: 'Unsaved changes will be lost. Continue anyway?',
+    delete: 'Delete',
+    yes: 'Yes',
+    no: 'No',
+    date_filter_placeholder: 'DD/MM/YYYY',
+    confirm: 'Confirm',
+    all: 'All',
+    actions: 'Actions',
+    filter_placeholder: 'Search…',
+    refresh: 'Refresh',
+    reset_filters: 'Reset filters',
+    previous: 'Previous',
+    next: 'Next',
+    empty: 'No data.',
+    active: 'Active',
+    inactive: 'Inactive',
+    list: {
+      count_total: '{count} item(s)',
+      count_filtered: '{shown} of {total}',
+      search_chip: 'Search: {query}',
+      filter_chip: 'Filter: {label}',
+      column_filters_chip: '{count} column filter(s)',
+      status: {
+        loading: 'Updating list.',
+        empty: 'No items to display.',
+        filtered_empty: 'No results match the active filters.',
+        filtered_scope: 'View restricted by active filters and search.',
+        full_scope: 'Showing all items in the current scope.',
+      },
+    },
+    error: {
+      unknown: 'An error occurred.',
+      forbidden: 'Access denied.',
+      notFound: 'Resource not found.',
+    },
+    api_limit_warning:
+      'Display limit reached (1,000 items). Results may be incomplete — refine the filters to reduce the loaded volume.',
+  },
+}

--- a/frontend/src/i18n/fr.ts
+++ b/frontend/src/i18n/fr.ts
@@ -215,6 +215,7 @@ export default {
     reset_filters: 'Réinitialiser les filtres',
     previous: 'Précédent',
     next: 'Suivant',
+    empty: 'Aucune donnée.',
     active: 'Actif',
     inactive: 'Inactif',
     list: {

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -1,5 +1,6 @@
 import { createI18n } from 'vue-i18n'
 import fr from './fr'
+import en from './en'
 
 const i18n = createI18n({
   legacy: false,
@@ -7,6 +8,7 @@ const i18n = createI18n({
   fallbackLocale: 'fr',
   messages: {
     fr,
+    en,
   },
 })
 

--- a/frontend/src/tests/views/ClientInvoicesView.spec.ts
+++ b/frontend/src/tests/views/ClientInvoicesView.spec.ts
@@ -413,3 +413,64 @@ describe('ClientInvoicesView', () => {
     expect(wrapper.text()).toContain('invoices.client.metrics.overdue_count')
   })
 })
+
+// ---------------------------------------------------------------------------
+// History dialog navigation (BIZ-165 + BIZ-168)
+// ---------------------------------------------------------------------------
+
+describe('ClientInvoicesView — history dialog navigation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockListContactsApi.mockResolvedValue([
+      { id: 10, type: 'client', nom: 'Dupont', prenom: 'Alice', email: null, telephone: null },
+    ] as never)
+    // Both invoices returned for every call so displayedInvoices has 2 entries
+    mockListInvoicesApi.mockResolvedValue([invoiceFixture, historicalInvoiceFixture] as never)
+    mockListPayments.mockResolvedValue([])
+  })
+
+  it('shows navigation counter and advances to next invoice on click', async () => {
+    const wrapper = mountView()
+    await flushView()
+
+    const historyButtons = wrapper
+      .findAll('button')
+      .filter((btn) => btn.attributes('title') === 'invoices.history')
+    expect(historyButtons.length).toBeGreaterThanOrEqual(1)
+
+    await historyButtons[0].trigger('click')
+    await flushView()
+
+    // Counter shows "1 / 2" (top bar or bottom bar)
+    expect(wrapper.text()).toContain('1 / 2')
+
+    // Click the first enabled Next button
+    const nextButton = wrapper
+      .findAll('button')
+      .find((btn) => btn.attributes('title') === 'common.next' && !btn.element.disabled)
+    expect(nextButton).toBeTruthy()
+    await nextButton!.trigger('click')
+    await flushView()
+
+    // Counter now shows "2 / 2"
+    expect(wrapper.text()).toContain('2 / 2')
+  })
+
+  it('disables the Previous button when at the first invoice', async () => {
+    const wrapper = mountView()
+    await flushView()
+
+    const historyButtons = wrapper
+      .findAll('button')
+      .filter((btn) => btn.attributes('title') === 'invoices.history')
+    await historyButtons[0].trigger('click')
+    await flushView()
+
+    const prevButtons = wrapper
+      .findAll('button')
+      .filter((btn) => btn.attributes('title') === 'common.previous')
+    expect(prevButtons.length).toBeGreaterThanOrEqual(1)
+    // All Previous buttons must be disabled at index 0
+    expect(prevButtons.every((btn) => btn.element.disabled)).toBe(true)
+  })
+})

--- a/frontend/src/tests/views/SupplierInvoicesView.spec.ts
+++ b/frontend/src/tests/views/SupplierInvoicesView.spec.ts
@@ -435,3 +435,68 @@ describe('SupplierInvoicesView — payment dialog', () => {
     )
   })
 })
+
+// ---------------------------------------------------------------------------
+// Preview dialog bottom navigation (BIZ-168)
+// ---------------------------------------------------------------------------
+
+describe('SupplierInvoicesView — preview dialog bottom navigation', () => {
+  // Variants with file_path so the preview button (v-if="data.file_path") is rendered
+  const invoiceWithFile = { ...invoiceFixture, file_path: 'uploads/FF-2025-001.pdf' }
+  const paidInvoiceWithFile = { ...paidInvoiceFixture, file_path: 'uploads/FF-2025-002.pdf' }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockListContactsApi.mockResolvedValue([
+      { id: 10, type: 'fournisseur', nom: 'Martin', prenom: 'Bob', email: null, telephone: null },
+    ] as never)
+    // Two invoices with file_path so the preview button is rendered for each
+    mockListInvoicesApi.mockResolvedValue([invoiceWithFile, paidInvoiceWithFile] as never)
+    mockListPayments.mockResolvedValue([])
+  })
+
+  it('shows navigation counter and advances via bottom bar Next button', async () => {
+    const wrapper = mountView()
+    await flushView()
+
+    const previewButtons = wrapper
+      .findAll('button')
+      .filter((btn) => btn.attributes('title') === 'invoices.supplier.preview_file')
+    expect(previewButtons.length).toBeGreaterThanOrEqual(1)
+
+    await previewButtons[0].trigger('click')
+    await flushView()
+
+    // Counter shows "1 / 2"
+    expect(wrapper.text()).toContain('1 / 2')
+
+    // Click the last enabled Next button (bottom bar is last in the DOM)
+    const nextButtons = wrapper
+      .findAll('button')
+      .filter((btn) => btn.attributes('title') === 'common.next' && !btn.element.disabled)
+    expect(nextButtons.length).toBeGreaterThanOrEqual(1)
+    await nextButtons[nextButtons.length - 1].trigger('click')
+    await flushView()
+
+    // Counter now shows "2 / 2"
+    expect(wrapper.text()).toContain('2 / 2')
+  })
+
+  it('disables Previous at the first invoice in both nav bars', async () => {
+    const wrapper = mountView()
+    await flushView()
+
+    const previewButtons = wrapper
+      .findAll('button')
+      .filter((btn) => btn.attributes('title') === 'invoices.supplier.preview_file')
+    await previewButtons[0].trigger('click')
+    await flushView()
+
+    const prevButtons = wrapper
+      .findAll('button')
+      .filter((btn) => btn.attributes('title') === 'common.previous')
+    expect(prevButtons.length).toBeGreaterThanOrEqual(1)
+    // All Previous buttons must be disabled at index 0
+    expect(prevButtons.every((btn) => btn.element.disabled)).toBe(true)
+  })
+})

--- a/frontend/src/views/CashView.vue
+++ b/frontend/src/views/CashView.vue
@@ -323,7 +323,7 @@
                             ? 'cash-warn'
                             : 'cash-positive'
                       "
-                    >Écart : {{ formatAmount(data.difference) }} €</span>
+                    >{{ t('cash.count_diff') }} : {{ formatAmount(data.difference) }} €</span>
                   </div>
                   <div v-if="data.notes" class="app-mobile-card-row">
                     <span class="app-mobile-card-label">{{ data.notes }}</span>

--- a/frontend/src/views/ClientInvoicesView.vue
+++ b/frontend/src/views/ClientInvoicesView.vue
@@ -488,6 +488,27 @@
       class="app-dialog app-dialog--xlarge"
       @hide="onHistoryHide"
     >
+      <div v-if="historyIndex >= 0" class="preview-nav-bar">
+        <Button
+          icon="pi pi-chevron-left"
+          text
+          rounded
+          size="small"
+          :disabled="historyIndex <= 0"
+          :title="t('common.previous')"
+          @click="goToPrevHistory"
+        />
+        <span class="preview-nav-bar__counter">{{ historyIndex + 1 }} / {{ displayedInvoices.length }}</span>
+        <Button
+          icon="pi pi-chevron-right"
+          text
+          rounded
+          size="small"
+          :disabled="historyIndex >= displayedInvoices.length - 1"
+          :title="t('common.next')"
+          @click="goToNextHistory"
+        />
+      </div>
       <div v-if="historyInvoice" class="history-dialog history-dialog--with-preview">
         <section class="app-dialog-intro history-dialog__intro">
           <div>
@@ -832,6 +853,7 @@ const writeOffLoading = ref(false)
 // History dialog
 const historyVisible = ref(false)
 const historyInvoice = ref<Invoice | null>(null)
+const historyIndex = ref(-1)
 const historyLoading = ref(false)
 const historyPayments = ref<Payment[]>([])
 const historyPdfBlobUrl = ref<string | null>(null)
@@ -1167,6 +1189,7 @@ async function duplicate(invoice: Invoice) {
 }
 
 async function openHistory(invoice: Invoice) {
+  historyIndex.value = displayedInvoices.value.findIndex((r) => r.id === invoice.id)
   historyInvoice.value = invoice
   historyVisible.value = true
   historyPdfBlobUrl.value = null
@@ -1185,6 +1208,22 @@ function onHistoryHide() {
     URL.revokeObjectURL(historyPdfBlobUrl.value)
     historyPdfBlobUrl.value = null
   }
+}
+
+async function goToPrevHistory(): Promise<void> {
+  const idx = historyIndex.value - 1
+  if (idx < 0) return
+  historyIndex.value = idx
+  const invoice = invoices.value.find((i) => i.id === displayedInvoices.value[idx]?.id)
+  if (invoice) await openHistory(invoice)
+}
+
+async function goToNextHistory(): Promise<void> {
+  const idx = historyIndex.value + 1
+  if (idx >= displayedInvoices.value.length) return
+  historyIndex.value = idx
+  const invoice = invoices.value.find((i) => i.id === displayedInvoices.value[idx]?.id)
+  if (invoice) await openHistory(invoice)
 }
 
 async function loadHistoryPayments(invoiceId: number) {
@@ -1475,5 +1514,22 @@ onMounted(async () => {
   .history-dialog__summary {
     grid-template-columns: 1fr;
   }
+}
+
+.preview-nav-bar {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--app-space-1);
+  padding-bottom: var(--app-space-3);
+  border-bottom: 1px solid var(--app-surface-border);
+  margin-bottom: var(--app-space-4);
+}
+
+.preview-nav-bar__counter {
+  font-size: 0.85rem;
+  color: var(--p-text-muted-color);
+  min-width: 3.5rem;
+  text-align: center;
 }
 </style>

--- a/frontend/src/views/ClientInvoicesView.vue
+++ b/frontend/src/views/ClientInvoicesView.vue
@@ -509,7 +509,7 @@
           @click="goToNextHistory"
         />
       </div>
-      <div v-if="historyInvoice" class="history-dialog history-dialog--with-preview">
+      <div v-if="historyInvoice" ref="historyDialogBodyRef" class="history-dialog history-dialog--with-preview">
         <section class="app-dialog-intro history-dialog__intro">
           <div>
             <p class="app-dialog-intro__eyebrow">{{ t('invoices.history') }}</p>
@@ -666,6 +666,28 @@
             </div>
           </div><!-- end history-dialog__preview -->
         </div><!-- end history-dialog__body -->
+
+        <div v-if="historyIndex >= 0" class="preview-nav-bar preview-nav-bar--bottom">
+          <Button
+            icon="pi pi-chevron-left"
+            text
+            rounded
+            size="small"
+            :disabled="historyIndex <= 0"
+            :title="t('common.previous')"
+            @click="goToPrevHistoryBottom"
+          />
+          <span class="preview-nav-bar__counter">{{ historyIndex + 1 }} / {{ displayedInvoices.length }}</span>
+          <Button
+            icon="pi pi-chevron-right"
+            text
+            rounded
+            size="small"
+            :disabled="historyIndex >= displayedInvoices.length - 1"
+            :title="t('common.next')"
+            @click="goToNextHistoryBottom"
+          />
+        </div>
 
       </div>
     </Dialog>
@@ -854,6 +876,14 @@ const writeOffLoading = ref(false)
 const historyVisible = ref(false)
 const historyInvoice = ref<Invoice | null>(null)
 const historyIndex = ref(-1)
+const historyDialogBodyRef = ref<HTMLElement | null>(null)
+
+function scrollHistoryDialogToBottom(): void {
+  nextTick(() => {
+    const el = historyDialogBodyRef.value?.closest('.p-dialog-content') as HTMLElement | null
+    if (el) el.scrollTop = el.scrollHeight
+  })
+}
 const historyLoading = ref(false)
 const historyPayments = ref<Payment[]>([])
 const historyPdfBlobUrl = ref<string | null>(null)
@@ -1226,6 +1256,16 @@ async function goToNextHistory(): Promise<void> {
   if (invoice) await openHistory(invoice)
 }
 
+async function goToPrevHistoryBottom(): Promise<void> {
+  await goToPrevHistory()
+  scrollHistoryDialogToBottom()
+}
+
+async function goToNextHistoryBottom(): Promise<void> {
+  await goToNextHistory()
+  scrollHistoryDialogToBottom()
+}
+
 async function loadHistoryPayments(invoiceId: number) {
   historyLoading.value = true
   historyPayments.value = []
@@ -1524,6 +1564,15 @@ onMounted(async () => {
   padding-bottom: var(--app-space-3);
   border-bottom: 1px solid var(--app-surface-border);
   margin-bottom: var(--app-space-4);
+}
+
+.preview-nav-bar--bottom {
+  padding-bottom: 0;
+  border-bottom: none;
+  padding-top: var(--app-space-3);
+  border-top: 1px solid var(--app-surface-border);
+  margin-bottom: 0;
+  margin-top: var(--app-space-4);
 }
 
 .preview-nav-bar__counter {

--- a/frontend/src/views/ClientInvoicesView.vue
+++ b/frontend/src/views/ClientInvoicesView.vue
@@ -1222,6 +1222,9 @@ async function openHistory(invoice: Invoice) {
   historyIndex.value = displayedInvoices.value.findIndex((r) => r.id === invoice.id)
   historyInvoice.value = invoice
   historyVisible.value = true
+  if (historyPdfBlobUrl.value) {
+    URL.revokeObjectURL(historyPdfBlobUrl.value)
+  }
   historyPdfBlobUrl.value = null
   historyPdfLoading.value = true
   await Promise.all([

--- a/frontend/src/views/ContactsView.vue
+++ b/frontend/src/views/ContactsView.vue
@@ -34,9 +34,9 @@
     <AppPanel :title="t('contacts.workspace_title')" :subtitle="t('contacts.workspace_subtitle')">
       <Tabs v-model:value="activeTab" class="contacts-tabs">
         <TabList>
-          <Tab value="all">{{ t('contacts.tabs.all') }} ({{ contacts.length }})</Tab>
           <Tab value="client">{{ t('contacts.tabs.clients') }} ({{ clientCount + mixedCount }})</Tab>
           <Tab value="fournisseur">{{ t('contacts.tabs.suppliers') }} ({{ supplierCount + mixedCount }})</Tab>
+          <Tab value="all">{{ t('contacts.tabs.all') }} ({{ contacts.length }})</Tab>
         </TabList>
       </Tabs>
 
@@ -445,7 +445,7 @@ const toast = useToast()
 const contacts = ref<Contact[]>([])
 const loading = ref(false)
 const search = ref('')
-const activeTab = ref<'all' | 'client' | 'fournisseur'>('all')
+const activeTab = ref<'all' | 'client' | 'fournisseur'>('client')
 const dialogVisible = ref(false)
 const contactFormRef = ref<InstanceType<typeof ContactForm> | null>(null)
 const editingContact = ref<Contact | null>(null)
@@ -511,8 +511,22 @@ const tabContacts = computed(() => {
   if (activeTab.value === 'fournisseur') return contacts.value.filter((c) => c.type === 'fournisseur' || c.type === 'les_deux')
   return contacts.value
 })
+
+function sortContacts(list: Contact[]): Contact[] {
+  const sixMonthsAgo = new Date()
+  sixMonthsAgo.setMonth(sixMonthsAgo.getMonth() - 6)
+  return [...list].sort((a, b) => {
+    const aRecent = a.last_invoice_date !== null && new Date(a.last_invoice_date) >= sixMonthsAgo
+    const bRecent = b.last_invoice_date !== null && new Date(b.last_invoice_date) >= sixMonthsAgo
+    if (aRecent !== bRecent) return aRecent ? -1 : 1
+    const nomCmp = (a.nom ?? '').localeCompare(b.nom ?? '', 'fr', { sensitivity: 'base' })
+    if (nomCmp !== 0) return nomCmp
+    return (a.prenom ?? '').localeCompare(b.prenom ?? '', 'fr', { sensitivity: 'base' })
+  })
+}
+
 const contactRows = computed(() =>
-  tabContacts.value.map((contact) => ({
+  sortContacts(tabContacts.value).map((contact) => ({
     ...contact,
     type_label: t(`contacts.types.${contact.type}`),
   })),
@@ -566,13 +580,13 @@ function debouncedLoad(): void {
 }
 
 const hasAnyFilters = computed(
-  () => hasActiveFilters.value || Boolean(search.value) || activeTab.value !== 'all',
+  () => hasActiveFilters.value || Boolean(search.value) || activeTab.value !== 'client',
 )
 
 function resetAllFilters(): void {
   resetFilters()
   search.value = ''
-  activeTab.value = 'all'
+  activeTab.value = 'client'
   void loadContacts()
 }
 

--- a/frontend/src/views/SupplierInvoicesView.vue
+++ b/frontend/src/views/SupplierInvoicesView.vue
@@ -451,7 +451,7 @@
           @click="goToNextPreview"
         />
       </div>
-      <div v-if="previewInvoice" class="supplier-preview-dialog">
+      <div v-if="previewInvoice" ref="previewDialogBodyRef" class="supplier-preview-dialog">
 
         <!-- Header info + actions -->
         <section class="app-dialog-intro history-dialog__intro">
@@ -589,10 +589,31 @@
           </div>
 
         </div>
+
+        <div class="preview-nav-bar preview-nav-bar--bottom">
+          <Button
+            icon="pi pi-chevron-left"
+            text
+            rounded
+            size="small"
+            :disabled="previewIndex <= 0"
+            :title="t('common.previous')"
+            @click="goToPrevPreviewBottom"
+          />
+          <span class="preview-nav-bar__counter">{{ previewIndex + 1 }} / {{ displayedInvoices.length }}</span>
+          <Button
+            icon="pi pi-chevron-right"
+            text
+            rounded
+            size="small"
+            :disabled="previewIndex >= displayedInvoices.length - 1"
+            :title="t('common.next')"
+            @click="goToNextPreviewBottom"
+          />
+        </div>
+
       </div>
     </Dialog>
-
-    <!-- Payment dialog -->
     <Dialog
       v-model:visible="paymentDialogVisible"
       :header="paymentInvoice ? t('invoices.record_payment') : ''"
@@ -788,6 +809,14 @@ const previewRemaining = computed(() => {
 })
 
 const previewIndex = ref(-1)
+const previewDialogBodyRef = ref<HTMLElement | null>(null)
+
+function scrollPreviewDialogToBottom(): void {
+  nextTick(() => {
+    const el = previewDialogBodyRef.value?.closest('.p-dialog-content') as HTMLElement | null
+    if (el) el.scrollTop = el.scrollHeight
+  })
+}
 
 const invoiceRows = computed(() =>
   invoices.value.map((invoice) => ({
@@ -1139,6 +1168,16 @@ async function goToNextPreview(): Promise<void> {
   await openPreviewDialog(displayedInvoices.value[idx] as Invoice)
 }
 
+async function goToPrevPreviewBottom(): Promise<void> {
+  await goToPrevPreview()
+  scrollPreviewDialogToBottom()
+}
+
+async function goToNextPreviewBottom(): Promise<void> {
+  await goToNextPreview()
+  scrollPreviewDialogToBottom()
+}
+
 function onFileSelect(event: { files: File[] }) {
   selectedFile.value = event.files[0] ?? null
 }
@@ -1277,6 +1316,24 @@ onMounted(async () => {
   padding-bottom: var(--app-space-3);
   border-bottom: 1px solid var(--app-surface-border);
   margin-bottom: var(--app-space-4);
+}
+
+.preview-nav-bar--bottom {
+  padding-bottom: 0;
+  border-bottom: none;
+  padding-top: var(--app-space-3);
+  border-top: 1px solid var(--app-surface-border);
+  margin-bottom: 0;
+  margin-top: var(--app-space-4);
+}
+
+.preview-nav-bar--bottom {
+  padding-bottom: 0;
+  border-bottom: none;
+  padding-top: var(--app-space-3);
+  border-top: 1px solid var(--app-surface-border);
+  margin-bottom: 0;
+  margin-top: var(--app-space-4);
 }
 
 .preview-nav-bar__counter {

--- a/frontend/src/views/SupplierInvoicesView.vue
+++ b/frontend/src/views/SupplierInvoicesView.vue
@@ -1327,15 +1327,6 @@ onMounted(async () => {
   margin-top: var(--app-space-4);
 }
 
-.preview-nav-bar--bottom {
-  padding-bottom: 0;
-  border-bottom: none;
-  padding-top: var(--app-space-3);
-  border-top: 1px solid var(--app-surface-border);
-  margin-bottom: 0;
-  margin-top: var(--app-space-4);
-}
-
 .preview-nav-bar__counter {
   font-size: 0.85rem;
   color: var(--p-text-muted-color);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "solde"
-version = "1.4.3"
+version = "1.4.4"
 description = "Web app for French non-profit accounting — invoicing, payments, cash management and double-entry bookkeeping."
 requires-python = ">=3.11"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "solde"
-version = "1.4.7"
+version = "1.4.8"
 description = "Web app for French non-profit accounting — invoicing, payments, cash management and double-entry bookkeeping."
 requires-python = ">=3.11"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "solde"
-version = "1.4.6"
+version = "1.4.7"
 description = "Web app for French non-profit accounting — invoicing, payments, cash management and double-entry bookkeeping."
 requires-python = ">=3.11"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "solde"
-version = "1.4.5"
+version = "1.4.6"
 description = "Web app for French non-profit accounting — invoicing, payments, cash management and double-entry bookkeeping."
 requires-python = ">=3.11"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "solde"
-version = "1.4.4"
+version = "1.4.5"
 description = "Web app for French non-profit accounting — invoicing, payments, cash management and double-entry bookkeeping."
 requires-python = ">=3.11"
 dependencies = [

--- a/tests/integration/test_payments_api.py
+++ b/tests/integration/test_payments_api.py
@@ -478,3 +478,96 @@ async def test_list_payments_filter_by_invoice_type(
     assert len(data) == 1
     assert data[0]["id"] == client_payment_response.json()["id"]
     assert data[0]["invoice_type"] == "client"
+
+
+# ---------------------------------------------------------------------------
+# TEC-158 — Tests for GET /api/payments/suggest_cheque_number
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_suggest_cheque_number_returns_200_with_string(
+    client: AsyncClient, admin_user: User, auth_headers: dict
+) -> None:
+    response = await client.get(
+        "/api/payments/suggest_cheque_number",
+        params={"payment_date": "2024-06-15"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    # Response must be a plain string (JSON string or raw text)
+    value = response.json()
+    assert isinstance(value, str)
+    assert len(value) > 0
+
+
+@pytest.mark.asyncio
+async def test_suggest_cheque_number_uses_today_when_no_date(
+    client: AsyncClient, admin_user: User, auth_headers: dict
+) -> None:
+    """Without payment_date the endpoint must still succeed using today's date."""
+    response = await client.get(
+        "/api/payments/suggest_cheque_number",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    assert isinstance(response.json(), str)
+
+
+@pytest.mark.asyncio
+async def test_suggest_cheque_number_increments_when_cheques_exist(
+    client: AsyncClient, db_session: AsyncSession, admin_user: User, auth_headers: dict
+) -> None:
+    """Sequence counter must advance when a cheque already exists for the same date."""
+    contact_id, invoice_id = await _setup_contact_invoice(db_session)
+    target_date = "2025-03-10"
+
+    # First suggestion before any cheque
+    r1 = await client.get(
+        "/api/payments/suggest_cheque_number",
+        params={"payment_date": target_date},
+        headers=auth_headers,
+    )
+    first = r1.json()
+
+    # Record a cheque payment on that date
+    await client.post(
+        "/api/payments/",
+        json={
+            "invoice_id": invoice_id,
+            "contact_id": contact_id,
+            "amount": "120.00",
+            "date": target_date,
+            "method": "cheque",
+            "cheque_number": first,
+        },
+        headers=auth_headers,
+    )
+
+    # Second suggestion must differ (next in sequence)
+    r2 = await client.get(
+        "/api/payments/suggest_cheque_number",
+        params={"payment_date": target_date},
+        headers=auth_headers,
+    )
+    second = r2.json()
+    assert second != first
+
+
+@pytest.mark.asyncio
+async def test_suggest_cheque_number_requires_auth(client: AsyncClient) -> None:
+    response = await client.get("/api/payments/suggest_cheque_number")
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_suggest_cheque_number_forbidden_for_readonly(
+    client: AsyncClient,
+    readonly_user: User,
+    readonly_auth_headers: dict,
+) -> None:
+    response = await client.get(
+        "/api/payments/suggest_cheque_number",
+        headers=readonly_auth_headers,
+    )
+    assert response.status_code == 403

--- a/tests/integration/test_payments_api.py
+++ b/tests/integration/test_payments_api.py
@@ -495,23 +495,27 @@ async def test_suggest_cheque_number_returns_200_with_string(
         headers=auth_headers,
     )
     assert response.status_code == 200
-    # Response must be a plain string (JSON string or raw text)
     value = response.json()
     assert isinstance(value, str)
-    assert len(value) > 0
+    # Default template is "{date}.{seq}" where date=YYYYMMDD and seq=2 digits
+    assert value == "20240615.01"
 
 
 @pytest.mark.asyncio
 async def test_suggest_cheque_number_uses_today_when_no_date(
     client: AsyncClient, admin_user: User, auth_headers: dict
 ) -> None:
-    """Without payment_date the endpoint must still succeed using today's date."""
+    """Without payment_date the endpoint must use today's date in the result."""
     response = await client.get(
         "/api/payments/suggest_cheque_number",
         headers=auth_headers,
     )
     assert response.status_code == 200
-    assert isinstance(response.json(), str)
+    value = response.json()
+    assert isinstance(value, str)
+    # The returned number must embed today's date formatted as YYYYMMDD
+    today_str = date.today().strftime("%Y%m%d")
+    assert today_str in value
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_settings_api.py
+++ b/tests/integration/test_settings_api.py
@@ -140,6 +140,49 @@ class TestUpdateSettings:
         assert response.status_code == 200
         assert response.json()["default_invoice_due_days"] == 30
 
+    # TEC-159 — cheque_number_template validation
+    async def test_cheque_number_template_default_returned(
+        self, client: AsyncClient, auth_headers: dict
+    ):
+        response = await client.get("/api/settings/", headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert "cheque_number_template" in data
+        assert data["cheque_number_template"] == "{date}.{seq}"
+
+    async def test_cheque_number_template_update_valid(
+        self, client: AsyncClient, auth_headers: dict
+    ):
+        response = await client.put(
+            "/api/settings/",
+            json={"cheque_number_template": "CHQ-{date}-{seq}"},
+            headers=auth_headers,
+        )
+        assert response.status_code == 200
+        assert response.json()["cheque_number_template"] == "CHQ-{date}-{seq}"
+
+    async def test_cheque_number_template_missing_seq_rejected(
+        self, client: AsyncClient, auth_headers: dict
+    ):
+        """Template without {seq} must be rejected with 422."""
+        response = await client.put(
+            "/api/settings/",
+            json={"cheque_number_template": "{date}-NNN"},
+            headers=auth_headers,
+        )
+        assert response.status_code == 422
+
+    async def test_cheque_number_template_unsupported_placeholder_rejected(
+        self, client: AsyncClient, auth_headers: dict
+    ):
+        """Template with an unknown placeholder must be rejected with 422."""
+        response = await client.put(
+            "/api/settings/",
+            json={"cheque_number_template": "{date}-{seq}-{user}"},
+            headers=auth_headers,
+        )
+        assert response.status_code == 422
+
 
 class TestTreasurySystemOpening:
     async def test_get_system_opening_requires_auth(self, client: AsyncClient) -> None:


### PR DESCRIPTION
## Summary

This PR delivers **Lot CR2 — post-mobile-mode finishing touches**, grouping 8 tickets across i18n fixes, integration tests, UX improvements, and a base for English localisation.

## Changes

### Added
- **BIZ-165** — Prev/Next navigation buttons in the client invoice history dialog (parity with supplier invoices view)
- **BIZ-166** — Contacts view: "Clients" tab active by default (tab order: Clients → Suppliers → All); contacts sorted by invoice recency (< 6 months first) then alphabetically
- **BIZ-168** — Bottom nav bar duplicated in client and supplier invoice preview dialogs; clicking from the bottom bar scrolls the dialog to the bottom to keep the PDF attachment in view
- **CHR-078** — `frontend/src/i18n/en.ts` created: English i18n skeleton with `app`, `auth`, and `common` sections translated; registered in `vue-i18n` with `fallbackLocale: 'fr'`

### Improved
- **TEC-157** — `AppMobileCardList`: hardcoded `'Aucune donnée'` default replaced by `common.empty` i18n key
- **TEC-157** — `CashView`: hardcoded `'Écart :'` label replaced by `cash.count_diff` i18n key

### Fixed
- **BIZ-167** — "Passer en créance douteuse" button hidden for supplier-type contacts (only meaningful for clients)

### Tests
- **TEC-158** — 5 new integration tests for `GET /api/payments/suggest_cheque_number`: status 200 + format, default date (today), sequential increment, 401 without auth, 403 for `readonly`
- **TEC-159** — 4 new integration tests for `cheque_number_template` in settings API: default value returned, valid update, rejection without `{seq}`, rejection with unsupported placeholder

## Version

`1.4.3` → `1.4.7` (patch bumps across 4 commits)

## Quality gate

- ✅ `ruff check` + `ruff format --check` — 0 issues
- ✅ `mypy` — 0 issues (159 source files)
- ✅ `pytest` — 1030 passed
- ✅ `vue-tsc --noEmit` — 0 errors
- ✅ `eslint src/` — 0 issues
- ✅ `vitest run` — 144 passed