### PR TITLE
feat(invoices): PAYÉ watermark on paid invoice PDFs (BIZ-186)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ Ce projet respecte le [Versionnage sémantique](https://semver.org/lang/fr/).
 - **TEC-171** — Suppression de tous les `db.commit()` dans les services et routeurs ; utilisation de `flush()` uniquement (commit/rollback gérés par `get_db()`)
 - **TEC-173** — Découpage de `bank.py` (781 lignes) en 3 sous-routeurs : `bank_transactions.py`, `bank_import.py`, `bank_deposits.py`
 
+### Ajouté
+- **BIZ-186** — Filigrane « PAYÉ » en rouge diagonal sur les PDF des factures intégralement réglées
+
 ---
 
 ## [1.6.0] — 2026-05-05

--- a/backend/services/pdf_service.py
+++ b/backend/services/pdf_service.py
@@ -21,11 +21,13 @@ def render_invoice_html(
     """Render the invoice Jinja2 template to an HTML string."""
     env = _template_env()
     template = env.get_template("invoice.html")
+    is_paid = getattr(invoice, "status", None) == "paid"
     return template.render(
         invoice=invoice,
         contact_name=contact_name,
         contact_address=contact_address,
         settings=settings,
+        is_paid=is_paid,
     )
 
 

--- a/backend/services/pdf_service.py
+++ b/backend/services/pdf_service.py
@@ -5,6 +5,8 @@ from pathlib import Path
 
 from jinja2 import Environment, FileSystemLoader
 
+from backend.models.invoice import InvoiceStatus
+
 
 @lru_cache(maxsize=1)
 def _template_env() -> Environment:
@@ -21,7 +23,7 @@ def render_invoice_html(
     """Render the invoice Jinja2 template to an HTML string."""
     env = _template_env()
     template = env.get_template("invoice.html")
-    is_paid = getattr(invoice, "status", None) == "paid"
+    is_paid = getattr(invoice, "status", None) == InvoiceStatus.PAID
     return template.render(
         invoice=invoice,
         contact_name=contact_name,

--- a/backend/templates/invoice.html
+++ b/backend/templates/invoice.html
@@ -39,9 +39,12 @@
   .payment-instructions h3 { font-size: 9pt; text-transform: uppercase; letter-spacing: 0.8px; color: #0369a1; margin-bottom: 10px; }
   .payment-instructions ul { margin: 8px 0 0 18px; padding: 0; }
   .payment-instructions li { margin-bottom: 4px; line-height: 1.5; }
+  .watermark { position: fixed; top: 50%; left: 50%; transform: translate(-50%, -50%) rotate(-45deg); font-size: 80pt; font-weight: bold; color: rgba(220, 38, 38, 0.15); white-space: nowrap; z-index: 1000; pointer-events: none; }
 </style>
 </head>
 <body>
+
+{% if is_paid %}<div class="watermark">PAYÉ</div>{% endif %}
 
 <div class="header">
   <div class="association">

--- a/doc/backlog.md
+++ b/doc/backlog.md
@@ -51,7 +51,7 @@ Facteur de marge actuel : **1,00** (0%) — inchangé (voir note CR2).
 | ID | Titre | Prio | Est. | Créé | Démarré | Terminé |
 | --- | --- | --- | --- | --- | --- | --- |
 | TEC-185 | Régression : aperçu PDF non fonctionnel dans Chrome | P1 | ~20 min | 2026-05-10 | | |
-| BIZ-186 | Filigrane « Payé » sur le PDF des factures réglées | P2 | ~20 min | 2026-05-10 | | |
+| BIZ-186 | Filigrane « Payé » sur le PDF des factures réglées | P2 | ~20 min | 2026-05-10 | 2026-05-10 | 2026-05-10 |
 | BIZ-169 | Édition/suppression des opérations manuelles | P2 | ~25 min | 2026-05-04 | 2026-05-04 | |
 | BIZ-171 | Améliorations tuiles et détail factures — mobile | P2 | ~35 min | 2026-05-05 | 2026-05-05 | 2026-05-05 |
 | BIZ-172 | Section admin : paiements chèques incohérents | P2 | ~45 min | 2026-05-05 | 2026-05-05 | 2026-05-05 |

--- a/tests/unit/test_pdf_service.py
+++ b/tests/unit/test_pdf_service.py
@@ -44,6 +44,7 @@ class _FakeInvoice:
     total_vat: Decimal = Decimal("0.00")
     notes: str | None = None
     lines: list[Any] = field(default_factory=lambda: [_InvoiceLine()])
+    status: str = "sent"
 
 
 @dataclass
@@ -114,6 +115,22 @@ def test_render_invoice_html_no_address_omitted() -> None:
     html = render_invoice_html(_FakeInvoice(), "Alice Martin", _FakeSettings(), None)
     # No address block should appear beyond the contact name
     assert "57000" not in html
+
+
+def test_render_invoice_html_paid_shows_watermark() -> None:
+    invoice = _FakeInvoice(status="paid")
+    html = render_invoice_html(invoice, "Alice Martin", _FakeSettings())
+    assert '<div class="watermark">' in html
+    assert "PAY\u00c9" in html
+
+
+def test_render_invoice_html_non_paid_no_watermark() -> None:
+    for status in ("sent", "partial", "draft", "overdue"):
+        invoice = _FakeInvoice(status=status)
+        html = render_invoice_html(invoice, "Alice Martin", _FakeSettings())
+        assert '<div class="watermark">' not in html, (
+            f"Watermark should not appear for status={status!r}"
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds a diagonal "PAYÉ" watermark to invoice PDFs when the invoice status is `paid`.

## Changes

- **`backend/services/pdf_service.py`** — `render_invoice_html` now computes `is_paid` from `invoice.status == "paid"` and passes it to the Jinja2 template context.
- **`backend/templates/invoice.html`** — Added `.watermark` CSS class (`position: fixed`, centered, `rotate(-45deg)`, `font-size: 80pt`, `color: rgba(220, 38, 38, 0.15)`) and a conditional `<div class="watermark">PAYÉ</div>` rendered only when `is_paid` is true.

## Behaviour

- `status = paid` → watermark displayed on every page of the PDF
- `status = partial` or any other status → no watermark
- Compatible with WeasyPrint's CSS rendering

## Testing

- 1059 backend tests passed
- 148 frontend tests passed
- ruff, mypy, eslint, vue-tsc all green

## Summary by Sourcery

Add a conditional "PAYÉ" watermark to paid invoice PDFs and record the feature in project documentation.

New Features:
- Display a red diagonal "PAYÉ" watermark on invoice PDFs when the invoice status is paid.

Documentation:
- Document the new invoice watermark feature in the changelog and mark BIZ-186 as completed in the backlog.