### PR TITLE
fix(contacts): allow SECRETAIRE role to merge contacts

### DIFF
--- a/backend/routers/contact.py
+++ b/backend/routers/contact.py
@@ -36,7 +36,7 @@ _ReadAccess = Annotated[
 
 _AdminAccess = Annotated[
     User,
-    Depends(require_role(UserRole.ADMIN)),
+    Depends(require_role(UserRole.SECRETAIRE, UserRole.ADMIN)),
 ]
 
 
@@ -215,7 +215,7 @@ async def merge_contact(
 ) -> MergeContactResult:
     """Merge source contact into target. Reassigns all linked records and soft-deletes source.
 
-    Only ADMIN role is allowed. The source contact (contact_id) is soft-deleted;
+    ADMIN and SECRETAIRE roles are allowed. The source contact (contact_id) is soft-deleted;
     the target contact (target_id query param) is kept.
     """
     try:

--- a/backend/routers/contact.py
+++ b/backend/routers/contact.py
@@ -34,7 +34,7 @@ _ReadAccess = Annotated[
 ]
 
 
-_AdminAccess = Annotated[
+_MergeAccess = Annotated[
     User,
     Depends(require_role(UserRole.SECRETAIRE, UserRole.ADMIN)),
 ]
@@ -211,7 +211,7 @@ async def merge_contact(
     contact_id: int,
     target_id: int,
     db: Annotated[AsyncSession, Depends(get_db)],
-    current_user: _AdminAccess,
+    current_user: _MergeAccess,
 ) -> MergeContactResult:
     """Merge source contact into target. Reassigns all linked records and soft-deletes source.
 

--- a/frontend/src/views/ContactsView.vue
+++ b/frontend/src/views/ContactsView.vue
@@ -119,7 +119,7 @@
                 @click="openHistoryDialog(data.id)"
               />
               <Button
-                v-if="authStore.isAdmin"
+                v-if="authStore.isAdmin || authStore.isGestionnaire"
                 icon="pi pi-arrow-right-arrow-left"
                 size="small"
                 severity="warn"
@@ -270,7 +270,7 @@
                 @click="openHistoryDialog(data.id)"
               />
               <Button
-                v-if="authStore.isAdmin"
+                v-if="authStore.isAdmin || authStore.isGestionnaire"
                 icon="pi pi-arrow-right-arrow-left"
                 size="small"
                 severity="warn"

--- a/tests/integration/test_contacts_api.py
+++ b/tests/integration/test_contacts_api.py
@@ -399,6 +399,31 @@ class TestMergeContact:
         )
         assert response.status_code == 403
 
+    async def test_merge_allowed_for_secretaire(
+        self, client: AsyncClient, auth_headers: dict, secretaire_auth_headers: dict
+    ):
+        source = await client.post(
+            "/api/contacts/", json={"type": "client", "nom": "Source"}, headers=auth_headers
+        )
+        target = await client.post(
+            "/api/contacts/", json={"type": "client", "nom": "Cible"}, headers=auth_headers
+        )
+        source_id = source.json()["id"]
+        target_id = target.json()["id"]
+
+        response = await client.post(
+            f"/api/contacts/{source_id}/merge",
+            params={"target_id": target_id},
+            headers=secretaire_auth_headers,
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["target_id"] == target_id
+
+        # Source should be soft-deleted
+        get_source = await client.get(f"/api/contacts/{source_id}", headers=auth_headers)
+        assert get_source.json()["is_active"] is False
+
     async def test_merge_moves_additional_emails_with_deduplication(
         self, client: AsyncClient, auth_headers: dict
     ):

--- a/tests/integration/test_contacts_api.py
+++ b/tests/integration/test_contacts_api.py
@@ -384,7 +384,7 @@ class TestMergeContact:
         assert response.status_code == 422
 
     async def test_merge_requires_admin(
-        self, client: AsyncClient, auth_headers: dict, secretaire_auth_headers: dict
+        self, client: AsyncClient, auth_headers: dict, tresorier_auth_headers: dict
     ):
         source = await client.post(
             "/api/contacts/", json={"type": "client", "nom": "Source"}, headers=auth_headers
@@ -395,7 +395,7 @@ class TestMergeContact:
         response = await client.post(
             f"/api/contacts/{source.json()['id']}/merge",
             params={"target_id": target.json()["id"]},
-            headers=secretaire_auth_headers,
+            headers=tresorier_auth_headers,
         )
         assert response.status_code == 403
 

--- a/tests/integration/test_contacts_api.py
+++ b/tests/integration/test_contacts_api.py
@@ -383,7 +383,7 @@ class TestMergeContact:
         )
         assert response.status_code == 422
 
-    async def test_merge_requires_admin(
+    async def test_merge_forbidden_for_tresorier(
         self, client: AsyncClient, auth_headers: dict, tresorier_auth_headers: dict
     ):
         source = await client.post(


### PR DESCRIPTION
## Summary

BIZ-202 correction: the merge button was hidden for the `secretaire` (gestionnaire) role, when it should be accessible to both `admin` and `secretaire`.

## Changes

- **Backend** (`backend/routers/contact.py`): `_AdminAccess` dependency now allows `SECRETAIRE` in addition to `ADMIN` on the `POST /{id}/merge` endpoint
- **Frontend** (`frontend/src/views/ContactsView.vue`): merge button `v-if` updated to `authStore.isAdmin || authStore.isGestionnaire` (both mobile card and desktop table)
- **Test** (`tests/integration/test_contacts_api.py`): `test_merge_requires_admin` now uses `tresorier_auth_headers` (trésorier must still get 403) instead of `secretaire_auth_headers`

## Roles allowed to merge contacts

| Role | Before | After |
|------|--------|-------|
| admin | ✅ | ✅ |
| secretaire | ❌ (regression) | ✅ |
| tresorier | ❌ | ❌ |
| readonly | ❌ | ❌ |

## Summary by Sourcery

Allow both admin and secretaire roles to merge contacts and update tests accordingly.

New Features:
- Enable users with the secretaire role to trigger contact merge operations in the backend and frontend UI.

Bug Fixes:
- Restore visibility of the contact merge action for secretaire users while keeping it restricted for other non-admin roles.

Tests:
- Adjust the contact merge permission test to assert that tresorier users are still forbidden from merging contacts.