### PR TITLE
fix(backup): always include data/pdfs in remote backup (BIZ-201)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,10 @@ Ce projet respecte le [Versionnage sémantique](https://semver.org/lang/fr/).
 ### Corrigé
 - **BIZ-201** — Backup automatique : le répertoire `data/pdfs` (factures et documents PDF) est désormais inclus systématiquement dans chaque sauvegarde envoyée vers les destinations distantes
 
-## [1.7.3] — Contacts : le bouton « Fusionner » est désormais masqué pour les utilisateurs non-administrateurs (seuls les admins peuvent fusionner des contacts)
+## [1.7.3] — 2026-05-14
+
+### Corrigé
+- **BIZ-202** — Contacts : le bouton « Fusionner » est désormais masqué pour les utilisateurs non-administrateurs (seuls les admins peuvent fusionner des contacts)
 - **BIZ-203** — Dialogue de fusion contacts : affichage du nom complet (NOM Prénom) via une computed property — évite les espaces parasites liés aux données
 - **BIZ-204** — Contacts : le nom (`nom`) est désormais normalisé en majuscules et dépouillé des espaces à la création et à la modification
 - **BIZ-205** — Aperçu PDF sur iOS Safari : remplacement de l'`<embed>` non supporté par un bouton « Ouvrir le PDF » (nouvel onglet) sur mobile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ Ce projet respecte le [Versionnage sémantique](https://semver.org/lang/fr/).
 ## [Non publié]
 
 ### Corrigé
-- **BIZ-202** — Contacts : le bouton « Fusionner » est désormais masqué pour les utilisateurs non-administrateurs (seuls les admins peuvent fusionner des contacts)
+- **BIZ-201** — Backup automatique : le répertoire `data/pdfs` (factures et documents PDF) est désormais inclus systématiquement dans chaque sauvegarde envoyée vers les destinations distantes
+
+## [1.7.3] — Contacts : le bouton « Fusionner » est désormais masqué pour les utilisateurs non-administrateurs (seuls les admins peuvent fusionner des contacts)
 - **BIZ-203** — Dialogue de fusion contacts : affichage du nom complet (NOM Prénom) via une computed property — évite les espaces parasites liés aux données
 - **BIZ-204** — Contacts : le nom (`nom`) est désormais normalisé en majuscules et dépouillé des espaces à la création et à la modification
 - **BIZ-205** — Aperçu PDF sur iOS Safari : remplacement de l'`<embed>` non supporté par un bouton « Ouvrir le PDF » (nouvel onglet) sur mobile

--- a/backend/services/backup_scheduler.py
+++ b/backend/services/backup_scheduler.py
@@ -239,6 +239,9 @@ async def _run_backup_job_inner(
             src_paths = [str(backup_file)]
         if include_uploads:
             src_paths.append(str(Path("data/uploads").resolve()))
+        pdfs_dir = Path("data/pdfs")
+        if pdfs_dir.exists():
+            src_paths.append(str(pdfs_dir.resolve()))
 
         dest_count = len(destinations)
         for i, dest in enumerate(destinations):

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "solde"
-version = "1.7.3"
+version = "1.7.4"
 description = "Web app for French non-profit accounting — invoicing, payments, cash management and double-entry bookkeeping."
 requires-python = ">=3.11"
 dependencies = [

--- a/tests/unit/test_backup_services.py
+++ b/tests/unit/test_backup_services.py
@@ -368,5 +368,3 @@ class TestBackupJobPdfsInclusion:
         assert expected_pdfs not in captured[0], (
             f"data/pdfs ne devrait pas être dans src_paths: {captured[0]}"
         )
-
-

--- a/tests/unit/test_backup_services.py
+++ b/tests/unit/test_backup_services.py
@@ -3,6 +3,7 @@
 Tests:
 - backup_destination_service: write_rclone_config, test_destination_connection
 - backup_restore_service: _do_test_restore on valid/corrupted/empty SQLite files
+- backup_scheduler: src_paths construction (BIZ-201 — data/pdfs inclusion)
 """
 
 from __future__ import annotations
@@ -214,3 +215,158 @@ class TestTestRestore:
         _make_valid_db(db)
         result = await service_test_restore(str(db))
         assert result.ok is True
+
+
+# ---------------------------------------------------------------------------
+# backup_scheduler — src_paths construction (BIZ-201)
+# ---------------------------------------------------------------------------
+
+
+def _make_scheduler_patches(
+    fake_backup: Path,
+    dest: BackupDestination,
+    sync_side_effect,
+) -> list:
+    """Return a list of patch objects for _run_backup_job_inner dependencies."""
+    mock_db = MagicMock()
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = [dest]
+    mock_db.execute = AsyncMock(return_value=mock_result)
+    mock_db.commit = AsyncMock()
+
+    mock_session_ctx = MagicMock()
+    mock_session_ctx.__aenter__ = AsyncMock(return_value=mock_db)
+    mock_session_ctx.__aexit__ = AsyncMock(return_value=False)
+    get_session_mock = MagicMock(return_value=mock_session_ctx)
+
+    return [
+        patch("backend.services.backup_service.create_backup", AsyncMock(return_value=fake_backup)),
+        patch(
+            "backend.services.backup_restore_service.test_restore",
+            AsyncMock(return_value=MagicMock(ok=True)),
+        ),
+        patch("backend.database.get_session", get_session_mock),
+        patch("backend.services.backup_destination_service.refresh_onedrive_tokens", AsyncMock()),
+        patch("backend.services.backup_destination_service.write_rclone_config", MagicMock()),
+        patch(
+            "backend.services.backup_destination_service.sync_destination",
+            side_effect=sync_side_effect,
+        ),
+        patch("backend.services.backup_scheduler._update_run_status", AsyncMock()),
+    ]
+
+
+def _make_dest_obj(name: str = "local-dest") -> BackupDestination:
+    dest = BackupDestination()
+    dest.id = 1
+    dest.name = name
+    dest.type = "local"
+    dest.rclone_remote_name = "local"
+    dest.rclone_config = None
+    dest.target_path = "/backup"
+    dest.enabled = True
+    return dest
+
+
+class TestBackupJobPdfsInclusion:
+    """BIZ-201: data/pdfs must always be included in the backup src_paths."""
+
+    @pytest.mark.asyncio
+    async def test_pdfs_included_snapshot_mode(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """data/pdfs is included in src_paths in snapshot (single-file) mode."""
+        (tmp_path / "data" / "pdfs").mkdir(parents=True)
+        monkeypatch.chdir(tmp_path)
+
+        fake_backup = tmp_path / "solde_backup_20260101_120000.db"
+        fake_backup.write_bytes(b"fake")
+        dest = _make_dest_obj()
+        captured: list[list[str]] = []
+
+        async def _fake_sync(dest, src_paths, run_ts, on_progress=None):
+            captured.append(list(src_paths))
+
+        from backend.services import backup_scheduler as sched
+
+        patches = _make_scheduler_patches(fake_backup, dest, _fake_sync)
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5], patches[6]:
+            await sched._run_backup_job_inner(
+                db_path="data/solde.db",
+                backup_dir="data/backups",
+                include_uploads=False,
+                include_all_backups=False,
+                notify_on_failure=False,
+            )
+
+        expected_pdfs = str((tmp_path / "data" / "pdfs").resolve())
+        assert len(captured) == 1
+        assert expected_pdfs in captured[0], f"data/pdfs absent de src_paths: {captured[0]}"
+
+    @pytest.mark.asyncio
+    async def test_pdfs_included_full_backup_mode(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """data/pdfs is included in src_paths in full-backup (include_all_backups) mode."""
+        (tmp_path / "data" / "pdfs").mkdir(parents=True)
+        monkeypatch.chdir(tmp_path)
+
+        fake_backup = tmp_path / "solde_backup_20260101_120000.db"
+        fake_backup.write_bytes(b"fake")
+        dest = _make_dest_obj()
+        captured: list[list[str]] = []
+
+        async def _fake_sync(dest, src_paths, run_ts, on_progress=None):
+            captured.append(list(src_paths))
+
+        from backend.services import backup_scheduler as sched
+
+        patches = _make_scheduler_patches(fake_backup, dest, _fake_sync)
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5], patches[6]:
+            await sched._run_backup_job_inner(
+                db_path="data/solde.db",
+                backup_dir="data/backups",
+                include_uploads=False,
+                include_all_backups=True,
+                notify_on_failure=False,
+            )
+
+        expected_pdfs = str((tmp_path / "data" / "pdfs").resolve())
+        assert len(captured) == 1
+        assert expected_pdfs in captured[0], f"data/pdfs absent de src_paths: {captured[0]}"
+
+    @pytest.mark.asyncio
+    async def test_pdfs_skipped_when_directory_absent(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """data/pdfs is NOT added to src_paths when the directory does not exist."""
+        # data/pdfs directory intentionally NOT created
+        monkeypatch.chdir(tmp_path)
+
+        fake_backup = tmp_path / "solde_backup_20260101_120000.db"
+        fake_backup.write_bytes(b"fake")
+        dest = _make_dest_obj()
+        captured: list[list[str]] = []
+
+        async def _fake_sync(dest, src_paths, run_ts, on_progress=None):
+            captured.append(list(src_paths))
+
+        from backend.services import backup_scheduler as sched
+
+        patches = _make_scheduler_patches(fake_backup, dest, _fake_sync)
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5], patches[6]:
+            await sched._run_backup_job_inner(
+                db_path="data/solde.db",
+                backup_dir="data/backups",
+                include_uploads=False,
+                include_all_backups=False,
+                notify_on_failure=False,
+            )
+
+        expected_pdfs = str((tmp_path / "data" / "pdfs").resolve())
+        assert len(captured) == 1
+        assert expected_pdfs not in captured[0], (
+            f"data/pdfs ne devrait pas être dans src_paths: {captured[0]}"
+        )
+
+

--- a/tests/unit/test_backup_services.py
+++ b/tests/unit/test_backup_services.py
@@ -9,6 +9,7 @@ Tests:
 from __future__ import annotations
 
 import sqlite3
+from contextlib import ExitStack
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -256,18 +257,6 @@ def _make_scheduler_patches(
     ]
 
 
-def _make_dest_obj(name: str = "local-dest") -> BackupDestination:
-    dest = BackupDestination()
-    dest.id = 1
-    dest.name = name
-    dest.type = "local"
-    dest.rclone_remote_name = "local"
-    dest.rclone_config = None
-    dest.target_path = "/backup"
-    dest.enabled = True
-    return dest
-
-
 class TestBackupJobPdfsInclusion:
     """BIZ-201: data/pdfs must always be included in the backup src_paths."""
 
@@ -281,7 +270,7 @@ class TestBackupJobPdfsInclusion:
 
         fake_backup = tmp_path / "solde_backup_20260101_120000.db"
         fake_backup.write_bytes(b"fake")
-        dest = _make_dest_obj()
+        dest = _make_dest(name="local-dest", rclone_remote_name="local")
         captured: list[list[str]] = []
 
         async def _fake_sync(dest, src_paths, run_ts, on_progress=None):
@@ -290,7 +279,9 @@ class TestBackupJobPdfsInclusion:
         from backend.services import backup_scheduler as sched
 
         patches = _make_scheduler_patches(fake_backup, dest, _fake_sync)
-        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5], patches[6]:
+        with ExitStack() as stack:
+            for p in patches:
+                stack.enter_context(p)
             await sched._run_backup_job_inner(
                 db_path="data/solde.db",
                 backup_dir="data/backups",
@@ -301,7 +292,7 @@ class TestBackupJobPdfsInclusion:
 
         expected_pdfs = str((tmp_path / "data" / "pdfs").resolve())
         assert len(captured) == 1
-        assert expected_pdfs in captured[0], f"data/pdfs absent de src_paths: {captured[0]}"
+        assert expected_pdfs in captured[0], f"data/pdfs missing from src_paths: {captured[0]}"
 
     @pytest.mark.asyncio
     async def test_pdfs_included_full_backup_mode(
@@ -313,7 +304,7 @@ class TestBackupJobPdfsInclusion:
 
         fake_backup = tmp_path / "solde_backup_20260101_120000.db"
         fake_backup.write_bytes(b"fake")
-        dest = _make_dest_obj()
+        dest = _make_dest(name="local-dest", rclone_remote_name="local")
         captured: list[list[str]] = []
 
         async def _fake_sync(dest, src_paths, run_ts, on_progress=None):
@@ -322,7 +313,9 @@ class TestBackupJobPdfsInclusion:
         from backend.services import backup_scheduler as sched
 
         patches = _make_scheduler_patches(fake_backup, dest, _fake_sync)
-        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5], patches[6]:
+        with ExitStack() as stack:
+            for p in patches:
+                stack.enter_context(p)
             await sched._run_backup_job_inner(
                 db_path="data/solde.db",
                 backup_dir="data/backups",
@@ -333,7 +326,7 @@ class TestBackupJobPdfsInclusion:
 
         expected_pdfs = str((tmp_path / "data" / "pdfs").resolve())
         assert len(captured) == 1
-        assert expected_pdfs in captured[0], f"data/pdfs absent de src_paths: {captured[0]}"
+        assert expected_pdfs in captured[0], f"data/pdfs missing from src_paths: {captured[0]}"
 
     @pytest.mark.asyncio
     async def test_pdfs_skipped_when_directory_absent(
@@ -345,7 +338,7 @@ class TestBackupJobPdfsInclusion:
 
         fake_backup = tmp_path / "solde_backup_20260101_120000.db"
         fake_backup.write_bytes(b"fake")
-        dest = _make_dest_obj()
+        dest = _make_dest(name="local-dest", rclone_remote_name="local")
         captured: list[list[str]] = []
 
         async def _fake_sync(dest, src_paths, run_ts, on_progress=None):
@@ -354,7 +347,9 @@ class TestBackupJobPdfsInclusion:
         from backend.services import backup_scheduler as sched
 
         patches = _make_scheduler_patches(fake_backup, dest, _fake_sync)
-        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5], patches[6]:
+        with ExitStack() as stack:
+            for p in patches:
+                stack.enter_context(p)
             await sched._run_backup_job_inner(
                 db_path="data/solde.db",
                 backup_dir="data/backups",
@@ -366,5 +361,5 @@ class TestBackupJobPdfsInclusion:
         expected_pdfs = str((tmp_path / "data" / "pdfs").resolve())
         assert len(captured) == 1
         assert expected_pdfs not in captured[0], (
-            f"data/pdfs ne devrait pas être dans src_paths: {captured[0]}"
+            f"data/pdfs should not be in src_paths: {captured[0]}"
         )


### PR DESCRIPTION
## Summary

**BIZ-201** — The automatic backup job was not including the `data/pdfs` directory when syncing to remote destinations, causing generated and stored PDF files (invoices, documents) to be lost in the event of a restore.

## Root cause

In `backup_scheduler._run_backup_job_inner`, only `data/uploads` was optionally appended to `src_paths`. The `data/pdfs` directory was never referenced.

## Fix

`data/pdfs` is now unconditionally appended to `src_paths` (when the directory exists) for every backup cycle, regardless of the mode (snapshot or full-backup) and regardless of the destination type (local, SMB, OneDrive).

## Changes

- **`backend/services/backup_scheduler.py`**: append `data/pdfs` to `src_paths` when the directory exists
- **`tests/unit/test_backup_services.py`**: 3 new regression tests (`TestBackupJobPdfsInclusion`):
  - `test_pdfs_included_snapshot_mode` — verifies inclusion in single-file snapshot mode
  - `test_pdfs_included_full_backup_mode` — verifies inclusion in full-backup mode
  - `test_pdfs_skipped_when_directory_absent` — verifies no error when `data/pdfs` does not exist

## Version

`1.7.3` → `1.7.4`