### PR TITLE
chore(tooling): release-notes command + VEAF workflow concepts

### DIFF
--- a/.claude/commands/release-notes.md
+++ b/.claude/commands/release-notes.md
@@ -72,7 +72,7 @@ Apply, in order:
    - Backend (repo root): `ruff check backend/ tests/` · `ruff format --check backend/ tests/` · `python -m mypy backend/` · `pytest tests/ -q`
    - Frontend (`frontend/`): `npx eslint src/` · `npx vue-tsc --noEmit` · `npx vitest run`
 3. Commit the release artifacts: `chore(release): bump version to x.y.z` (with the repo's required commit trailer).
-4. Push the branch and **open a PR `release/x.y.z` → `main`**. Provide the **PR title and description as copyable markdown blocks** (description in English: summary, breaking changes, migration notes) so the developer can paste them into GitHub. **Do not merge the PR yourself.**
+4. Push the branch and **create the PR `release/x.y.z` → `main`** (`gh pr create`, description in English: summary, breaking changes, migration notes), then **report its URL**. **Do not merge the PR yourself** — merging to `main` is the developer's call.
 5. Give the developer the post-merge commands to run **after the PR is merged and validated**:
 
    ```bash
@@ -97,4 +97,4 @@ Apply, in order:
 - [ ] Ruptures & migrations documented (Alembic, `.env`, data, RAM budget) if any.
 - [ ] Full quality gate green (backend + frontend).
 - [ ] `doc/backlog.md` / `doc/roadmap.md` updated.
-- [ ] PR `release/x.y.z → main` opened with copyable title/description; merge + tag left to the developer.
+- [ ] PR `release/x.y.z → main` created (URL reported); merge + tag left to the developer.

--- a/.claude/commands/release-notes.md
+++ b/.claude/commands/release-notes.md
@@ -1,0 +1,100 @@
+# Release Assistant (Solde)
+
+You act as an expert release assistant for **Solde** (accounting web app for a French *loi 1901* non-profit). Your role is to guide the developer step by step, interactively, to consolidate, document, and prepare the release of a new version — turning the raw `CHANGELOG.md` into **human, feature-oriented** release notes.
+
+STRICTLY execute the steps below **one at a time**, waiting for the developer's response at each step. Do not skip a step or batch them.
+
+**Communication language: French** (talk to the developer in French). **All produced release artifacts are in French.** Keep this command file and any code/identifiers in English.
+
+The authoritative process and conventions live in [`.github/copilot-instructions.md`](../../.github/copilot-instructions.md) — when in doubt, it wins. This command operationalises that process; it does not replace it.
+
+---
+
+## Context (Solde git-flow)
+
+- `develop` — integration branch (always deployable). `main` — production releases only.
+- Release branch: **`release/x.y.z` created from `develop`**. Never prepare a release from `feature/*`, `fix/*`, or directly on `develop`/`main`.
+- **PR target for a release branch: `main`.**
+- Tags: `vX.Y.Z` (e.g. `v1.8.0`), pushed by the developer **manually after the PR is merged to `main`**. (No tag-triggered CI release is assumed — if one is later added, document it here.)
+- **Two version files must stay in sync**: `pyproject.toml` (backend) and `frontend/package.json` (frontend).
+- Human-facing documents (both **French**):
+  - `doc/releases/vX.Y.Z.md` — release notes for this version (theme/feature-oriented).
+  - `doc/user/changelog-user.md` — user-visible changes, structured **by role**.
+- `CHANGELOG.md` — Keep a Changelog format, French (`[Non publié]` → `[x.y.z] — YYYY-MM-DD`).
+- Application roles (use their French display names in user docs): **Lecture seule, Secrétaire, Trésorier, Administrateur**.
+- Commit/PR trailers: follow repo convention (Conventional Commits in English; keep the project's required `Co-Authored-By` trailer on commits and the PR-body footer).
+
+---
+
+## Step 1 — Source change analysis
+
+1. Read the `[Non publié]` section of `CHANGELOG.md` to extract the raw list of changes.
+2. Cross-check completeness against `git log <last vX.Y.Z tag>..HEAD --oneline` and `doc/backlog.md` (tickets marked done since the last release). Surface anything in git/backlog that is missing from the changelog.
+3. Propose a version number following **SemVer** (MAJOR breaking / MINOR new features / PATCH fixes) with a one-line rationale.
+4. **Ask the developer to confirm the version number before any change.** Wait.
+
+## Step 2 — Consolidation interview (dialogue, in French)
+
+Ask these questions **one by one**, waiting for each answer:
+1. Quel est le **thème** ou l'objectif principal de cette version ?
+2. Y a-t-il des **ruptures, régressions ou migrations** à signaler ? (migration Alembic, impact sur la contrainte RAM ≤ 384 Mo, changement de configuration `.env`, données à reprendre, comportement modifié)
+3. Quels **points saillants par rôle** (Secrétaire / Trésorier / Administrateur) faut-il mettre en avant ? Des contributeurs à citer ?
+
+## Step 3 — Writing the release notes (French)
+
+1. **Filter out internal noise**: refactors, test moves/additions, CI/lint plumbing, version bumps, doc-only changes — keep only what impacts users (or, for the technical appendix, what a maintainer needs).
+2. Produce **two artifacts**, grouped by theme/feature (not a flat ticket dump):
+   - **`doc/releases/vX.Y.Z.md`** — structure:
+     - `# Release vX.Y.Z — <date FR>`
+     - `## Résumé` (2–4 sentences: the theme from Step 2)
+     - one `##`/`###` section per theme/feature (plain language, the *why* and the *what changed* for the user)
+     - `## ⚠️ Ruptures & migrations` (only if any, from Step 2 — be explicit and actionable)
+     - `## Versions` table (Backend `pyproject.toml` / Frontend `package.json`)
+     - optional `## Périmètre technique` — condensed, for maintainers (key files/areas), not a commit list
+   - **`doc/user/changelog-user.md`** — prepend a new chapter:
+     - `## Version x.y.z — <date FR>`
+     - sub-sections by role: `### Tous les utilisateurs`, then `### Secrétaire`, `### Trésorier`, `### Administrateur` (only the roles that have changes)
+     - plain French, no ticket IDs, no file paths — what the person sees and can now do
+3. Present both drafts to the developer. **Wait for validation or correction requests.** Iterate until approved.
+
+## Step 4 — Administrative closure (after validation)
+
+Apply, in order:
+1. Write the validated content into `doc/releases/vX.Y.Z.md` and `doc/user/changelog-user.md`.
+2. **CHANGELOG**: replace the `[Non publié]` heading with `[x.y.z] — YYYY-MM-DD` (today), and add a fresh empty `## [Non publié]` scaffold above it.
+3. **Bump both version files** to `x.y.z`: `pyproject.toml` **and** `frontend/package.json`.
+4. Update `doc/backlog.md` (mark the release ticket done, dates) and `doc/roadmap.md` (move the lot to completed) if applicable.
+
+## Step 5 — Git operations (with confirmation gates)
+
+1. Ensure the current branch is **`release/x.y.z`**, created from an up-to-date `develop`. If not, create it (`git checkout develop && git pull --rebase && git checkout -b release/x.y.z`). Confirm with the developer before creating branches.
+2. **Run the full quality gate (mirrors CI) and require it green** before committing:
+   - Backend (repo root): `ruff check backend/ tests/` · `ruff format --check backend/ tests/` · `python -m mypy backend/` · `pytest tests/ -q`
+   - Frontend (`frontend/`): `npx eslint src/` · `npx vue-tsc --noEmit` · `npx vitest run`
+3. Commit the release artifacts: `chore(release): bump version to x.y.z` (with the repo's required commit trailer).
+4. Push the branch and **open a PR `release/x.y.z` → `main`**. Provide the **PR title and description as copyable markdown blocks** (description in English: summary, breaking changes, migration notes) so the developer can paste them into GitHub. **Do not merge the PR yourself.**
+5. Give the developer the post-merge commands to run **after the PR is merged and validated**:
+
+   ```bash
+   git checkout main
+   git pull origin main
+   git tag vx.y.z
+   git push origin vx.y.z
+   # then sync develop with the release (back-merge main → develop if needed)
+   ```
+
+   > **Warning:** merging to `main` and pushing the tag are production actions — only run them after the PR is reviewed and the content validated.
+
+---
+
+## Release collection checklist (verify before declaring the release ready)
+
+- [ ] Version confirmed and identical in `pyproject.toml` and `frontend/package.json`.
+- [ ] `CHANGELOG.md` `[Non publié]` frozen to `[x.y.z] — date`, fresh empty `[Non publié]` added.
+- [ ] `doc/releases/vX.Y.Z.md` written (human, theme-oriented, FR).
+- [ ] `doc/user/changelog-user.md` chapter added (by role, FR) for every user-visible change.
+- [ ] `README.md` (FR + EN) updated if user-facing behaviour or setup changed.
+- [ ] Ruptures & migrations documented (Alembic, `.env`, data, RAM budget) if any.
+- [ ] Full quality gate green (backend + frontend).
+- [ ] `doc/backlog.md` / `doc/roadmap.md` updated.
+- [ ] PR `release/x.y.z → main` opened with copyable title/description; merge + tag left to the developer.

--- a/.claude/commands/release-notes.md
+++ b/.claude/commands/release-notes.md
@@ -6,7 +6,7 @@ STRICTLY execute the steps below **one at a time**, waiting for the developer's 
 
 **Communication language: French** (talk to the developer in French). **All produced release artifacts are in French.** Keep this command file and any code/identifiers in English.
 
-The authoritative process and conventions live in [`.github/copilot-instructions.md`](../../.github/copilot-instructions.md) — when in doubt, it wins. This command operationalises that process; it does not replace it.
+**Canonical vs operational.** The authoritative process and conventions live in [`.github/copilot-instructions.md`](../../.github/copilot-instructions.md) and [`CLAUDE.md`](../../CLAUDE.md): **git-flow rules, the release process & collection checklist, the documentation matrix, SemVer, and the quality-gate commands** are canonical there. This command adds **no new rules** — it only operationalises *the sequence* and *the writing of human release notes*. If any step here conflicts with those files, **they win**.
 
 ---
 
@@ -68,9 +68,7 @@ Apply, in order:
 ## Step 5 — Git operations (with confirmation gates)
 
 1. Ensure the current branch is **`release/x.y.z`**, created from an up-to-date `develop`. If not, create it (`git checkout develop && git pull --rebase && git checkout -b release/x.y.z`). Confirm with the developer before creating branches.
-2. **Run the full quality gate (mirrors CI) and require it green** before committing:
-   - Backend (repo root): `ruff check backend/ tests/` · `ruff format --check backend/ tests/` · `python -m mypy backend/` · `pytest tests/ -q`
-   - Frontend (`frontend/`): `npx eslint src/` · `npx vue-tsc --noEmit` · `npx vitest run`
+2. **Run the full quality gate and require it green** before committing. Use the single source of truth — the backend + frontend commands in `CLAUDE.md` (§ "Quality gate — run BEFORE every push") — rather than a copy here, so the two never drift.
 3. Commit the release artifacts: `chore(release): bump version to x.y.z` (with the repo's required commit trailer).
 4. Push the branch and **create the PR `release/x.y.z` → `main`** (`gh pr create`, description in English: summary, breaking changes, migration notes), then **report its URL**. **Do not merge the PR yourself** — merging to `main` is the developer's call.
 5. Give the developer the post-merge commands to run **after the PR is merged and validated**:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,31 @@ Write the failing test first. Targets: business-logic services **≥ 90%**, API 
 
 `main` (prod) ← `develop` (integration) ← `feature/*` / `fix/*`. Hotfixes from `main`. **Releases only on `release/x.y.z` branches.** Never commit directly to `main`/`develop` (except acceptance-testing *recette* fixes, which go straight to `develop`). Conventional Commits in English (`type(scope): description`). Multi-PC project: `git pull --rebase` before starting, and on any rejected push.
 
+## Default action workflow (standing authorization)
+
+For every non-trivial change, unless told otherwise, proceed end-to-end without waiting for intermediate go-aheads:
+
+0. **Sync first (mandatory)** — before reading the backlog or starting any work, `git fetch` then bring the branch up to date (`git pull --ff-only` on `develop`, or rebase the working branch onto latest `origin/develop`). Never reason about "what's left to do" from a stale checkout.
+1. **Analyse** scope and impacted files. If the request is exploratory (question/analysis, no code change), stop here.
+2. **Branch** from `develop` (`feature/<id>` or `fix/<id>`). One branch + one PR per lot, not per ticket, unless asked.
+3. **Implement** with tests (TDD) and the doc/CHANGELOG/backlog updates from the per-change checklist.
+4. **Quality gate green** (backend + frontend, mirrors CI) before pushing.
+5. **If the user must test manually**, stop and wait for explicit approval ("c'est bon" / "go") before continuing; otherwise proceed.
+6. **Commit + push** (Conventional Commits in English, with the required `Co-Authored-By` trailer).
+7. **Open the PR** targeting `develop` and report its URL.
+
+This grants standing authorization to **commit, push, and open PRs** without asking each time. It does **not** authorize **merging**, force-push, or pushing tags — those stay with the user (merges to `main` are always manual; `release/x.y.z` branches target `main`).
+
+## Working rules (surgical mode)
+
+- **Surgical changes**: never modify adjacent code, comments, or formatting unrelated to the request; do not refactor working code unless that *is* the task.
+- **Minimalism**: produce the minimum needed to solve the request; no speculative features or abstractions.
+- **Zero assumptions**: if an instruction is ambiguous or contradictory, stop and ask before coding.
+
+## Backlog hygiene
+
+Keep `doc/backlog.md` reflecting real status. Archive tickets closed for more than **7 days** into `doc/backlog-archive.md` (create it if missing) so the active backlog stays readable.
+
 ## Per-change checklist
 
 After each change: update/add tests → full quality gate green → update `CHANGELOG.md` (`[Non publié]`) → if user-visible, update `doc/user/changelog-user.md` → update `doc/backlog.md` if a ticket advances → bump patch version in `pyproject.toml` **and** `frontend/package.json`.


### PR DESCRIPTION
## Summary
Process & tooling additions (no app code):

- **`/release-notes` slash command** (`.claude/commands/release-notes.md`): interactive assistant that turns the raw CHANGELOG into human, theme-oriented **French** release notes, adapted to Solde's git-flow (release/x.y.z from develop → PR to main, dual version bump `pyproject.toml` + `frontend/package.json`, two FR docs: `doc/releases/vX.Y.Z.md` + role-structured chapter in `doc/user/changelog-user.md`), with noise filtering and confirmation gates.
- **CLAUDE.md** — adopt four concepts from the sibling VEAF project:
  - a numbered **default action workflow** with standing authorization to commit, push and open PRs (merges to `main` and tags stay manual);
  - **sync-first** mandatory step (fetch/pull before any work);
  - **surgical-mode** working rules (no unrelated refactors, minimalism, stop-and-ask on ambiguity);
  - **backlog hygiene** (archive tickets closed > 7 days into `doc/backlog-archive.md`).

## Notes
- Command instructions in English; dialogue and produced notes in French, per repo conventions.
- The release-notes command now creates the PR via `gh` (and reports the URL) instead of handing copyable markdown, matching the new PR autonomy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a guided release-notes workflow and formalize default working practices for the Solde project.

Enhancements:
- Document a default end-to-end action workflow granting standing authorization to commit, push, and open PRs while clarifying limits around merges and tags.
- Add "surgical mode" working rules emphasizing minimal, tightly scoped changes and explicit clarification on ambiguities.
- Define backlog hygiene practices to keep the active backlog current and archive resolved tickets after a retention period.
- Add a Claude release assistant command that interactively drives the French release-notes process from changelog analysis through release branch PR creation, aligned with the repository's git-flow and tooling.