### PR TITLE
docs(roadmap): mark v1.8 as released

### DIFF
--- a/doc/roadmap.md
+++ b/doc/roadmap.md
@@ -28,7 +28,7 @@
 | **1.6.2** | Lot REV2 — standardize API errors, remove service commits, split bank router (TEC-170, TEC-171, TEC-173) | ✅ Merged 2026-05-07 |
 | **1.6.3** | TEC-185 (Chrome PDF fix), BIZ-186 (paid watermark on PDF) | ✅ Released 2026-05-10 |
 | **1.7** | Lot BK — automated backup (BIZ-173–184) | 🔧 In progress (PR #85) |
-| **1.8** | Lot RF — UI/UX redesign (dashboard, invoices, admin) + dark mode + responsive | 🔧 Release prepared (release/1.8.0 → main) |
+| **1.8** | Lot RF — UI/UX redesign (dashboard, invoices, admin) + dark mode + responsive | ✅ Released 2026-06-21 |
 
 Test suite: **1090 backend + 148 frontend Vitest — 0 failures.**
 
@@ -343,7 +343,7 @@ Ajouter une section d'index dans le manuel utilisateur listant les cas d'usage p
 
 ---
 
-## v1.8 — Lot RF — UI/UX redesign + dark mode ⬜ Planned
+## v1.8 — Lot RF — UI/UX redesign + dark mode ✅ Released 2026-06-21
 
 Source: `design_handoff_solde_refonte-v2/` (Claude Design handoff, supersedes v1, adds the responsive track). Not a cosmetic theme — a rework of **information hierarchy**, **consolidation of duplicated components**, and **mobile/tablet/desktop adaptation**, within the Solde identity (Manrope, emerald, slate surfaces). Delivery order advised by the designer: shared `InvoiceWorkspace` first (removes the most duplication), then dark mode (theme store + tokens), then dashboard and admin screens, finally the cross-cutting responsive layer. See backlog Lot RF for the full ticket breakdown.
 


### PR DESCRIPTION
Flip the v1.8 roadmap status from "Release prepared" to "✅ Released 2026-06-21" (both the summary table and the detailed section), now that v1.8.0 is merged to main, tagged, and published.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Documentation:
- Mark v1.8 as released in the roadmap summary table and detailed section, including the 2026-06-21 release date.