### PR TITLE
fix(dashboard): scope "to reconcile" count to the current fiscal year (BIZ-215)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Ce projet respecte le [Versionnage sémantique](https://semver.org/lang/fr/).
 
 ## [Non publié]
 
+### Corrigé
+- **BIZ-215** — Tableau de bord, file « À traiter » : le compteur **« À rapprocher »** était faux (212 affichés alors que seules 2 transactions sont réellement à rapprocher). Il comptait toutes les transactions bancaires non rapprochées **tous exercices confondus**, gonflé par l'historique importé ; il est désormais **scopé à l'exercice courant**, comme l'écran Banque
+
 ## [1.8.0] — 2026-06-21
 
 ### Corrigé

--- a/backend/services/dashboard_service.py
+++ b/backend/services/dashboard_service.py
@@ -94,14 +94,6 @@ async def get_dashboard(db: AsyncSession) -> dict[str, object]:
     )
     undeposited_count = undeposited_result.scalar_one_or_none() or 0
 
-    # --- Bank transactions still to reconcile (same definition as the bank view) ---
-    to_reconcile_result = await db.execute(
-        select(func.count(BankTransaction.id)).where(
-            BankTransaction.reconciled == False  # noqa: E712
-        )
-    )
-    to_reconcile_count: int = to_reconcile_result.scalar_one_or_none() or 0
-
     # --- Current fiscal year result ---
     from backend.services.accounting_entry_service import (
         _compute_resultat,
@@ -116,6 +108,21 @@ async def get_dashboard(db: AsyncSession) -> dict[str, object]:
         current_fy_name = current_fy.name
         charges, produits = await _compute_resultat(db, current_fy.id)
         current_resultat = produits - charges
+
+    # --- Bank transactions still to reconcile ---
+    # Scoped to the current fiscal year so the count matches the bank view, which
+    # filters transactions by the selected fiscal year. Without this scope the
+    # count would include every never-reconciled historical import (all years).
+    to_reconcile_query = select(func.count(BankTransaction.id)).where(
+        BankTransaction.reconciled == False  # noqa: E712
+    )
+    if current_fy:
+        to_reconcile_query = to_reconcile_query.where(
+            BankTransaction.date >= current_fy.start_date,
+            BankTransaction.date <= current_fy.end_date,
+        )
+    to_reconcile_result = await db.execute(to_reconcile_query)
+    to_reconcile_count: int = to_reconcile_result.scalar_one_or_none() or 0
 
     # --- Alerts ---
     alerts: list[dict[str, str]] = []

--- a/doc/backlog.md
+++ b/doc/backlog.md
@@ -78,6 +78,7 @@ Constats de la revue détaillée de la PR #96 (réalisée à la place de Sourcer
 
 | ID | Titre | Prio | Est. | Créé | Démarré | Terminé |
 | --- | --- | --- | --- | --- | --- | --- |
+| BIZ-215 | Dashboard « À rapprocher » : compteur faux (212 affichés vs 2 réels) | P2 | ~20 min | 2026-06-21 | | |
 | BIZ-169 | Édition/suppression des opérations manuelles | P2 | ~25 min | 2026-05-04 | 2026-05-04 | |
 | BIZ-210 | Factures client — réintroduire un rappel créances exercice/historique (post-RF) | P3 | ~20 min | 2026-06-18 | | |
 | BIZ-202 | Ligne de remise (prix négatif) dans une facture client | P2 | ~20 min | 2026-05-30 | 2026-05-30 | 2026-05-30 |
@@ -192,6 +193,18 @@ Nouveau `formatCurrency` dans `utils/format.ts` (EUR fr-FR, coercition des Decim
 #### BIZ-214 — Dédoublonnage Relancer / Envoyer
 
 `ClientInvoicesView` : pour une facture en retard, « Relancer » (action principale) et « Envoyer email » (menu) appelaient la même fonction. L'entrée de menu « Envoyer » est désormais omise quand « Relancer » est l'action principale.
+
+### BIZ-215 — Dashboard « À rapprocher » : compteur faux
+
+**Symptôme** : la file « À traiter » du tableau de bord affiche **212** opérations « À rapprocher », alors que l'écran Banque (relevé compte courant, filtre non-rapprochées) n'en montre que **2** réellement à traiter.
+
+**Cause probable** : `to_reconcile_count` (introduit en TEC-198, `backend/services/dashboard_service.py`) compte **toutes** les `BankTransaction` avec `reconciled == False`, sans aucune exclusion. Ce total englobe vraisemblablement des transactions qui ne sont **pas** actionnables pour l'utilisateur : catégorie phantom `no_entry`, source `system_opening`, transactions déjà liées à un paiement (`payment_id` non nul ou présentes dans `bank_transaction_payments`), et/ou tout l'historique importé. La vue Banque a une définition plus stricte de « à rapprocher » (cf. `_require_unreconciled_transaction` dans `backend/services/bank_service.py` : `reconciled OR payment_id IS NOT NULL OR lien dans bank_transaction_payments`).
+
+**À faire** :
+1. Déterminer la **définition métier exacte** de « à rapprocher » telle que vue par l'utilisateur (probablement : `reconciled == False` **ET** `payment_id IS NULL` **ET** pas de lien **ET** catégorie ≠ `no_entry` **ET** source ≠ `system_opening` — à confirmer avec ce que liste réellement l'écran Banque, et vérifier le périmètre par compte courant/épargne).
+2. Aligner `to_reconcile_count` sur cette définition (idéalement factoriser une fonction/clause partagée entre `dashboard_service` et `bank_service` pour éviter toute divergence future).
+3. Vérifier que le lien profond `?reconcile=1` du dashboard mène bien au même ensemble.
+4. Test d'intégration : fixtures couvrant `no_entry`, `system_opening`, déjà-lié → s'assurer que le compteur correspond à ce que l'utilisateur voit.
 
 ### BIZ-195 — Statut ARCHIVED — modèle, transitions, service, router, migration
 

--- a/doc/backlog.md
+++ b/doc/backlog.md
@@ -78,7 +78,7 @@ Constats de la revue détaillée de la PR #96 (réalisée à la place de Sourcer
 
 | ID | Titre | Prio | Est. | Créé | Démarré | Terminé |
 | --- | --- | --- | --- | --- | --- | --- |
-| BIZ-215 | Dashboard « À rapprocher » : compteur faux (212 affichés vs 2 réels) | P2 | ~20 min | 2026-06-21 | | |
+| BIZ-215 | Dashboard « À rapprocher » : compteur faux (212 affichés vs 2 réels) | P2 | ~20 min | 2026-06-21 | 2026-06-22 | 2026-06-22 |
 | BIZ-169 | Édition/suppression des opérations manuelles | P2 | ~25 min | 2026-05-04 | 2026-05-04 | |
 | BIZ-210 | Factures client — réintroduire un rappel créances exercice/historique (post-RF) | P3 | ~20 min | 2026-06-18 | | |
 | BIZ-202 | Ligne de remise (prix négatif) dans une facture client | P2 | ~20 min | 2026-05-30 | 2026-05-30 | 2026-05-30 |
@@ -198,13 +198,9 @@ Nouveau `formatCurrency` dans `utils/format.ts` (EUR fr-FR, coercition des Decim
 
 **Symptôme** : la file « À traiter » du tableau de bord affiche **212** opérations « À rapprocher », alors que l'écran Banque (relevé compte courant, filtre non-rapprochées) n'en montre que **2** réellement à traiter.
 
-**Cause probable** : `to_reconcile_count` (introduit en TEC-198, `backend/services/dashboard_service.py`) compte **toutes** les `BankTransaction` avec `reconciled == False`, sans aucune exclusion. Ce total englobe vraisemblablement des transactions qui ne sont **pas** actionnables pour l'utilisateur : catégorie phantom `no_entry`, source `system_opening`, transactions déjà liées à un paiement (`payment_id` non nul ou présentes dans `bank_transaction_payments`), et/ou tout l'historique importé. La vue Banque a une définition plus stricte de « à rapprocher » (cf. `_require_unreconciled_transaction` dans `backend/services/bank_service.py` : `reconciled OR payment_id IS NOT NULL OR lien dans bank_transaction_payments`).
+**Cause réelle** : `to_reconcile_count` (introduit en TEC-198, `backend/services/dashboard_service.py`) comptait **toutes** les `BankTransaction` avec `reconciled == False`, **tous exercices confondus**. Or la vue Banque (`loadTransactions`) filtre par l'**exercice fiscal sélectionné** (`from_date`/`to_date`). Comme une transaction est `reconciled=False` par défaut tant qu'elle n'est pas appariée manuellement à un paiement, tout l'historique bancaire importé (exercices antérieurs, ex. compte épargne) gonflait le total : **212 tous exercices** vs **2 sur l'exercice courant**.
 
-**À faire** :
-1. Déterminer la **définition métier exacte** de « à rapprocher » telle que vue par l'utilisateur (probablement : `reconciled == False` **ET** `payment_id IS NULL` **ET** pas de lien **ET** catégorie ≠ `no_entry` **ET** source ≠ `system_opening` — à confirmer avec ce que liste réellement l'écran Banque, et vérifier le périmètre par compte courant/épargne).
-2. Aligner `to_reconcile_count` sur cette définition (idéalement factoriser une fonction/clause partagée entre `dashboard_service` et `bank_service` pour éviter toute divergence future).
-3. Vérifier que le lien profond `?reconcile=1` du dashboard mène bien au même ensemble.
-4. Test d'intégration : fixtures couvrant `no_entry`, `system_opening`, déjà-lié → s'assurer que le compteur correspond à ce que l'utilisateur voit.
+**Correctif livré (2026-06-22)** : le compteur est désormais scopé à l'**exercice courant** (`get_current_fiscal_year`) — `reconciled == False` ET `date` dans `[start_date, end_date]` — pour s'aligner sur ce que montre l'écran Banque. Pas d'exclusion par catégorie (toutes les transactions doivent être rapprochées, confirmé). Si aucun exercice courant n'existe, repli sur le total (comme la vue Banque sans exercice sélectionné). Test d'intégration de régression ajouté (transaction hors-exercice exclue).
 
 ### BIZ-195 — Statut ARCHIVED — modèle, transitions, service, router, migration
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "solde"
-version = "1.8.0"
+version = "1.8.1"
 description = "Web app for French non-profit accounting — invoicing, payments, cash management and double-entry bookkeeping."
 requires-python = ">=3.11"
 dependencies = [

--- a/tests/integration/test_dashboard_api.py
+++ b/tests/integration/test_dashboard_api.py
@@ -136,6 +136,50 @@ async def test_dashboard_counts_unreconciled_bank_transactions(
 
 
 @pytest.mark.asyncio
+async def test_dashboard_to_reconcile_is_scoped_to_current_fiscal_year(
+    client: AsyncClient, auth_headers: dict, db_session: AsyncSession
+) -> None:
+    """`to_reconcile_count` ignores never-reconciled history outside the current FY.
+
+    Regression for BIZ-215: the bank view filters by the selected fiscal year, so
+    the dashboard count must do the same — otherwise old imported statements
+    (all unreconciled by default) inflate the number.
+    """
+    today = date.today()
+    await _create_fy(db_session, "Courant", date(today.year, 1, 1), date(today.year, 12, 31))
+
+    db_session.add_all(
+        [
+            # Inside the current fiscal year → counted.
+            BankTransaction(
+                date=today,
+                amount=Decimal("120.00"),
+                description="À rapprocher (exercice courant)",
+                balance_after=Decimal("120.00"),
+                reconciled=False,
+                source="manual",
+                detected_category="other_credit",
+            ),
+            # Two years ago → outside the current fiscal year → ignored.
+            BankTransaction(
+                date=date(today.year - 2, 6, 15),
+                amount=Decimal("90.00"),
+                description="Historique importé non rapproché",
+                balance_after=Decimal("90.00"),
+                reconciled=False,
+                source="manual",
+                detected_category="other_credit",
+            ),
+        ]
+    )
+    await db_session.commit()
+
+    response = await client.get("/api/dashboard/", headers=auth_headers)
+    assert response.status_code == 200
+    assert response.json()["to_reconcile_count"] == 1
+
+
+@pytest.mark.asyncio
 async def test_dashboard_uses_open_fiscal_year_covering_today(
     client: AsyncClient, auth_headers: dict, db_session: AsyncSession
 ) -> None:


### PR DESCRIPTION
## Summary
The dashboard worklist showed **212 "À rapprocher"** while only **2** transactions are actually to reconcile.

**Root cause:** `to_reconcile_count` (added in TEC-198) counted every `BankTransaction` with `reconciled == False` **across all fiscal years**. Since a transaction stays unreconciled until manually matched to a payment, all imported history (prior years, e.g. the savings account) inflated the number. The bank view, by contrast, filters transactions by the **selected fiscal year**.

**Fix:** scope `to_reconcile_count` to the **current fiscal year** (`reconciled == False` AND `date` within `[start_date, end_date]`), matching the bank view. Falls back to all-time when no current fiscal year exists (mirrors the bank view with no year selected). No category exclusion — all transactions are meant to be reconciled (confirmed with the user).

## Tests
- New integration test: an unreconciled transaction dated outside the current fiscal year is excluded from the count.
- Full backend suite green (1124 passed).

## Notes
- Patch bump to 1.8.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Scope dashboard "to reconcile" bank transaction count to the current fiscal year and bump patch version.

Bug Fixes:
- Align the dashboard "to reconcile" counter with the bank view by limiting unreconciled bank transactions to the current fiscal year, falling back to all-time when no current fiscal year is available.

Enhancements:
- Add an integration test ensuring unreconciled transactions outside the current fiscal year are excluded from the dashboard "to reconcile" count.
- Document BIZ-215 in the backlog and changelog, describing the incorrect dashboard counter and the applied fix.

Build:
- Bump backend and frontend application versions from 1.8.0 to 1.8.1.