### PR TITLE
docs(claude): allow backlog commits straight to develop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,7 @@ Write the failing test first. Targets: business-logic services **≥ 90%**, API 
 
 ## Git flow (summary — see copilot-instructions.md for the full rules)
 
-`main` (prod) ← `develop` (integration) ← `feature/*` / `fix/*`. Hotfixes from `main`. **Releases only on `release/x.y.z` branches.** Never commit directly to `main`/`develop` (except acceptance-testing *recette* fixes, which go straight to `develop`). Conventional Commits in English (`type(scope): description`). Multi-PC project: `git pull --rebase` before starting, and on any rejected push.
+`main` (prod) ← `develop` (integration) ← `feature/*` / `fix/*`. Hotfixes from `main`. **Releases only on `release/x.y.z` branches.** Never commit directly to `main`/`develop` (except acceptance-testing *recette* fixes and **backlog edits** — see Backlog hygiene — which go straight to `develop`). Conventional Commits in English (`type(scope): description`). Multi-PC project: `git pull --rebase` before starting, and on any rejected push.
 
 ## Default action workflow (standing authorization)
 
@@ -126,6 +126,8 @@ This grants standing authorization to **commit, push, and open PRs** without ask
 ## Backlog hygiene
 
 Keep `doc/backlog.md` reflecting real status. Archive tickets closed for more than **7 days** into `doc/backlog-archive.md` (create it if missing) so the active backlog stays readable.
+
+**Backlog commits go straight to `develop`** — creating, editing, or archiving tickets/lots in `doc/backlog.md` (and `doc/backlog-archive.md`) does **not** need a branch or PR. This exception covers backlog-only changes; any commit that also touches code, other docs, or `doc/roadmap.md` follows the normal feature/fix branch + PR flow.
 
 ## Per-change checklist
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,7 +127,7 @@ This grants standing authorization to **commit, push, and open PRs** without ask
 
 Keep `doc/backlog.md` reflecting real status. Archive tickets closed for more than **7 days** into `doc/backlog-archive.md` (create it if missing) so the active backlog stays readable.
 
-**Backlog commits go straight to `develop`** — creating, editing, or archiving tickets/lots in `doc/backlog.md` (and `doc/backlog-archive.md`) does **not** need a branch or PR. This exception covers backlog-only changes; any commit that also touches code, other docs, or `doc/roadmap.md` follows the normal feature/fix branch + PR flow.
+**Backlog commits go straight to `develop`** — a commit whose diff touches **only** `doc/backlog.md` and/or `doc/backlog-archive.md` (creating, editing, or archiving tickets/lots) needs **no branch or PR**. The moment a commit touches **any** other file (code, tests, other docs, `doc/roadmap.md`, formatting elsewhere, …), the exception no longer applies and it follows the normal feature/fix branch + PR flow.
 
 ## Per-change checklist
 


### PR DESCRIPTION
## Summary
Adds a process rule to `CLAUDE.md`: **backlog-only commits** (creating, editing, archiving tickets/lots in `doc/backlog.md` / `doc/backlog-archive.md`) go **straight to `develop`** — no branch or PR needed.

Any commit that also touches code, other docs, or `doc/roadmap.md` keeps the normal feature/fix branch + PR flow.

Documented in both the Git-flow summary (exception) and the Backlog hygiene section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Document an exception in the git flow allowing backlog-only commits to go directly to the develop branch and clarify this rule in the backlog hygiene section.

Documentation:
- Update the Git flow summary to note that backlog-only edits are allowed as direct commits to the develop branch.
- Extend the Backlog hygiene section to specify that creating, editing, or archiving backlog tickets can be committed straight to develop without a branch or PR when no other files are changed.