### PR TITLE
feat(backup): Lot BK2 — remote retention + incremental PDF mirror (TEC-208, TEC-209)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Ce projet respecte le [Versionnage sémantique](https://semver.org/lang/fr/).
 
 ## [Non publié]
 
+### Technique
+- **TEC-208** (Lot BK2) — Rétention distante des backups : après chaque synchronisation réussie, les **snapshots horodatés** au-delà des **5 plus récents** sont purgés sur chaque destination (OneDrive via Graph, autres via rclone). Plafonne l'espace occupé sur OneDrive (croissance jusque-là illimitée). Purge best-effort (n'échoue jamais le backup) ; ne touche qu'aux dossiers `YYYY-MM-DDTHH-MM-SS`, jamais aux futurs dossiers miroirs
+
 ### Corrigé
 - **BIZ-215** — Tableau de bord, file « À traiter » : le compteur **« À rapprocher »** était faux (212 affichés alors que seules 2 transactions sont réellement à rapprocher). Il comptait toutes les transactions bancaires non rapprochées **tous exercices confondus**, gonflé par l'historique importé ; il est désormais **scopé à l'exercice courant**, comme l'écran Banque
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Ce projet respecte le [Versionnage sémantique](https://semver.org/lang/fr/).
 ## [Non publié]
 
 ### Technique
+- **TEC-209** (Lot BK2) — Miroir incrémental des PDFs/pièces jointes : `data/pdfs` (et `data/uploads` si activé) ne sont plus rebundlés dans chaque snapshot horodaté mais synchronisés vers un **dossier distant stable** en mode « envoyer si absent » (OneDrive via Graph : diff par nom + taille ; rclone : `copy` incrémental natif). Fin de la duplication des PDFs à chaque backup. La restauration (base seule) est inchangée ; les PDFs vivent dans le dossier miroir pour la reprise
 - **TEC-208** (Lot BK2) — Rétention distante des backups : après chaque synchronisation réussie, les **snapshots horodatés** au-delà des **5 plus récents** sont purgés sur chaque destination (OneDrive via Graph, autres via rclone). Plafonne l'espace occupé sur OneDrive (croissance jusque-là illimitée). Purge best-effort (n'échoue jamais le backup) ; ne touche qu'aux dossiers `YYYY-MM-DDTHH-MM-SS`, jamais aux futurs dossiers miroirs
 
 ### Corrigé

--- a/backend/services/backup_destination_service.py
+++ b/backend/services/backup_destination_service.py
@@ -491,6 +491,79 @@ async def prune_remote_backups(dest: BackupDestination, keep: int = 5) -> int:
     return len(to_delete_names)
 
 
+# ---------------------------------------------------------------------------
+# Incremental mirror — stable folders for immutable assets (TEC-209)
+# ---------------------------------------------------------------------------
+
+
+async def _graph_list_files(
+    client: httpx.AsyncClient, access_token: str, drive_id: str, base: str
+) -> dict[str, int]:
+    """Recursively map ``relpath -> size`` for every file under ``base``.
+
+    Used to diff a OneDrive mirror folder against the local directory so only
+    missing/changed files are uploaded. Empty dict if the folder is absent.
+    """
+    files: dict[str, int] = {}
+
+    async def _walk(folder_path: str, rel_prefix: str) -> None:
+        for child in await _graph_list_children(client, access_token, drive_id, folder_path):
+            name = str(child.get("name", ""))
+            rel = f"{rel_prefix}{name}"
+            if child.get("folder") is not None:
+                await _walk(f"{folder_path}/{name}", f"{rel}/")
+            else:
+                size = child.get("size", 0)
+                files[rel] = size if isinstance(size, int) else 0
+
+    await _walk(base, "")
+    return files
+
+
+async def mirror_dir_incremental(
+    dest: BackupDestination, local_dir: str, remote_subdir: str
+) -> int:
+    """Mirror ``local_dir`` to a **stable** remote folder, uploading only new files.
+
+    Unlike the timestamped snapshot, the mirror lives at a fixed remote path
+    (``<target_path>/<remote_subdir>``) and is **append-only** (never pruned),
+    so immutable assets (PDFs, uploads) are stored once instead of being
+    re-uploaded on every backup. Returns the number of files uploaded
+    (0 for rclone, which performs its own incremental copy).
+    """
+    local = Path(local_dir)
+    if not local.is_dir():
+        return 0
+    base = (dest.target_path or "").rstrip("/")
+    remote_base = f"{base}/{remote_subdir}".strip("/")
+
+    if dest.type == "onedrive":
+        config = json.loads(dest.rclone_config or "{}")
+        drive_id = config.get("drive_id", "")
+        access_token = _graph_access_token(dest)
+        uploaded = 0
+        async with httpx.AsyncClient() as client:
+            remote_files = await _graph_list_files(client, access_token, drive_id, remote_base)
+            for local_file in sorted(p for p in local.rglob("*") if p.is_file()):
+                rel = local_file.relative_to(local).as_posix()
+                if remote_files.get(rel) == local_file.stat().st_size:
+                    continue  # already present with the same size — skip
+                await _graph_upload_file(
+                    client, access_token, drive_id, f"{remote_base}/{rel}", local_file
+                )
+                uploaded += 1
+        if uploaded:
+            logger.info("Mirrored %d file(s) to %s (dest %s)", uploaded, remote_subdir, dest.id)
+        return uploaded
+
+    # rclone destinations: `rclone copy` to a stable folder is already incremental
+    # (skips files identical by size/modtime).
+    conf = str(_RCLONE_CONF_PATH.resolve())
+    remote = f"{dest.rclone_remote_name}:{remote_base}"
+    await _run_rclone(["rclone", "copy", str(local.resolve()), remote, "--config", conf])
+    return 0
+
+
 _RCLONE_TS_RE = re.compile(r"^\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2} (?:ERROR : |WARNING: )?")
 
 

--- a/backend/services/backup_destination_service.py
+++ b/backend/services/backup_destination_service.py
@@ -395,6 +395,102 @@ async def fetch_remote_backup(
     await _run_rclone(cmd)
 
 
+# ---------------------------------------------------------------------------
+# Remote retention — prune old timestamped snapshot folders (TEC-208)
+# ---------------------------------------------------------------------------
+
+# Matches a backup snapshot folder name, e.g. "2026-06-13T02-00-04".
+_BACKUP_TS_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}$")
+
+
+async def _graph_list_children(
+    client: httpx.AsyncClient, access_token: str, drive_id: str, base: str
+) -> list[dict[str, object]]:
+    """List the immediate children (files + folders) of a OneDrive folder.
+
+    ``base`` is the drive-relative path of the parent folder (empty = drive root).
+    Returns the raw Graph item dicts (each has ``id``, ``name`` and, for folders,
+    a ``folder`` facet). Returns ``[]`` if the folder does not exist yet.
+    """
+    auth = {"Authorization": f"Bearer {access_token}"}
+    if base:
+        encoded = urllib.parse.quote(base)
+        url: str | None = f"{_GRAPH_BASE}/drives/{drive_id}/root:/{encoded}:/children"
+    else:
+        url = f"{_GRAPH_BASE}/drives/{drive_id}/root/children"
+    items: list[dict[str, object]] = []
+    while url:
+        resp = await client.get(url, headers=auth, timeout=30)
+        if resp.status_code == 404:
+            return []
+        resp.raise_for_status()
+        data = resp.json()
+        items.extend(data.get("value", []))
+        url = data.get("@odata.nextLink")
+    return items
+
+
+async def _graph_delete_item(
+    client: httpx.AsyncClient, access_token: str, drive_id: str, item_id: str
+) -> None:
+    """Delete a OneDrive item (folder or file) by its id."""
+    auth = {"Authorization": f"Bearer {access_token}"}
+    resp = await client.delete(
+        f"{_GRAPH_BASE}/drives/{drive_id}/items/{item_id}", headers=auth, timeout=30
+    )
+    if resp.status_code not in (200, 204, 404):
+        resp.raise_for_status()
+
+
+async def prune_remote_backups(dest: BackupDestination, keep: int = 5) -> int:
+    """Delete timestamped backup **snapshot** folders beyond the ``keep`` most recent.
+
+    Targets only folders whose name matches the run-timestamp pattern
+    (``YYYY-MM-DDTHH-MM-SS``) directly under the destination's ``target_path``.
+    Stable mirror folders (e.g. ``pdfs/``, ``uploads/``, introduced by TEC-209)
+    never match the pattern and are therefore never pruned.
+
+    Returns the number of snapshot folders deleted. Raises on a hard failure;
+    the caller treats pruning as best-effort.
+    """
+    if keep < 1:
+        raise ValueError("keep must be >= 1")
+    base = (dest.target_path or "").rstrip("/")
+
+    if dest.type == "onedrive":
+        config = json.loads(dest.rclone_config or "{}")
+        drive_id = config.get("drive_id", "")
+        access_token = _graph_access_token(dest)
+        async with httpx.AsyncClient() as client:
+            children = await _graph_list_children(client, access_token, drive_id, base)
+            snapshots = sorted(
+                (
+                    (str(c.get("name", "")), str(c.get("id", "")))
+                    for c in children
+                    if c.get("folder") is not None and _BACKUP_TS_RE.match(str(c.get("name", "")))
+                ),
+                key=lambda nm: nm[0],
+            )
+            to_delete = snapshots[:-keep] if len(snapshots) > keep else []
+            for name, item_id in to_delete:
+                await _graph_delete_item(client, access_token, drive_id, item_id)
+                logger.info("Pruned remote snapshot %s (dest %s)", name, dest.id)
+            return len(to_delete)
+
+    # rclone-based destinations (SMB, local, …)
+    conf = str(_RCLONE_CONF_PATH.resolve())
+    remote_base = f"{dest.rclone_remote_name}:{base}" if base else f"{dest.rclone_remote_name}:"
+    out = await _run_rclone(["rclone", "lsf", "--dirs-only", remote_base, "--config", conf])
+    names = sorted(
+        n.rstrip("/") for n in out.splitlines() if _BACKUP_TS_RE.match(n.strip().rstrip("/"))
+    )
+    to_delete_names = names[:-keep] if len(names) > keep else []
+    for name in to_delete_names:
+        await _run_rclone(["rclone", "purge", f"{remote_base}/{name}", "--config", conf])
+        logger.info("Pruned remote snapshot %s (dest %s)", name, dest.id)
+    return len(to_delete_names)
+
+
 _RCLONE_TS_RE = re.compile(r"^\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2} (?:ERROR : |WARNING: )?")
 
 

--- a/backend/services/backup_scheduler.py
+++ b/backend/services/backup_scheduler.py
@@ -24,6 +24,10 @@ logger = logging.getLogger(__name__)
 
 _JOB_ID = "backup_job"
 
+# Remote retention: number of most-recent timestamped snapshots kept per
+# destination (aligned with the local rotation in backup_service).
+_REMOTE_BACKUP_RETENTION = 5
+
 # Module-level scheduler instance shared across requests
 _scheduler: AsyncIOScheduler | None = None
 
@@ -173,6 +177,7 @@ async def _run_backup_job_inner(
     """Execute one backup cycle (called by the scheduler)."""
     from backend.database import get_session
     from backend.services.backup_destination_service import (
+        prune_remote_backups,
         refresh_onedrive_tokens,
         sync_destination,
         write_rclone_config,
@@ -262,6 +267,14 @@ async def _run_backup_job_inner(
                     dest, src_paths, run_ts, on_progress=_make_progress_cb(dest_start, dest_end)
                 )
                 logger.info("Synced to destination %s (%s)", dest.name, dest.type)
+                # Remote retention: prune old timestamped snapshots (keep N most
+                # recent). Best-effort — never fail the backup over pruning.
+                try:
+                    pruned = await prune_remote_backups(dest, keep=_REMOTE_BACKUP_RETENTION)
+                    if pruned:
+                        logger.info("Pruned %d old snapshot(s) on %s", pruned, dest.name)
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning("Remote prune failed for %s: %s", dest.name, exc)
             except Exception as exc:
                 overall_success = False
                 msg = f"{dest.name}: {exc}"

--- a/backend/services/backup_scheduler.py
+++ b/backend/services/backup_scheduler.py
@@ -177,6 +177,7 @@ async def _run_backup_job_inner(
     """Execute one backup cycle (called by the scheduler)."""
     from backend.database import get_session
     from backend.services.backup_destination_service import (
+        mirror_dir_incremental,
         prune_remote_backups,
         refresh_onedrive_tokens,
         sync_destination,
@@ -236,17 +237,14 @@ async def _run_backup_job_inner(
     if destinations:
         write_rclone_config(destinations)
         run_ts = datetime.now().strftime("%Y-%m-%dT%H-%M-%S")
-        # By default send only the freshly created backup file (not the whole backups dir).
-        # When include_all_backups is True, send the entire backups directory instead.
+        # The timestamped snapshot carries only the database now. Immutable
+        # assets (PDFs, uploads) are mirrored incrementally to stable folders
+        # below (TEC-209) instead of being re-bundled on every run.
+        # When include_all_backups is True, send the entire backups directory.
         if include_all_backups:
             src_paths: list[str] = [backup_dir]
         else:
             src_paths = [str(backup_file)]
-        if include_uploads:
-            src_paths.append(str(Path("data/uploads").resolve()))
-        pdfs_dir = Path("data/pdfs")
-        if pdfs_dir.exists():
-            src_paths.append(str(pdfs_dir.resolve()))
 
         dest_count = len(destinations)
         for i, dest in enumerate(destinations):
@@ -267,6 +265,15 @@ async def _run_backup_job_inner(
                     dest, src_paths, run_ts, on_progress=_make_progress_cb(dest_start, dest_end)
                 )
                 logger.info("Synced to destination %s (%s)", dest.name, dest.type)
+                # Incremental mirror of immutable assets to stable folders (TEC-209):
+                # uploaded once, never duplicated across snapshots.
+                pdfs_dir = Path("data/pdfs")
+                if pdfs_dir.exists():
+                    await mirror_dir_incremental(dest, str(pdfs_dir.resolve()), "pdfs")
+                if include_uploads:
+                    uploads_dir = Path("data/uploads")
+                    if uploads_dir.exists():
+                        await mirror_dir_incremental(dest, str(uploads_dir.resolve()), "uploads")
                 # Remote retention: prune old timestamped snapshots (keep N most
                 # recent). Best-effort — never fail the backup over pruning.
                 try:

--- a/doc/backlog.md
+++ b/doc/backlog.md
@@ -83,7 +83,7 @@ Constats de la revue détaillée de la PR #96 (réalisée à la place de Sourcer
 | ID | Titre | Prio | Est. | Créé | Démarré | Terminé |
 | --- | --- | --- | --- | --- | --- | --- |
 | TEC-208 | Rétention distante des backups — purger les dossiers horodatés au-delà de 5 (OneDrive/SMB) | P1 | ~40 min | 2026-06-22 | 2026-06-23 | 2026-06-23 |
-| TEC-209 | Miroir PDF/uploads incrémental — dossier distant stable, « upload si absent » (fin de la duplication) | P1 | ~70 min | 2026-06-22 | | |
+| TEC-209 | Miroir PDF/uploads incrémental — dossier distant stable, « upload si absent » (fin de la duplication) | P1 | ~70 min | 2026-06-22 | 2026-06-23 | 2026-06-23 |
 | BIZ-216 | N'inclure que les PDFs non régénérables (factures archivées + uploads) ; régénérer le reste | P2 | ~50 min | 2026-06-22 | | |
 
 > Ordre conseillé : **TEC-208** d'abord (quick win, plafonne la croissance sur la structure actuelle), puis **TEC-209** (corrige la racine), puis **BIZ-216** (s'appuie sur le miroir de TEC-209). Rétention cible : **5** backups distants, aligné sur la rotation locale (`backup_service._rotate_backups`).

--- a/doc/backlog.md
+++ b/doc/backlog.md
@@ -84,9 +84,9 @@ Constats de la revue détaillée de la PR #96 (réalisée à la place de Sourcer
 | --- | --- | --- | --- | --- | --- | --- |
 | TEC-208 | Rétention distante des backups — purger les dossiers horodatés au-delà de 5 (OneDrive/SMB) | P1 | ~40 min | 2026-06-22 | 2026-06-23 | 2026-06-23 |
 | TEC-209 | Miroir PDF/uploads incrémental — dossier distant stable, « upload si absent » (fin de la duplication) | P1 | ~70 min | 2026-06-22 | 2026-06-23 | 2026-06-23 |
-| BIZ-216 | N'inclure que les PDFs non régénérables (factures archivées + uploads) ; régénérer le reste | P2 | ~50 min | 2026-06-22 | | |
+| BIZ-216 | N'inclure que les PDFs non régénérables (factures archivées + uploads) ; régénérer le reste | P2 | ~50 min | 2026-06-22 | | reporté |
 
-> Ordre conseillé : **TEC-208** d'abord (quick win, plafonne la croissance sur la structure actuelle), puis **TEC-209** (corrige la racine), puis **BIZ-216** (s'appuie sur le miroir de TEC-209). Rétention cible : **5** backups distants, aligné sur la rotation locale (`backup_service._rotate_backups`).
+> Ordre : **TEC-208** + **TEC-209** livrés ensemble (PR BK2) — ils règlent la saturation OneDrive (fin de la duplication + purge des snapshots, rétention **5**). **BIZ-216 est reporté** dans un lot séparé : il nécessite en plus un garde-fou de **régénération à la demande quand le fichier PDF est absent** (sinon des factures non archivées exclues du backup auraient un `pdf_path` renseigné mais un fichier manquant après restauration). À traiter proprement avec ce prérequis.
 
 ---
 
@@ -154,9 +154,11 @@ Envoyer un email à tous les **adhérents (clients) actifs**. **Actif** = a eu u
 
 **Approche** : au moment du miroir (TEC-209), filtrer `data/pdfs` selon le statut de la facture liée (ne garder que les archivées). Réglage **« Sauvegarder uniquement les PDFs non régénérables »** dans Paramètres › Sauvegardes (**off par défaut** par prudence).
 
-**Dépendance** : TEC-209 (applique le filtre au miroir). **Risque** : si un PDF non archivé n'est pas sauvegardé et que la régénération diverge (template modifié), différence visuelle — acceptable car sans valeur légale ; à documenter côté utilisateur.
+**Prérequis bloquant (sécurité de restauration)** : aujourd'hui, la régénération à la demande ne se déclenche que si `invoice.pdf_path` est **vide**. Si on exclut du backup le PDF d'une facture non archivée (dont `pdf_path` est renseigné), une restauration de désastre laisserait la base avec un `pdf_path` pointant vers un **fichier absent** → consultation cassée. BIZ-216 doit donc **d'abord** ajouter un garde-fou « **régénérer le PDF si le fichier référencé est manquant** » (à la consultation / au téléchargement), indépendamment de `pdf_path`. Sans ce garde-fou, ne pas activer le filtre.
 
-**Tests** : avec le réglage activé, seuls les PDFs de factures archivées + uploads sont inclus ; les non-archivés sont exclus.
+**Dépendance** : TEC-209 (applique le filtre au miroir) + le garde-fou ci-dessus. **Statut** : **reporté** hors de la PR BK2 (208+209), à faire dans son propre lot. **Risque** : si un PDF non archivé régénéré diverge (template modifié), différence visuelle — acceptable car sans valeur légale ; à documenter côté utilisateur.
+
+**Tests** : régénération déclenchée quand le fichier manque même si `pdf_path` est défini ; avec le réglage activé, seuls les PDFs de factures archivées + uploads sont inclus dans le miroir ; les non-archivés sont exclus.
 
 ### Lot ML — Mailing aux adhérents actifs
 

--- a/doc/backlog.md
+++ b/doc/backlog.md
@@ -82,7 +82,7 @@ Constats de la revue détaillée de la PR #96 (réalisée à la place de Sourcer
 
 | ID | Titre | Prio | Est. | Créé | Démarré | Terminé |
 | --- | --- | --- | --- | --- | --- | --- |
-| TEC-208 | Rétention distante des backups — purger les dossiers horodatés au-delà de 5 (OneDrive/SMB) | P1 | ~40 min | 2026-06-22 | | |
+| TEC-208 | Rétention distante des backups — purger les dossiers horodatés au-delà de 5 (OneDrive/SMB) | P1 | ~40 min | 2026-06-22 | 2026-06-23 | 2026-06-23 |
 | TEC-209 | Miroir PDF/uploads incrémental — dossier distant stable, « upload si absent » (fin de la duplication) | P1 | ~70 min | 2026-06-22 | | |
 | BIZ-216 | N'inclure que les PDFs non régénérables (factures archivées + uploads) ; régénérer le reste | P2 | ~50 min | 2026-06-22 | | |
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "solde"
-version = "1.8.1"
+version = "1.8.2"
 description = "Web app for French non-profit accounting — invoicing, payments, cash management and double-entry bookkeeping."
 requires-python = ">=3.11"
 dependencies = [

--- a/tests/unit/test_backup_services.py
+++ b/tests/unit/test_backup_services.py
@@ -3,7 +3,7 @@
 Tests:
 - backup_destination_service: write_rclone_config, test_destination_connection
 - backup_restore_service: _do_test_restore on valid/corrupted/empty SQLite files
-- backup_scheduler: src_paths construction (BIZ-201 — data/pdfs inclusion)
+- backup_scheduler: asset mirroring (TEC-209) + remote retention (TEC-208)
 """
 
 from __future__ import annotations
@@ -219,7 +219,7 @@ class TestTestRestore:
 
 
 # ---------------------------------------------------------------------------
-# backup_scheduler — src_paths construction (BIZ-201)
+# backup_scheduler — asset mirror + snapshot (TEC-209)
 # ---------------------------------------------------------------------------
 
 
@@ -253,18 +253,27 @@ def _make_scheduler_patches(
             "backend.services.backup_destination_service.sync_destination",
             side_effect=sync_side_effect,
         ),
+        patch(
+            "backend.services.backup_destination_service.prune_remote_backups",
+            AsyncMock(return_value=0),
+        ),
         patch("backend.services.backup_scheduler._update_run_status", AsyncMock()),
     ]
 
 
-class TestBackupJobPdfsInclusion:
-    """BIZ-201: data/pdfs must always be included in the backup src_paths."""
+class TestBackupJobAssetMirror:
+    """TEC-209: PDFs/uploads are mirrored to stable folders, not bundled into the
+    timestamped snapshot."""
+
+    @staticmethod
+    def _mirror_subdirs(mirror_mock: AsyncMock) -> list[str]:
+        return [call.args[2] for call in mirror_mock.call_args_list]
 
     @pytest.mark.asyncio
-    async def test_pdfs_included_snapshot_mode(
+    async def test_pdfs_mirrored_not_in_snapshot(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """data/pdfs is included in src_paths in snapshot (single-file) mode."""
+        """data/pdfs is excluded from the snapshot and mirrored to the stable folder."""
         (tmp_path / "data" / "pdfs").mkdir(parents=True)
         monkeypatch.chdir(tmp_path)
 
@@ -276,12 +285,19 @@ class TestBackupJobPdfsInclusion:
         async def _fake_sync(dest, src_paths, run_ts, on_progress=None):
             captured.append(list(src_paths))
 
+        mirror_mock = AsyncMock(return_value=1)
         from backend.services import backup_scheduler as sched
 
         patches = _make_scheduler_patches(fake_backup, dest, _fake_sync)
         with ExitStack() as stack:
             for p in patches:
                 stack.enter_context(p)
+            stack.enter_context(
+                patch(
+                    "backend.services.backup_destination_service.mirror_dir_incremental",
+                    mirror_mock,
+                )
+            )
             await sched._run_backup_job_inner(
                 db_path="data/solde.db",
                 backup_dir="data/backups",
@@ -292,13 +308,15 @@ class TestBackupJobPdfsInclusion:
 
         expected_pdfs = str((tmp_path / "data" / "pdfs").resolve())
         assert len(captured) == 1
-        assert expected_pdfs in captured[0], f"data/pdfs missing from src_paths: {captured[0]}"
+        assert expected_pdfs not in captured[0]  # no longer bundled in the snapshot
+        mirrored = [call.args for call in mirror_mock.call_args_list]
+        assert any(args[1] == expected_pdfs and args[2] == "pdfs" for args in mirrored)
 
     @pytest.mark.asyncio
-    async def test_pdfs_included_full_backup_mode(
+    async def test_pdfs_mirrored_in_full_backup_mode(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """data/pdfs is included in src_paths in full-backup (include_all_backups) mode."""
+        """PDFs are still mirrored (not snapshotted) in include_all_backups mode."""
         (tmp_path / "data" / "pdfs").mkdir(parents=True)
         monkeypatch.chdir(tmp_path)
 
@@ -310,12 +328,19 @@ class TestBackupJobPdfsInclusion:
         async def _fake_sync(dest, src_paths, run_ts, on_progress=None):
             captured.append(list(src_paths))
 
+        mirror_mock = AsyncMock(return_value=1)
         from backend.services import backup_scheduler as sched
 
         patches = _make_scheduler_patches(fake_backup, dest, _fake_sync)
         with ExitStack() as stack:
             for p in patches:
                 stack.enter_context(p)
+            stack.enter_context(
+                patch(
+                    "backend.services.backup_destination_service.mirror_dir_incremental",
+                    mirror_mock,
+                )
+            )
             await sched._run_backup_job_inner(
                 db_path="data/solde.db",
                 backup_dir="data/backups",
@@ -325,15 +350,52 @@ class TestBackupJobPdfsInclusion:
             )
 
         expected_pdfs = str((tmp_path / "data" / "pdfs").resolve())
-        assert len(captured) == 1
-        assert expected_pdfs in captured[0], f"data/pdfs missing from src_paths: {captured[0]}"
+        assert expected_pdfs not in captured[0]
+        assert "pdfs" in self._mirror_subdirs(mirror_mock)
 
     @pytest.mark.asyncio
-    async def test_pdfs_skipped_when_directory_absent(
+    async def test_pdfs_not_mirrored_when_absent(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """data/pdfs is NOT added to src_paths when the directory does not exist."""
-        # data/pdfs directory intentionally NOT created
+        """No mirror call for pdfs when data/pdfs does not exist."""
+        monkeypatch.chdir(tmp_path)  # data/pdfs intentionally not created
+
+        fake_backup = tmp_path / "solde_backup_20260101_120000.db"
+        fake_backup.write_bytes(b"fake")
+        dest = _make_dest(name="local-dest", rclone_remote_name="local")
+
+        async def _fake_sync(dest, src_paths, run_ts, on_progress=None):
+            pass
+
+        mirror_mock = AsyncMock(return_value=0)
+        from backend.services import backup_scheduler as sched
+
+        patches = _make_scheduler_patches(fake_backup, dest, _fake_sync)
+        with ExitStack() as stack:
+            for p in patches:
+                stack.enter_context(p)
+            stack.enter_context(
+                patch(
+                    "backend.services.backup_destination_service.mirror_dir_incremental",
+                    mirror_mock,
+                )
+            )
+            await sched._run_backup_job_inner(
+                db_path="data/solde.db",
+                backup_dir="data/backups",
+                include_uploads=False,
+                include_all_backups=False,
+                notify_on_failure=False,
+            )
+
+        assert "pdfs" not in self._mirror_subdirs(mirror_mock)
+
+    @pytest.mark.asyncio
+    async def test_uploads_mirrored_when_included(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """data/uploads is mirrored (not snapshotted) when include_uploads is True."""
+        (tmp_path / "data" / "uploads").mkdir(parents=True)
         monkeypatch.chdir(tmp_path)
 
         fake_backup = tmp_path / "solde_backup_20260101_120000.db"
@@ -344,25 +406,31 @@ class TestBackupJobPdfsInclusion:
         async def _fake_sync(dest, src_paths, run_ts, on_progress=None):
             captured.append(list(src_paths))
 
+        mirror_mock = AsyncMock(return_value=0)
         from backend.services import backup_scheduler as sched
 
         patches = _make_scheduler_patches(fake_backup, dest, _fake_sync)
         with ExitStack() as stack:
             for p in patches:
                 stack.enter_context(p)
+            stack.enter_context(
+                patch(
+                    "backend.services.backup_destination_service.mirror_dir_incremental",
+                    mirror_mock,
+                )
+            )
             await sched._run_backup_job_inner(
                 db_path="data/solde.db",
                 backup_dir="data/backups",
-                include_uploads=False,
+                include_uploads=True,
                 include_all_backups=False,
                 notify_on_failure=False,
             )
 
-        expected_pdfs = str((tmp_path / "data" / "pdfs").resolve())
-        assert len(captured) == 1
-        assert expected_pdfs not in captured[0], (
-            f"data/pdfs should not be in src_paths: {captured[0]}"
-        )
+        expected_uploads = str((tmp_path / "data" / "uploads").resolve())
+        assert expected_uploads not in captured[0]
+        mirrored = [call.args for call in mirror_mock.call_args_list]
+        assert any(args[1] == expected_uploads and args[2] == "uploads" for args in mirrored)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_backup_services.py
+++ b/tests/unit/test_backup_services.py
@@ -363,3 +363,84 @@ class TestBackupJobPdfsInclusion:
         assert expected_pdfs not in captured[0], (
             f"data/pdfs should not be in src_paths: {captured[0]}"
         )
+
+
+# ---------------------------------------------------------------------------
+# prune_remote_backups (TEC-208 — remote retention)
+# ---------------------------------------------------------------------------
+
+
+def _onedrive_config() -> str:
+    import json
+
+    return json.dumps({"drive_id": "d1", "token": json.dumps({"access_token": "tok"})})
+
+
+class TestPruneRemoteBackups:
+    @pytest.mark.asyncio
+    async def test_onedrive_keeps_recent_and_ignores_mirror(self) -> None:
+        dest = _make_dest(
+            dest_type="onedrive", target_path="backups", rclone_config=_onedrive_config()
+        )
+        snaps = [f"2026-06-{d:02d}T02-00-00" for d in range(1, 8)]  # 7 snapshots
+        children = [{"id": n, "name": n, "folder": {}} for n in snaps]
+        children += [
+            {"id": "pdfs", "name": "pdfs", "folder": {}},  # stable mirror — never pruned
+            {"id": "f1", "name": "readme.txt"},  # a file — ignored
+        ]
+        deleted: list[str] = []
+
+        def _del(client: object, token: str, drive: str, item_id: str) -> None:
+            deleted.append(item_id)
+
+        with (
+            patch.object(bds, "_graph_list_children", AsyncMock(return_value=children)),
+            patch.object(bds, "_graph_delete_item", AsyncMock(side_effect=_del)),
+        ):
+            n = await bds.prune_remote_backups(dest, keep=5)
+
+        assert n == 2
+        assert deleted == ["2026-06-01T02-00-00", "2026-06-02T02-00-00"]
+
+    @pytest.mark.asyncio
+    async def test_onedrive_noop_when_at_or_below_keep(self) -> None:
+        dest = _make_dest(
+            dest_type="onedrive", target_path="backups", rclone_config=_onedrive_config()
+        )
+        children = [
+            {"id": f"s{d}", "name": f"2026-06-0{d}T02-00-00", "folder": {}} for d in range(1, 4)
+        ]
+        del_mock = AsyncMock()
+        with (
+            patch.object(bds, "_graph_list_children", AsyncMock(return_value=children)),
+            patch.object(bds, "_graph_delete_item", del_mock),
+        ):
+            n = await bds.prune_remote_backups(dest, keep=5)
+
+        assert n == 0
+        del_mock.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_rclone_prunes_oldest_and_ignores_mirror(self) -> None:
+        dest = _make_dest(dest_type="smb", rclone_remote_name="smb", target_path="backups")
+        calls: list[list[str]] = []
+
+        def _run(cmd: list[str]) -> str:
+            calls.append(cmd)
+            if cmd[1] == "lsf":
+                return "".join(f"2026-06-0{d}T02-00-00/\n" for d in range(1, 8)) + "pdfs/\n"
+            return ""
+
+        with patch.object(bds, "_run_rclone", AsyncMock(side_effect=_run)):
+            n = await bds.prune_remote_backups(dest, keep=5)
+
+        assert n == 2
+        purges = [c for c in calls if c[1] == "purge"]
+        assert len(purges) == 2
+        assert all("pdfs" not in c[2] for c in purges)
+
+    @pytest.mark.asyncio
+    async def test_keep_must_be_positive(self) -> None:
+        dest = _make_dest(dest_type="smb")
+        with pytest.raises(ValueError):
+            await bds.prune_remote_backups(dest, keep=0)


### PR DESCRIPTION
## Summary
Fixes the production **OneDrive saturation** (measured: 3.94 GB, 87% duplicated PDFs across 32 un-pruned daily snapshots).

- **TEC-208 — remote retention**: after each successful sync, prune timestamped snapshot folders beyond the **5 most recent** (OneDrive via Graph list+delete; other destinations via rclone lsf+purge). Best-effort, never fails the backup. Only `YYYY-MM-DDTHH-MM-SS` folders are targeted — stable mirror folders are never pruned.
- **TEC-209 — incremental mirror**: `data/pdfs` (and `data/uploads` if enabled) are no longer re-bundled into every snapshot. They are mirrored to a **stable remote folder**, uploading only files absent/size-different (OneDrive via Graph diff; rclone via native incremental copy). Ends per-run PDF duplication. Restore (database only) is unchanged.

Together these cap and de-duplicate remote storage (≈3.94 GB → ≈0.3 GB going forward).

## Scope
- **BIZ-216 deferred** to its own lot: it needs a "regenerate PDF when the referenced file is missing" safeguard first, otherwise excluded non-archived PDFs would be missing after a disaster restore. Documented in `doc/backlog.md`.

## Tests
- New unit tests for prune (OneDrive + rclone, keep-5, mirror folders never targeted) and for the asset-mirror scheduler flow (PDFs/uploads mirrored, not snapshotted).
- Full backend suite green (1129 passed); ruff/format/mypy clean.

## Notes
- Version bumped to 1.8.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Implement remote backup retention and incremental asset mirroring to cap OneDrive usage and eliminate duplicate PDF storage.

New Features:
- Add incremental mirroring of PDFs and optional uploads to stable remote folders per destination instead of bundling them into each timestamped snapshot.
- Introduce remote backup retention that prunes timestamped snapshot folders beyond the five most recent per destination for both OneDrive and rclone-based backends.

Enhancements:
- Align remote snapshot retention with existing local backup rotation using a shared keep-5 policy and ensure pruning is best-effort so backups do not fail.
- Log pruning and mirroring activity per destination to improve backup observability.

Build:
- Bump backend and frontend version numbers to 1.8.2 to release the new backup behaviour.

Documentation:
- Update backlog documentation to mark TEC-208 and TEC-209 as delivered together and to clarify that BIZ-216 is deferred pending a safer PDF regeneration guardrail.
- Document the technical behaviour of incremental PDF/uploads mirroring and remote retention in the changelog.

Tests:
- Extend backup scheduler tests to verify that PDFs/uploads are excluded from snapshot payloads and mirrored to stable folders only when present and configured.
- Add unit tests for OneDrive- and rclone-based remote pruning, including keep-5 semantics, mirror-folder exclusion, and invalid retention configuration.