### PR TITLE
feat(contacts): Lot ML — email to active members (TEC-210, BIZ-217)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Ce projet respecte le [Versionnage sémantique](https://semver.org/lang/fr/).
 
 ## [Non publié]
 
+### Ajouté
+- **TEC-210** (Lot ML) — API d'envoi groupé d'emails aux **adhérents (clients) actifs** : `GET /api/contacts/active-clients?months=N` (clients/les_deux actifs, avec email, ayant une facture client OU un paiement dans les N derniers mois ; défaut 6) et `POST /api/contacts/mailing` (un email individuel par contact sur **une seule connexion SMTP**, adresses secondaires en `Cc`, placeholders `{prenom}`/`{nom}`, récap envoyés/échecs, journalisé). Accès Secrétaire+. *(Interface : BIZ-217.)*
+
 ### Technique
 - **TEC-209** (Lot BK2) — Miroir incrémental des PDFs/pièces jointes : `data/pdfs` (et `data/uploads` si activé) ne sont plus rebundlés dans chaque snapshot horodaté mais synchronisés vers un **dossier distant stable** en mode « envoyer si absent » (OneDrive via Graph : diff par nom + taille ; rclone : `copy` incrémental natif). Fin de la duplication des PDFs à chaque backup. La restauration (base seule) est inchangée ; les PDFs vivent dans le dossier miroir pour la reprise
 - **TEC-208** (Lot BK2) — Rétention distante des backups : après chaque synchronisation réussie, les **snapshots horodatés** au-delà des **5 plus récents** sont purgés sur chaque destination (OneDrive via Graph, autres via rclone). Plafonne l'espace occupé sur OneDrive (croissance jusque-là illimitée). Purge best-effort (n'échoue jamais le backup) ; ne touche qu'aux dossiers `YYYY-MM-DDTHH-MM-SS`, jamais aux futurs dossiers miroirs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Ce projet respecte le [Versionnage sémantique](https://semver.org/lang/fr/).
 ## [Non publié]
 
 ### Ajouté
-- **TEC-210** (Lot ML) — API d'envoi groupé d'emails aux **adhérents (clients) actifs** : `GET /api/contacts/active-clients?months=N` (clients/les_deux actifs, avec email, ayant une facture client OU un paiement dans les N derniers mois ; défaut 6) et `POST /api/contacts/mailing` (un email individuel par contact sur **une seule connexion SMTP**, adresses secondaires en `Cc`, placeholders `{prenom}`/`{nom}`, récap envoyés/échecs, journalisé). Accès Secrétaire+. *(Interface : BIZ-217.)*
+- **TEC-210 / BIZ-217** (Lot ML) — **Envoi d'un email aux adhérents (clients) actifs**. Depuis l'écran Contacts, un assistant en 3 étapes : (1) choix de la période (« actif » = facture client OU paiement sur les N derniers mois, défaut 6) ; (2) liste des adhérents concernés, tous présélectionnés et désélectionnables ; (3) rédaction (objet + message, placeholders `{prenom}`/`{nom}`) et envoi. Côté serveur : un email individuel par destinataire sur **une seule connexion SMTP** (adresses secondaires en `Cc`), récapitulatif envoyés/échecs, journalisé. Accès Secrétaire+.
 
 ### Technique
 - **TEC-209** (Lot BK2) — Miroir incrémental des PDFs/pièces jointes : `data/pdfs` (et `data/uploads` si activé) ne sont plus rebundlés dans chaque snapshot horodaté mais synchronisés vers un **dossier distant stable** en mode « envoyer si absent » (OneDrive via Graph : diff par nom + taille ; rclone : `copy` incrémental natif). Fin de la duplication des PDFs à chaque backup. La restauration (base seule) est inchangée ; les PDFs vivent dans le dossier miroir pour la reprise

--- a/backend/routers/contact.py
+++ b/backend/routers/contact.py
@@ -11,12 +11,15 @@ from backend.models.contact import ContactType
 from backend.models.user import User, UserRole
 from backend.routers.auth import require_role
 from backend.schemas.contact import (
+    ActiveClientRead,
     ContactCreate,
     ContactEmailImportResult,
     ContactEmailImportRow,
     ContactHistory,
     ContactRead,
     ContactUpdate,
+    MemberMailingRequest,
+    MemberMailingResult,
     MergeContactResult,
 )
 from backend.services import contact as contact_service
@@ -97,6 +100,59 @@ async def import_contact_emails(
 ) -> ContactEmailImportResult:
     """Bulk-import email addresses into existing contacts matched by name."""
     return await contact_service.import_emails_from_rows(db, payload)
+
+
+@router.get("/active-clients", response_model=list[ActiveClientRead])
+async def list_active_clients(
+    db: Annotated[AsyncSession, Depends(get_db)],
+    _current_user: _WriteAccess,
+    months: int = Query(default=6, ge=1, le=120),
+) -> list[ActiveClientRead]:
+    """List client members active within the last ``months`` (invoice or payment)."""
+    rows = await contact_service.list_active_clients(db, months)
+    return [ActiveClientRead.model_validate(row) for row in rows]
+
+
+@router.post("/mailing", response_model=MemberMailingResult)
+async def send_member_mailing(
+    payload: MemberMailingRequest,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    current_user: _WriteAccess,
+) -> MemberMailingResult:
+    """Send an email to the selected active client members (one message each)."""
+    from backend.services import email_service  # noqa: PLC0415
+    from backend.services import settings as settings_service  # noqa: PLC0415
+
+    app_settings = await settings_service.get_settings(db)
+    try:
+        result = await contact_service.send_member_mailing(
+            db,
+            contact_ids=payload.contact_ids,
+            subject=payload.subject,
+            body=payload.body,
+            settings=app_settings,
+        )
+    except email_service.EmailConfigError as exc:
+        raise api_error(
+            status.HTTP_400_BAD_REQUEST,
+            "SMTP_NOT_CONFIGURED",
+            "La configuration SMTP est incomplète.",
+        ) from exc
+    except email_service.EmailSendError as exc:
+        raise api_error(
+            status.HTTP_502_BAD_GATEWAY,
+            "EMAIL_SEND_FAILED",
+            "Échec de l'envoi des emails.",
+        ) from exc
+
+    response = MemberMailingResult.model_validate(result)
+    await record_audit(
+        db,
+        action=AuditAction.MEMBER_MAILING_SENT,
+        actor=current_user,
+        detail={"sent": response.sent, "failed": len(response.failed)},
+    )
+    return response
 
 
 @router.get("/{contact_id}", response_model=ContactRead)

--- a/backend/schemas/contact.py
+++ b/backend/schemas/contact.py
@@ -183,3 +183,29 @@ class ContactEmailImportResult(BaseModel):
     updated_indices: list[int] = []
     not_found_indices: list[int] = []
     already_has_email_indices: list[int] = []
+
+
+class ActiveClientRead(BaseModel):
+    """A client member considered active for a mailing campaign."""
+
+    id: int
+    nom: str
+    prenom: str | None = None
+    email: str | None = None
+    last_activity: date_value | None = None
+
+
+class MemberMailingRequest(BaseModel):
+    contact_ids: list[int] = Field(min_length=1)
+    subject: str = Field(min_length=1, max_length=300)
+    body: str = Field(min_length=1)
+
+
+class MemberMailingFailure(BaseModel):
+    contact_id: int
+    error: str
+
+
+class MemberMailingResult(BaseModel):
+    sent: int
+    failed: list[MemberMailingFailure]

--- a/backend/services/audit_service.py
+++ b/backend/services/audit_service.py
@@ -68,6 +68,7 @@ class AuditAction(StrEnum):
     CONTACT_DELETED = "contact.delete"
     CONTACT_CREANCE_DOUTEUSE = "contact.creance_douteuse"
     CONTACT_MERGED = "contact.merge"
+    MEMBER_MAILING_SENT = "contact.mailing.send"
     # Excel import
     IMPORT_EXECUTED = "import.run.execute"
     IMPORT_UNDONE = "import.run.undo"

--- a/backend/services/contact.py
+++ b/backend/services/contact.py
@@ -1,5 +1,6 @@
 """Contact service — CRUD and search."""
 
+import calendar
 import unicodedata
 from datetime import date
 from decimal import Decimal
@@ -9,11 +10,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from backend.models.accounting_entry import AccountingEntry, EntrySourceType
+from backend.models.app_settings import AppSettings
 from backend.models.cash import CashRegister
 from backend.models.contact import Contact, ContactType
 from backend.models.contact_email import ContactEmail
 from backend.models.fiscal_year import FiscalYear, FiscalYearStatus
-from backend.models.invoice import Invoice, InvoiceStatus
+from backend.models.invoice import Invoice, InvoiceStatus, InvoiceType
 from backend.models.payment import Payment
 from backend.models.salary import Salary
 from backend.schemas.contact import (
@@ -500,3 +502,163 @@ async def merge_contacts(
         cash_entries_reassigned=cash_reassigned,
         salaries_reassigned=salaries_reassigned,
     )
+
+
+# ---------------------------------------------------------------------------
+# Member mailing (Lot ML)
+# ---------------------------------------------------------------------------
+
+_MEMBER_TYPES = (ContactType.CLIENT, ContactType.LES_DEUX)
+
+
+def _months_ago(reference: date, months: int) -> date:
+    """Return the date `months` calendar months before `reference` (clamped day)."""
+    total = reference.month - 1 - months
+    year = reference.year + total // 12
+    month = total % 12 + 1
+    day = min(reference.day, calendar.monthrange(year, month)[1])
+    return date(year, month, day)
+
+
+def _resolve_addresses(contact: Contact) -> list[str]:
+    """Ordered, de-duplicated email addresses of a contact (primary first)."""
+    addresses: list[str] = []
+    if contact.email:
+        addresses.append(contact.email)
+    for extra in contact.emails:
+        if extra.email and extra.email not in addresses:
+            addresses.append(extra.email)
+    return addresses
+
+
+def _apply_placeholders(text: str, contact: Contact) -> str:
+    return text.replace("{prenom}", contact.prenom or "").replace("{nom}", contact.nom or "")
+
+
+async def list_active_clients(db: AsyncSession, months: int) -> list[dict[str, object]]:
+    """List client members active within the last `months`.
+
+    "Active" = at least one client invoice issued OR one payment received since
+    the cutoff. Only contacts of type client/les_deux that are active and have at
+    least one email address are returned. ``last_activity`` is
+    ``max(last client invoice date, last payment date)`` (non-null by construction).
+    """
+    if months < 1:
+        raise ValueError("months must be >= 1")
+    cutoff = _months_ago(date.today(), months)
+
+    last_invoice = (
+        select(func.max(Invoice.date))
+        .where(Invoice.contact_id == Contact.id, Invoice.type == InvoiceType.CLIENT)
+        .correlate(Contact)
+        .scalar_subquery()
+    )
+    last_payment = (
+        select(func.max(Payment.date))
+        .where(Payment.contact_id == Contact.id)
+        .correlate(Contact)
+        .scalar_subquery()
+    )
+    has_recent_invoice = (
+        select(Invoice.id)
+        .where(
+            Invoice.contact_id == Contact.id,
+            Invoice.type == InvoiceType.CLIENT,
+            Invoice.date >= cutoff,
+        )
+        .correlate(Contact)
+        .exists()
+    )
+    has_recent_payment = (
+        select(Payment.id)
+        .where(Payment.contact_id == Contact.id, Payment.date >= cutoff)
+        .correlate(Contact)
+        .exists()
+    )
+    has_email = or_(
+        and_(Contact.email.is_not(None), Contact.email != ""),
+        Contact.emails.any(),
+    )
+
+    query = (
+        select(Contact, last_invoice.label("last_inv"), last_payment.label("last_pay"))
+        .options(selectinload(Contact.emails))
+        .where(
+            Contact.type.in_(_MEMBER_TYPES),
+            Contact.is_active == True,  # noqa: E712
+            has_email,
+            or_(has_recent_invoice, has_recent_payment),
+        )
+        .order_by(Contact.nom, Contact.prenom)
+    )
+    result = await db.execute(query)
+    clients: list[dict[str, object]] = []
+    for contact, last_inv, last_pay in result.all():
+        activity = max((d for d in (last_inv, last_pay) if d is not None), default=None)
+        addresses = _resolve_addresses(contact)
+        clients.append(
+            {
+                "id": contact.id,
+                "nom": contact.nom,
+                "prenom": contact.prenom,
+                "email": addresses[0] if addresses else None,
+                "last_activity": activity,
+            }
+        )
+    return clients
+
+
+async def send_member_mailing(
+    db: AsyncSession,
+    *,
+    contact_ids: list[int],
+    subject: str,
+    body: str,
+    settings: AppSettings,
+) -> dict[str, object]:
+    """Send an individual email to each selected contact over one SMTP connection.
+
+    ``To`` = primary address, secondary addresses in ``Cc``. ``{prenom}``/``{nom}``
+    placeholders are substituted. Returns ``{"sent": int, "failed": [...]}``.
+    Raises email_service.EmailConfigError / EmailSendError on configuration or
+    connection failure.
+    """
+    from backend.services import email_service  # noqa: PLC0415
+
+    result = await db.execute(
+        select(Contact).options(selectinload(Contact.emails)).where(Contact.id.in_(contact_ids))
+    )
+    contacts = list(result.scalars().all())
+
+    messages: list[email_service.BulkEmailMessage] = []
+    failed: list[dict[str, object]] = []
+    for contact in contacts:
+        addresses = _resolve_addresses(contact)
+        if not addresses:
+            failed.append({"contact_id": contact.id, "error": "Aucune adresse email"})
+            continue
+        messages.append(
+            {
+                "to": addresses[0],
+                "cc": addresses[1:],
+                "subject": _apply_placeholders(subject, contact),
+                "body": _apply_placeholders(body, contact),
+                "ref": contact.id,
+            }
+        )
+
+    send_failures: list[email_service.BulkEmailFailure] = []
+    if messages:
+        send_failures = email_service.send_bulk_emails(
+            host=settings.smtp_host or "",
+            port=settings.smtp_port,
+            user=settings.smtp_user,
+            password=settings.smtp_password,
+            use_tls=settings.smtp_use_tls,
+            from_email=settings.smtp_from_email or settings.smtp_user or "",
+            messages=messages,
+        )
+    for failure in send_failures:
+        failed.append({"contact_id": failure["ref"], "error": failure["error"]})
+
+    return {"sent": len(messages) - len(send_failures), "failed": failed}

--- a/backend/services/email_service.py
+++ b/backend/services/email_service.py
@@ -5,6 +5,7 @@ import ssl
 from email.mime.application import MIMEApplication
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
+from typing import TypedDict
 
 
 class EmailConfigError(Exception):
@@ -182,3 +183,69 @@ def send_plain_email(
                 server.send_message(msg)
     except (smtplib.SMTPException, OSError) as exc:
         raise EmailSendError(f"Failed to send plain email: {exc}") from exc
+
+
+class BulkEmailMessage(TypedDict):
+    to: str
+    cc: list[str]
+    subject: str
+    body: str
+    ref: int
+
+
+class BulkEmailFailure(TypedDict):
+    ref: int
+    error: str
+
+
+def send_bulk_emails(
+    *,
+    host: str,
+    port: int,
+    user: str | None,
+    password: str | None,
+    use_tls: bool,
+    from_email: str,
+    messages: list[BulkEmailMessage],
+) -> list[BulkEmailFailure]:
+    """Send many plain-text emails over a **single** SMTP connection.
+
+    Each message is sent to ``to`` with ``cc`` in copy. ``ref`` is echoed back
+    on failure so the caller can map it to a contact.
+
+    Returns the list of per-message failures. Raises EmailConfigError if the
+    host is missing, EmailSendError if the connection (or login) itself fails.
+    """
+    if not host:
+        raise EmailConfigError("SMTP host is not configured")
+
+    failures: list[BulkEmailFailure] = []
+    try:
+        if use_tls:
+            ctx = ssl.create_default_context()
+            server = smtplib.SMTP(host, port, timeout=30)
+            server.ehlo()
+            server.starttls(context=ctx)
+        else:
+            server = smtplib.SMTP(host, port, timeout=30)
+        with server:
+            if user and password:
+                server.login(user, password)
+            for message in messages:
+                to_email = message["to"]
+                cc_list = list(message["cc"])
+                msg = MIMEMultipart()
+                msg["From"] = from_email
+                msg["To"] = to_email
+                if cc_list:
+                    msg["Cc"] = ", ".join(cc_list)
+                msg["Subject"] = message["subject"]
+                msg.attach(MIMEText(message["body"], "plain", "utf-8"))
+                try:
+                    server.send_message(msg, to_addrs=[to_email, *cc_list])
+                except smtplib.SMTPException as exc:
+                    failures.append({"ref": message["ref"], "error": str(exc)})
+    except (smtplib.SMTPException, OSError) as exc:
+        raise EmailSendError(f"SMTP connection failed: {exc}") from exc
+
+    return failures

--- a/doc/backlog.md
+++ b/doc/backlog.md
@@ -99,7 +99,7 @@ Envoyer un email à tous les **adhérents (clients) actifs**. **Actif** = a eu u
 | ID | Titre | Prio | Est. | Créé | Démarré | Terminé |
 | --- | --- | --- | --- | --- | --- | --- |
 | TEC-210 | Backend — endpoint « clients actifs » (mois paramétrable) + envoi groupé | P2 | ~50 min | 2026-06-23 | 2026-06-23 | 2026-06-23 |
-| BIZ-217 | Frontend — assistant d'envoi en 3 étapes (période → sélection → rédaction) | P2 | ~70 min | 2026-06-23 | | |
+| BIZ-217 | Frontend — assistant d'envoi en 3 étapes (période → sélection → rédaction) | P2 | ~70 min | 2026-06-23 | 2026-06-23 | 2026-06-23 |
 
 > Dépendance : BIZ-217 dépend de TEC-210.
 

--- a/doc/backlog.md
+++ b/doc/backlog.md
@@ -98,7 +98,7 @@ Envoyer un email à tous les **adhérents (clients) actifs**. **Actif** = a eu u
 
 | ID | Titre | Prio | Est. | Créé | Démarré | Terminé |
 | --- | --- | --- | --- | --- | --- | --- |
-| TEC-210 | Backend — endpoint « clients actifs » (mois paramétrable) + envoi groupé | P2 | ~50 min | 2026-06-23 | | |
+| TEC-210 | Backend — endpoint « clients actifs » (mois paramétrable) + envoi groupé | P2 | ~50 min | 2026-06-23 | 2026-06-23 | 2026-06-23 |
 | BIZ-217 | Frontend — assistant d'envoi en 3 étapes (période → sélection → rédaction) | P2 | ~70 min | 2026-06-23 | | |
 
 > Dépendance : BIZ-217 dépend de TEC-210.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/frontend/src/api/contacts.ts
+++ b/frontend/src/api/contacts.ts
@@ -172,3 +172,39 @@ export async function mergeContactApi(sourceId: number, targetId: number): Promi
   )
   return response.data
 }
+
+// --- Member mailing (Lot ML) ---
+
+export interface ActiveClient {
+  id: number
+  nom: string
+  prenom: string | null
+  email: string | null
+  last_activity: string | null
+}
+
+export interface MemberMailingFailure {
+  contact_id: number
+  error: string
+}
+
+export interface MemberMailingResult {
+  sent: number
+  failed: MemberMailingFailure[]
+}
+
+export async function listActiveClientsApi(months: number): Promise<ActiveClient[]> {
+  const response = await apiClient.get<ActiveClient[]>(
+    `/api/contacts/active-clients?months=${months}`,
+  )
+  return response.data
+}
+
+export async function sendMemberMailingApi(payload: {
+  contact_ids: number[]
+  subject: string
+  body: string
+}): Promise<MemberMailingResult> {
+  const response = await apiClient.post<MemberMailingResult>('/api/contacts/mailing', payload)
+  return response.data
+}

--- a/frontend/src/components/contacts/MemberMailingDialog.vue
+++ b/frontend/src/components/contacts/MemberMailingDialog.vue
@@ -1,0 +1,209 @@
+<template>
+  <Dialog
+    :visible="visible"
+    modal
+    :header="t('contacts.mailing.title')"
+    class="app-dialog app-dialog--large"
+    @update:visible="(v: boolean) => emit('update:visible', v)"
+    @show="reset"
+  >
+    <!-- Step 1 — period -->
+    <div v-if="step === 1" class="member-mailing">
+      <p class="member-mailing__intro">{{ t('contacts.mailing.step1_intro') }}</p>
+      <div class="app-field">
+        <label class="app-field__label">{{ t('contacts.mailing.months_label') }}</label>
+        <InputNumber v-model="months" :min="1" :max="120" show-buttons data-testid="mm-months" />
+      </div>
+      <div class="app-form-actions">
+        <Button :label="t('common.cancel')" severity="secondary" text @click="close" />
+        <Button
+          :label="t('contacts.mailing.load_recipients')"
+          icon="pi pi-search"
+          :loading="loading"
+          data-testid="mm-load"
+          @click="loadRecipients"
+        />
+      </div>
+    </div>
+
+    <!-- Step 2 — recipient selection (all preselected) -->
+    <div v-else-if="step === 2" class="member-mailing">
+      <p class="member-mailing__intro">
+        {{ t('contacts.mailing.step2_intro', { count: clients.length }) }}
+      </p>
+      <DataTable
+        v-model:selection="selected"
+        :value="clients"
+        data-key="id"
+        class="app-data-table"
+        paginator
+        :rows="50"
+        scrollable
+        scroll-height="45vh"
+        size="small"
+      >
+        <Column selection-mode="multiple" header-style="width:3rem" />
+        <Column field="nom" :header="t('contacts.nom')">
+          <template #body="{ data }">
+            {{ data.nom }}<template v-if="data.prenom"> {{ data.prenom }}</template>
+          </template>
+        </Column>
+        <Column field="email" :header="t('contacts.email')" />
+        <template #empty>
+          <div class="app-empty-state">{{ t('contacts.mailing.no_recipients') }}</div>
+        </template>
+      </DataTable>
+      <div class="app-form-actions">
+        <Button
+          :label="t('common.previous')"
+          icon="pi pi-arrow-left"
+          severity="secondary"
+          text
+          @click="step = 1"
+        />
+        <span class="member-mailing__count">
+          {{ t('contacts.mailing.selected_count', { count: selected.length }) }}
+        </span>
+        <Button
+          :label="t('common.next')"
+          icon="pi pi-arrow-right"
+          :disabled="selected.length === 0"
+          data-testid="mm-to-compose"
+          @click="step = 3"
+        />
+      </div>
+    </div>
+
+    <!-- Step 3 — compose & send -->
+    <div v-else class="member-mailing">
+      <p class="member-mailing__intro">
+        {{ t('contacts.mailing.step3_intro', { count: selected.length }) }}
+      </p>
+      <div class="app-field">
+        <label class="app-field__label">{{ t('contacts.mailing.subject') }}</label>
+        <InputText v-model="subject" data-testid="mm-subject" />
+      </div>
+      <div class="app-field">
+        <label class="app-field__label">{{ t('contacts.mailing.body') }}</label>
+        <Textarea v-model="body" rows="8" data-testid="mm-body" />
+        <small class="app-dialog-note">{{ t('contacts.mailing.placeholders_help') }}</small>
+      </div>
+      <div class="app-form-actions">
+        <Button
+          :label="t('common.previous')"
+          icon="pi pi-arrow-left"
+          severity="secondary"
+          text
+          @click="step = 2"
+        />
+        <Button
+          :label="t('contacts.mailing.send')"
+          icon="pi pi-send"
+          :loading="sending"
+          :disabled="!subject.trim() || !body.trim()"
+          data-testid="mm-send"
+          @click="send"
+        />
+      </div>
+    </div>
+  </Dialog>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useToast } from 'primevue/usetoast'
+import Dialog from 'primevue/dialog'
+import Button from 'primevue/button'
+import Column from 'primevue/column'
+import DataTable from 'primevue/datatable'
+import InputNumber from 'primevue/inputnumber'
+import InputText from 'primevue/inputtext'
+import Textarea from 'primevue/textarea'
+import { listActiveClientsApi, sendMemberMailingApi, type ActiveClient } from '@/api/contacts'
+
+defineProps<{ visible: boolean }>()
+const emit = defineEmits<{ 'update:visible': [value: boolean]; sent: [] }>()
+
+const { t } = useI18n()
+const toast = useToast()
+
+const step = ref<1 | 2 | 3>(1)
+const months = ref(6)
+const clients = ref<ActiveClient[]>([])
+const selected = ref<ActiveClient[]>([])
+const subject = ref('')
+const body = ref('')
+const loading = ref(false)
+const sending = ref(false)
+
+function reset(): void {
+  step.value = 1
+  months.value = 6
+  clients.value = []
+  selected.value = []
+  subject.value = ''
+  body.value = ''
+}
+
+function close(): void {
+  emit('update:visible', false)
+}
+
+async function loadRecipients(): Promise<void> {
+  loading.value = true
+  try {
+    clients.value = await listActiveClientsApi(months.value)
+    selected.value = [...clients.value] // all preselected by default
+    step.value = 2
+  } catch {
+    toast.add({ severity: 'error', summary: t('common.error.unknown'), life: 3000 })
+  } finally {
+    loading.value = false
+  }
+}
+
+async function send(): Promise<void> {
+  sending.value = true
+  try {
+    const result = await sendMemberMailingApi({
+      contact_ids: selected.value.map((c) => c.id),
+      subject: subject.value,
+      body: body.value,
+    })
+    toast.add({
+      severity: result.failed.length ? 'warn' : 'success',
+      summary: t('contacts.mailing.sent_summary', {
+        sent: result.sent,
+        failed: result.failed.length,
+      }),
+      life: 5000,
+    })
+    emit('sent')
+    close()
+  } catch {
+    toast.add({ severity: 'error', summary: t('contacts.mailing.send_error'), life: 4000 })
+  } finally {
+    sending.value = false
+  }
+}
+</script>
+
+<style scoped>
+.member-mailing {
+  display: flex;
+  flex-direction: column;
+  gap: var(--app-space-4);
+}
+
+.member-mailing__intro {
+  margin: 0;
+  color: var(--p-text-muted-color);
+}
+
+.member-mailing__count {
+  font-size: 0.875rem;
+  color: var(--p-text-muted-color);
+  margin-inline: auto;
+}
+</style>

--- a/frontend/src/i18n/fr.ts
+++ b/frontend/src/i18n/fr.ts
@@ -284,6 +284,24 @@ export default {
     changelog_error: 'Impossible de charger les nouveautés.',
   },
   contacts: {
+    mailing: {
+      button: 'Email aux adhérents',
+      title: 'Email aux adhérents actifs',
+      step1_intro:
+        'Choisissez la période : un adhérent est « actif » s’il a eu une facture ou un paiement sur les derniers mois.',
+      months_label: 'Activité sur les derniers mois',
+      load_recipients: 'Voir les destinataires',
+      step2_intro: '{count} adhérent(s) actif(s). Décochez ceux à exclure.',
+      selected_count: '{count} sélectionné(s)',
+      no_recipients: 'Aucun adhérent actif sur cette période.',
+      step3_intro: 'Rédigez le message envoyé aux {count} destinataire(s) sélectionné(s).',
+      subject: 'Objet',
+      body: 'Message',
+      placeholders_help: 'Vous pouvez utiliser {prenom} et {nom} dans l’objet et le message.',
+      send: 'Envoyer',
+      sent_summary: '{sent} email(s) envoyé(s), {failed} échec(s).',
+      send_error: 'Échec de l’envoi des emails.',
+    },
     title: 'Contacts',
     subtitle:
       "Un carnet d'adresses clarifie pour retrouver rapidement les bons interlocuteurs et leurs informations utiles.",

--- a/frontend/src/tests/components/MemberMailingDialog.spec.ts
+++ b/frontend/src/tests/components/MemberMailingDialog.spec.ts
@@ -1,0 +1,111 @@
+import { mount } from '@vue/test-utils'
+import { defineComponent, h, nextTick } from 'vue'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}))
+vi.mock('primevue/usetoast', () => ({
+  useToast: () => ({ add: vi.fn() }),
+}))
+
+const mockList = vi.fn()
+const mockSend = vi.fn()
+vi.mock('@/api/contacts', () => ({
+  listActiveClientsApi: (m: number) => mockList(m),
+  sendMemberMailingApi: (p: unknown) => mockSend(p),
+}))
+
+import MemberMailingDialog from '../../components/contacts/MemberMailingDialog.vue'
+
+const ButtonStub = defineComponent({
+  props: ['label', 'disabled', 'loading'],
+  emits: ['click'],
+  setup(props, { attrs, emit }) {
+    return () =>
+      h(
+        'button',
+        { 'data-testid': attrs['data-testid'], disabled: props.disabled, onClick: () => emit('click') },
+        props.label,
+      )
+  },
+})
+const InputStub = defineComponent({
+  props: ['modelValue'],
+  emits: ['update:modelValue'],
+  setup(props, { attrs, emit }) {
+    return () =>
+      h('input', {
+        'data-testid': attrs['data-testid'],
+        value: props.modelValue,
+        onInput: (e: Event) => emit('update:modelValue', (e.target as HTMLInputElement).value),
+      })
+  },
+})
+const Passthrough = defineComponent({
+  setup(_props, { slots }) {
+    return () => h('div', slots.default?.())
+  },
+})
+
+const stubs = {
+  Dialog: Passthrough,
+  DataTable: Passthrough,
+  Column: true,
+  Button: ButtonStub,
+  InputNumber: InputStub,
+  InputText: InputStub,
+  Textarea: InputStub,
+}
+
+async function flush(): Promise<void> {
+  await Promise.resolve()
+  await Promise.resolve()
+  await nextTick()
+}
+
+describe('MemberMailingDialog', () => {
+  it('walks period → selection → compose → send', async () => {
+    mockList.mockResolvedValue([
+      { id: 1, nom: 'A', prenom: null, email: 'a@x.org', last_activity: '2026-06-01' },
+      { id: 2, nom: 'B', prenom: null, email: 'b@x.org', last_activity: '2026-06-02' },
+    ])
+    mockSend.mockResolvedValue({ sent: 2, failed: [] })
+
+    const wrapper = mount(MemberMailingDialog, { props: { visible: true }, global: { stubs } })
+
+    // Step 1 → load recipients (default 6 months)
+    await wrapper.get('[data-testid="mm-load"]').trigger('click')
+    await flush()
+    expect(mockList).toHaveBeenCalledWith(6)
+
+    // Step 2 → all preselected → go to compose
+    await wrapper.get('[data-testid="mm-to-compose"]').trigger('click')
+    await nextTick()
+
+    // Step 3 → compose + send
+    await wrapper.get('[data-testid="mm-subject"]').setValue('Bonjour')
+    await wrapper.get('[data-testid="mm-body"]').setValue('Message')
+    await wrapper.get('[data-testid="mm-send"]').trigger('click')
+    await flush()
+
+    expect(mockSend).toHaveBeenCalledWith({
+      contact_ids: [1, 2],
+      subject: 'Bonjour',
+      body: 'Message',
+    })
+    expect(wrapper.emitted('sent')).toBeTruthy()
+    expect(wrapper.emitted('update:visible')?.at(-1)).toEqual([false])
+  })
+
+  it('does not send when no recipient is selected (Next disabled)', async () => {
+    mockList.mockResolvedValue([])
+    mockSend.mockClear()
+    const wrapper = mount(MemberMailingDialog, { props: { visible: true }, global: { stubs } })
+
+    await wrapper.get('[data-testid="mm-load"]').trigger('click')
+    await flush()
+    // 0 recipients → Next is disabled
+    expect(wrapper.get('[data-testid="mm-to-compose"]').attributes('disabled')).toBeDefined()
+  })
+})

--- a/frontend/src/views/ContactsView.vue
+++ b/frontend/src/views/ContactsView.vue
@@ -6,6 +6,7 @@
       :subtitle="t('contacts.subtitle')"
     >
       <template #actions>
+        <Button :label="t('contacts.mailing.button')" icon="pi pi-send" severity="secondary" outlined @click="mailingDialogVisible = true" />
         <Button :label="t('contacts.import_emails')" icon="pi pi-envelope" severity="secondary" outlined @click="importDialogVisible = true" />
         <Button :label="t('contacts.new')" icon="pi pi-plus" @click="openCreateDialog" />
       </template>
@@ -370,6 +371,7 @@
       :contacts="contacts"
       @merged="onMerged"
     />
+    <MemberMailingDialog v-model:visible="mailingDialogVisible" />
     <ConfirmDialog />
   </AppPage>
 </template>
@@ -407,6 +409,7 @@ import type { ContactType } from '@/api/types'
 import ContactForm from '@/components/ContactForm.vue'
 import ContactHistoryDialog from '@/components/ContactHistoryDialog.vue'
 import ContactMergeDialog from '@/components/ContactMergeDialog.vue'
+import MemberMailingDialog from '@/components/contacts/MemberMailingDialog.vue'
 import { useKeyboardShortcuts } from '@/composables/useKeyboardShortcuts'
 import { useUnsavedChangesGuard } from '@/composables/useUnsavedChangesGuard'
 import { useBreakpoints } from '@/composables/useBreakpoints'
@@ -453,6 +456,7 @@ const selectedContactId = ref<number | null>(null)
 
 const mergeDialogVisible = ref(false)
 const mergeSourceContact = ref<Contact | null>(null)
+const mailingDialogVisible = ref(false)
 
 function openMergeDialog(contact: Contact): void {
   mergeSourceContact.value = contact

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "solde"
-version = "1.8.2"
+version = "1.8.3"
 description = "Web app for French non-profit accounting — invoicing, payments, cash management and double-entry bookkeeping."
 requires-python = ">=3.11"
 dependencies = [

--- a/tests/integration/test_contact_mailing_api.py
+++ b/tests/integration/test_contact_mailing_api.py
@@ -1,0 +1,190 @@
+"""Integration tests for the member-mailing feature (Lot ML).
+
+- GET /api/contacts/active-clients — active client members (invoice OR payment in window)
+- POST /api/contacts/mailing — bulk email to selected contacts
+"""
+
+from datetime import date
+from decimal import Decimal
+from unittest.mock import patch
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.models.contact import Contact, ContactType
+from backend.models.contact_email import ContactEmail
+from backend.models.invoice import Invoice, InvoiceStatus, InvoiceType
+from backend.models.payment import Payment, PaymentMethod
+
+_TODAY = date.today()
+_RECENT = _TODAY
+_OLD = date(_TODAY.year - 1, _TODAY.month, _TODAY.day)  # > 6 months ago
+
+
+async def _add_contact(
+    db: AsyncSession,
+    *,
+    nom: str,
+    type_: ContactType = ContactType.CLIENT,
+    is_active: bool = True,
+    email: str | None = None,
+) -> Contact:
+    c = Contact(nom=nom, type=type_, is_active=is_active, email=email)
+    db.add(c)
+    await db.flush()
+    return c
+
+
+async def _add_invoice(db: AsyncSession, contact: Contact, *, number: str, when: date) -> Invoice:
+    inv = Invoice(
+        number=number,
+        type=InvoiceType.CLIENT,
+        contact_id=contact.id,
+        date=when,
+        due_date=when,
+        total_amount=Decimal("100.00"),
+        paid_amount=Decimal("0.00"),
+        status=InvoiceStatus.SENT,
+    )
+    db.add(inv)
+    await db.flush()
+    return inv
+
+
+async def _add_payment(db: AsyncSession, contact: Contact, invoice: Invoice, *, when: date) -> None:
+    db.add(
+        Payment(
+            invoice_id=invoice.id,
+            contact_id=contact.id,
+            amount=Decimal("50.00"),
+            date=when,
+            method=PaymentMethod.VIREMENT,
+        )
+    )
+    await db.flush()
+
+
+@pytest.mark.asyncio
+async def test_active_clients_filters(
+    client: AsyncClient, auth_headers: dict, db_session: AsyncSession
+) -> None:
+    """Only active client/les_deux members with an email and recent activity are returned."""
+    recent_inv = await _add_contact(db_session, nom="Recent Invoice", email="ri@example.org")
+    await _add_invoice(db_session, recent_inv, number="F-RI-1", when=_RECENT)
+
+    recent_pay = await _add_contact(db_session, nom="Recent Payment", email="rp@example.org")
+    pay_inv = await _add_invoice(db_session, recent_pay, number="F-RP-1", when=_OLD)
+    await _add_payment(db_session, recent_pay, pay_inv, when=_RECENT)
+
+    mixed = await _add_contact(
+        db_session, nom="Mixed", type_=ContactType.LES_DEUX, email="mx@example.org"
+    )
+    await _add_invoice(db_session, mixed, number="F-MX-1", when=_RECENT)
+
+    # Excluded cases
+    old = await _add_contact(db_session, nom="Old", email="old@example.org")
+    await _add_invoice(db_session, old, number="F-OLD-1", when=_OLD)
+
+    inactive = await _add_contact(
+        db_session, nom="Inactive", is_active=False, email="in@example.org"
+    )
+    await _add_invoice(db_session, inactive, number="F-IN-1", when=_RECENT)
+
+    no_email = await _add_contact(db_session, nom="No Email", email=None)
+    await _add_invoice(db_session, no_email, number="F-NE-1", when=_RECENT)
+
+    supplier = await _add_contact(
+        db_session, nom="Supplier", type_=ContactType.FOURNISSEUR, email="su@example.org"
+    )
+    await _add_invoice(db_session, supplier, number="F-SU-1", when=_RECENT)
+
+    await db_session.commit()
+
+    resp = await client.get("/api/contacts/active-clients?months=6", headers=auth_headers)
+    assert resp.status_code == 200
+    names = {row["nom"] for row in resp.json()}
+    assert names == {"Recent Invoice", "Recent Payment", "Mixed"}
+    # last_activity is present (non-null by construction)
+    assert all(row["last_activity"] for row in resp.json())
+
+
+@pytest.mark.asyncio
+async def test_active_clients_rejects_bad_months(client: AsyncClient, auth_headers: dict) -> None:
+    resp = await client.get("/api/contacts/active-clients?months=0", headers=auth_headers)
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_mailing_sends_to_selected(
+    client: AsyncClient, auth_headers: dict, db_session: AsyncSession
+) -> None:
+    """A successful mailing reports every selected contact as sent."""
+    a = await _add_contact(db_session, nom="Alpha", email="a@example.org")
+    b = await _add_contact(db_session, nom="Beta", email="b@example.org")
+    # Beta has a secondary address → should go in Cc
+    db_session.add(ContactEmail(contact_id=b.id, email="b2@example.org", sort_order=0))
+    await db_session.commit()
+
+    captured: dict = {}
+
+    def _fake_send(**kwargs):
+        captured.update(kwargs)
+        return []  # no failures
+
+    with patch("backend.services.email_service.send_bulk_emails", side_effect=_fake_send):
+        resp = await client.post(
+            "/api/contacts/mailing",
+            headers=auth_headers,
+            json={"contact_ids": [a.id, b.id], "subject": "Bonjour {prenom}", "body": "Coucou"},
+        )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["sent"] == 2
+    assert data["failed"] == []
+    tos = {m["to"] for m in captured["messages"]}
+    assert tos == {"a@example.org", "b@example.org"}
+    beta_msg = next(m for m in captured["messages"] if m["to"] == "b@example.org")
+    assert beta_msg["cc"] == ["b2@example.org"]
+
+
+@pytest.mark.asyncio
+async def test_mailing_reports_partial_failure(
+    client: AsyncClient, auth_headers: dict, db_session: AsyncSession
+) -> None:
+    a = await _add_contact(db_session, nom="Alpha", email="a@example.org")
+    b = await _add_contact(db_session, nom="Beta", email="b@example.org")
+    await db_session.commit()
+
+    def _fake_send(**kwargs):
+        return [{"ref": b.id, "error": "mailbox full"}]
+
+    with patch("backend.services.email_service.send_bulk_emails", side_effect=_fake_send):
+        resp = await client.post(
+            "/api/contacts/mailing",
+            headers=auth_headers,
+            json={"contact_ids": [a.id, b.id], "subject": "S", "body": "B"},
+        )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["sent"] == 1
+    assert data["failed"] == [{"contact_id": b.id, "error": "mailbox full"}]
+
+
+@pytest.mark.asyncio
+async def test_mailing_smtp_not_configured(
+    client: AsyncClient, auth_headers: dict, db_session: AsyncSession
+) -> None:
+    """With no SMTP host configured, the real sender raises and the API returns 400."""
+    a = await _add_contact(db_session, nom="Alpha", email="a@example.org")
+    await db_session.commit()
+
+    resp = await client.post(
+        "/api/contacts/mailing",
+        headers=auth_headers,
+        json={"contact_ids": [a.id], "subject": "S", "body": "B"},
+    )
+    assert resp.status_code == 400
+    assert resp.json()["detail"]["code"] == "SMTP_NOT_CONFIGURED"


### PR DESCRIPTION
## Summary
Adds the ability to email all **active client members** from the Contacts screen.

**"Active"** = a client invoice issued OR a payment received within the last N months (default 6, configurable).

**Flow** (3-step wizard): pick the months → review the matching members (all preselected, deselectable) → compose subject/body → send.

- **TEC-210 (backend)**: `GET /api/contacts/active-clients?months=N` and `POST /api/contacts/mailing`. One individual email per contact over a **single SMTP connection** (secondary addresses in `Cc`), `{prenom}`/`{nom}` placeholders, per-recipient failure report, audit log. Secrétaire+. New `email_service.send_bulk_emails`.
- **BIZ-217 (frontend)**: `MemberMailingDialog` 3-step wizard + "Email aux adhérents" entry point on Contacts.

## Tests
- Backend: active-clients filtering (type/active/email/window, invoice OR payment), mailing send, partial failure, SMTP-not-configured → 1134 passed.
- Frontend: wizard flow (period → selection → compose → send) + disabled Next on empty selection → 191 passed.
- ruff/format/mypy/eslint/vue-tsc clean.

## Notes
- Version bumped to 1.8.3. `last_activity` = max(last client invoice, last payment), non-null by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add backend and frontend support for emailing active client members from the Contacts screen via a three-step wizard and bulk SMTP sending.

New Features:
- Expose an API to list active client members within a configurable activity window and to send individualized emails to selected contacts in a single mailing operation.
- Add a Contacts screen action and three-step MemberMailing dialog to select an activity period, choose recipients, compose an email, and send it to active members.

Enhancements:
- Introduce reusable bulk email sending support over a single SMTP connection with per-recipient failure reporting.
- Record an audit log entry when a member mailing is sent from the contacts module.

Build:
- Bump backend and frontend package versions to 1.8.3 for the new member mailing feature.

Documentation:
- Update backlog and changelog to document the active member mailing feature and release it as version 1.8.3.

Tests:
- Add backend integration tests covering active client filtering, mailing success and partial failure cases, and SMTP misconfiguration handling.
- Add frontend tests for the MemberMailing dialog flow, including period selection, recipient selection, composition, sending, and disabled navigation when no recipients are selected.