### PR TITLE
docs(roadmap): mark v1.8.1 as released

### DIFF
--- a/doc/roadmap.md
+++ b/doc/roadmap.md
@@ -29,7 +29,7 @@
 | **1.6.3** | TEC-185 (Chrome PDF fix), BIZ-186 (paid watermark on PDF) | ✅ Released 2026-05-10 |
 | **1.7** | Lot BK — automated backup (BIZ-173–184) | 🔧 In progress (PR #85) |
 | **1.8** | Lot RF — UI/UX redesign (dashboard, invoices, admin) + dark mode + responsive | ✅ Released 2026-06-21 |
-| **1.8.1** | Lot BK2 (backup retention + incremental mirror) · Lot ML (member mailing) · dashboard "to reconcile" fix | 🔧 Release prepared (release/1.8.1 → main) |
+| **1.8.1** | Lot BK2 (backup retention + incremental mirror) · Lot ML (member mailing) · dashboard "to reconcile" fix | ✅ Released 2026-06-23 |
 
 Test suite: **1090 backend + 148 frontend Vitest — 0 failures.**
 


### PR DESCRIPTION
Flip the v1.8.1 roadmap status from "Release prepared" to "✅ Released 2026-06-23", now that v1.8.1 is merged to main, tagged, and published.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Documentation:
- Mark version 1.8.1 as released on 2026-06-23 in the roadmap documentation.