### PR TITLE
fix(ui): supprimer le scroll horizontal des tableaux sur grand écran (TEC-212)

### DIFF
--- a/.backlog/README.md
+++ b/.backlog/README.md
@@ -26,7 +26,7 @@ générateur). Les artefacts sont créés à `⬜ ready`. Convention détaillée
 | [EDIT-OPS](EDIT-OPS/PRD.md) — édition/suppression des opérations bancaires manuelles (BIZ-169) | ⬜ |
 | [CREANCES-RAPPEL](CREANCES-RAPPEL/PRD.md) — rappel créances exercice/historique sur factures client (BIZ-210) | 🧑 |
 | [RELANCES](RELANCES/PRD.md) — relances factures impayées : historique daté, templates dédiés, filtrage irrécouvrables (BIZ-218→221) | ⬜ |
-| [TABLE-FIT](TABLE-FIT/PRD.md) — supprimer le scroll horizontal des tableaux sur grand écran (TEC-212) | ⬜ |
+| [TABLE-FIT](TABLE-FIT/PRD.md) — supprimer le scroll horizontal des tableaux sur grand écran (TEC-212) | 🔄 |
 
 ## Lots archivés
 

--- a/.backlog/TABLE-FIT/PRD.md
+++ b/.backlog/TABLE-FIT/PRD.md
@@ -1,6 +1,6 @@
 # Lot TABLE-FIT — Supprimer le scroll horizontal des tableaux sur grand écran
 
-Status: ⬜ ready
+Status: 🔄 in-progress
 Branch: fix/table-horizontal-scroll → PR → develop
 
 ## Problem Statement

--- a/.backlog/TABLE-FIT/tickets/01-fix-table-horizontal-scroll.md
+++ b/.backlog/TABLE-FIT/tickets/01-fix-table-horizontal-scroll.md
@@ -1,6 +1,6 @@
 # TEC-212 — Supprimer le scroll horizontal des tableaux sur grand écran
 
-Status: ⬜ ready
+Status: 🔄 in-progress
 Type: fix
 Files: `frontend/src/views/BankView.vue`, `frontend/src/assets/main.css`, autres vues à `DataTable` (audit), `frontend/src/tests/`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Ce projet respecte le [Versionnage sémantique](https://semver.org/lang/fr/).
 
 ## [Non publié]
 
+### Corrigé
+- **TEC-212** (Lot TABLE-FIT) — **Scroll horizontal des tableaux supprimé sur grand écran**. Le conteneur de contenu (`.main-inner`) plafonnait toutes les pages à 1320 px, ce qui **neutralisait le mode « large » (1640 px)** des écrans denses (Banque, comptabilité…) : la table débordait son panneau (scroll horizontal) tout en laissant de l'espace inutilisé sur les côtés. `.main-inner` suit désormais la largeur « large », les tableaux s'étirent à leur conteneur (`width: 100%`) et les colonnes texte de la Banque (libellé/référence) ne sont plus compressées. Vérifié sur 16 écrans à tableau : aucun débordement.
+
 ### Technique
 - **Restructuration du backlog** — passage du backlog monolithique `doc/backlog.md` (+ archive) à une structure **par lot** sous `.backlog/` : un dossier `PRD.md` + `tickets/NN-slug.md` par lot actif, archives compactes par lot, index `.backlog/README.md`. Câblage (sans fork) des skills d'ingénierie `/to-prd` · `/to-issues` · `/triage` via `docs/agents/*`. Vocabulaire de statut unique (⬜ 🔄 🧑 ✅ 🚫). Décision actée dans `docs/adr/0001-backlog-restructure.md`
 - **Renommage `doc/` → `docs/`** — alignement sur la convention usuelle. Chemins runtime mis à jour (manuel/changelog servis par le chatbot), `Dockerfile`, `README.md` et docs de process. `CHANGELOG.md` conservé tel quel (ledger historique)

--- a/docs/user/changelog-user.md
+++ b/docs/user/changelog-user.md
@@ -4,6 +4,14 @@ Ce document présente les changements visibles dans l'application, version par v
 
 ---
 
+## Version 1.8.2 — à venir
+
+### Tous les utilisateurs
+
+- **Tableaux mieux affichés sur grand écran** : les écrans riches en colonnes (Banque, comptabilité…) utilisent désormais toute la largeur disponible. Fini la barre de défilement horizontale et les libellés écrasés sur les grands écrans.
+
+---
+
 ## Version 1.8.1 — 23 juin 2026
 
 Nouveauté d'envoi d'emails aux adhérents, sauvegardes plus économes, et correction du tableau de bord.

--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -471,6 +471,14 @@ html.dark-mode .app-chip {
   vertical-align: middle;
 }
 
+/* Stretch the table to fill its container so spare width is distributed to the
+   flexible (text) columns instead of leaving empty space on the side. When the
+   table genuinely can't fit (narrow screens), PrimeVue's own
+   .p-datatable-table-container already scrolls it horizontally. */
+.app-data-table table {
+  width: 100%;
+}
+
 .app-dialog {
   width: min(calc(100vw - 2rem), 720px);
 }

--- a/frontend/src/layouts/AppLayout.vue
+++ b/frontend/src/layouts/AppLayout.vue
@@ -451,8 +451,11 @@ onMounted(() => {
     top: var(--app-topbar-height);
   }
 
+  /* Allow wide pages (.app-page--wide) to reach their 1640px cap. Each
+     .app-page sets its own width (1320 normal / 1640 wide) and centers itself,
+     so this only needs to stop being the bottleneck — not clamp to 1320. */
   .main-inner {
-    max-width: 1320px;
+    max-width: var(--app-page-wide-max-width);
     margin: 0 auto;
   }
 }

--- a/frontend/src/views/BankView.vue
+++ b/frontend/src/views/BankView.vue
@@ -1636,7 +1636,10 @@ onMounted(async () => {
 
 :deep(.bank-table__reference) {
   min-width: 7rem;
-  overflow-wrap: anywhere;
+  /* break-word over anywhere: only wrap long tokens (refs/IBANs) when they
+     overflow, preserving legibility/copyability. PrimeVue's native horizontal
+     scroll covers the rare too-narrow case. */
+  overflow-wrap: break-word;
 }
 
 :deep(.bank-table__amount) {

--- a/frontend/src/views/BankView.vue
+++ b/frontend/src/views/BankView.vue
@@ -1626,12 +1626,17 @@ onMounted(async () => {
   color: var(--p-text-muted-color);
 }
 
+/* Modest floors only: the table is width:100% (see main.css), so these text
+   columns absorb spare width on wide screens and stay readable; the small
+   min-width keeps them from collapsing to a vertical sliver on narrow ones,
+   where the table-level horizontal scroll takes over. */
 :deep(.bank-table__description) {
-  min-width: 20rem;
+  min-width: 11rem;
 }
 
 :deep(.bank-table__reference) {
-  min-width: 12rem;
+  min-width: 7rem;
+  overflow-wrap: anywhere;
 }
 
 :deep(.bank-table__amount) {


### PR DESCRIPTION
## Lot TABLE-FIT — TEC-212

### Problème
L'écran Banque (et les autres écrans denses) déclenchait un **scroll horizontal** sur grand écran, alors qu'il restait de la place inutilisée sur les côtés.

### Cause racine
Le conteneur de contenu `.main-inner` (desktop ≥ 1200 px) plafonnait **toutes** les pages à `max-width: 1320px`, ce qui **neutralisait le mode « large » (1640 px)** demandé par `AppPage width="wide"`. La table de la Banque (~1331 px) débordait donc le panneau (1318 px) → scroll, et ~317 px étaient gâchés à droite.

### Correctif
- `AppLayout.vue` — `.main-inner` suit désormais la largeur « large » (`--app-page-wide-max-width`, 1640) au lieu de brider à 1320. Chaque `.app-page` gère déjà sa propre largeur (1320 normal / 1640 large) et son centrage → aucune régression sur les pages normales.
- `main.css` — `.app-data-table table { width: 100% }` : la table remplit son conteneur, l'espace va aux colonnes texte (règle centralisée, tous les tableaux). Le scroll horizontal natif de PrimeVue (`.p-datatable-table-container`) reste comme filet sur fenêtre étroite.
- `BankView.vue` — `min-width` de `description`/`reference` assouplis (plancher plus bas pour les fenêtres intermédiaires).

### Vérification (mesurée en local, 1920 px, sans scaling)
- Banque : page **1320 → 1609 px**, table **1559 px** dans panneau **1607 px** → **aucun scroll** ; colonne Libellé **357 px** (plus de mot vertical).
- Pages normales (Paiements, Contacts…) : **1320 px, centrées — inchangées**.
- **Audit de 16 écrans à tableau** (factures, caisse, salaires, toute la comptabilité, utilisateurs…) : **aucun débordement**.
- Quality gate frontend vert : ESLint, vue-tsc, Vitest **191/191**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Improve table layout on wide screens to remove unnecessary horizontal scrolling and better use available width.

Bug Fixes:
- Remove horizontal scroll on dense data-table pages by allowing wide page layouts and making tables fill their containers.

Enhancements:
- Relax minimum widths and wrapping for Bank table text columns so labels and references remain readable across screen sizes.

Documentation:
- Add user-facing changelog entry for version 1.8.2 describing improved table display on large screens.

Chores:
- Update TABLE-FIT backlog items and tickets to in-progress status and reflect TEC-212 in the technical changelog.