### PR TITLE
chore(ci): build Docker image for amd64 only

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -41,7 +41,11 @@ jobs:
         with:
           context: .
           push: true
-          platforms: linux/amd64,linux/arm64
+          # Target Synology NAS is x86_64 — building arm64 under QEMU emulation
+          # roughly tripled build time for no benefit. If an arm64 host is ever
+          # needed, add it back via a native runner (ubuntu-24.04-arm) matrix
+          # rather than QEMU.
+          platforms: linux/amd64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha


### PR DESCRIPTION
## Optimisation du build Docker

Le NAS Synology cible est **x86_64** (`uname -m` → `x86_64`). Or le workflow buildait aussi `linux/arm64` **en émulation QEMU**, ce qui triplait le temps de build (≈18 min à froid contre 4-7 min habituels) **sans bénéfice**.

### Changement
- `platforms: linux/amd64,linux/arm64` → `linux/amd64`.

### Impact
- Build mono-arch natif → plus de QEMU, temps de build nettement réduit.
- Le cache GHA reste en place (la lenteur ponctuelle de la 1.9.0 venait surtout du cache évincé après 6 j + l'émulation).

### Si arm64 redevient nécessaire un jour
Le réintroduire via un **runner ARM natif** (`ubuntu-24.04-arm`, gratuit sur ce repo public) en matrix + manifest multi-arch — pas via QEMU.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Build:
- Update the Docker GitHub Actions workflow to build only the linux/amd64 image instead of a multi-arch amd64/arm64 image.