### PR TITLE
fix(salary): fiabiliser les écritures comptables des salaires (SALARY-FIX)

### DIFF
--- a/.backlog/README.md
+++ b/.backlog/README.md
@@ -27,6 +27,7 @@ générateur). Les artefacts sont créés à `⬜ ready`. Convention détaillée
 | [CREANCES-RAPPEL](CREANCES-RAPPEL/PRD.md) — rappel créances exercice/historique sur factures client (BIZ-210) | 🚫 |
 | [RELANCES](RELANCES/PRD.md) — relances factures impayées : historique daté, templates dédiés, filtrage irrécouvrables (BIZ-218→221) | ✅ |
 | [TABLE-FIT](TABLE-FIT/PRD.md) — supprimer le scroll horizontal des tableaux sur grand écran (TEC-212) | ✅ |
+| [SALARY-FIX](SALARY-FIX/PRD.md) — fiabiliser les écritures comptables des salaires : net auto-validé, régénération à l'édition, garde-fou incomplet (BIZ-222 + TEC-213/214) | ✅ |
 
 ## Lots archivés
 

--- a/.backlog/SALARY-FIX/PRD.md
+++ b/.backlog/SALARY-FIX/PRD.md
@@ -1,0 +1,75 @@
+# Lot SALARY-FIX — Fiabiliser les écritures comptables des salaires
+
+Status: ✅ done
+Branch: feature/salary-entries-fix → PR → develop
+
+## Problem Statement
+
+Un cas réel (paie WOLFF mai 2026) a produit un trou comptable : la constatation du
+salaire a bien été générée (641/421, 421/431, 645/431) mais **l'écriture de paiement
+banque** (421000 D / 512100 C) **manquait**, ce qui a faussé le solde du compte 512100
+de 157,50 €. Cause racine établie par l'`audit_logs` :
+
+1. **Saisie** : à la création, le champ « Net à payer » du formulaire est **manuel**,
+   initialisé à `0`, et **découplé** du « Net calculé » affiché (brut − charges − impôt).
+   Le salaire a été enregistré avec `net_pay = 0`, donc l'étape 5 de
+   `generate_entries_for_salary` (`if rule_payment and salary.net_pay > 0`) a été
+   **sautée en silence** — sans erreur.
+2. **Correction sans régénération** : ~2 min plus tard, le net a été corrigé à 157,50 €
+   via une édition. Mais `update_salary` ne fait que `setattr` + flush : il **ne
+   régénère aucune écriture comptable**. L'écriture de paiement, absente depuis la
+   création, n'a jamais été créée.
+
+La donnée PROD a été corrigée ponctuellement (écriture manuelle 421000/512100). Ce lot
+corrige les **trois défauts logiciels** sous-jacents pour que le cas ne se reproduise pas.
+
+## Solution
+
+- **A (BIZ-222)** — Le champ « Net à payer » se remplit automatiquement depuis le net
+  calculé (brut − charges − impôt) tout en restant éditable ; le formulaire refuse un
+  net ≤ 0. On ne peut plus enregistrer un salaire au net nul par inadvertance.
+- **B (TEC-213)** — `update_salary` régénère les écritures comptables du salaire quand
+  un **montant comptable** change ; refuse si l'exercice concerné est clôturé. C'est le
+  défaut qui transforme une erreur de saisie rattrapée en trou permanent.
+- **C (TEC-214)** — Garde-fou moteur : journaliser un avertissement quand une
+  constatation de salaire est générée **sans** paiement (net ≤ 0), et fournir un moyen
+  de lister les salaires structurellement incomplets.
+
+## User Stories
+
+1. En tant que secrétaire, je veux que le net soit pré-rempli et cohérent, pour ne pas
+   enregistrer une paie au net nul.
+2. En tant que trésorier, je veux que corriger un salaire mette à jour ses écritures
+   comptables, pour ne pas garder un journal incohérent.
+3. En tant que trésorier, je veux être alerté d'un salaire constaté mais non payé, pour
+   détecter un trou avant qu'il ne fausse la trésorerie.
+
+## Implementation Decisions
+
+- **B** : à l'édition, si `gross`, `employee_charges`, `employer_charges`, `tax` ou
+  `net_pay` change, supprimer les écritures `source_type=salary, source_id=<id>` puis
+  rappeler `generate_entries_for_salary`. **Refuser** (exception typée → 409) si
+  l'exercice de l'ancienne date d'écriture **ou** de la nouvelle est `CLOSED`. Un
+  changement qui ne touche aucun montant (notes seules) ne régénère rien.
+- **A** : `watch` sur (gross, employee_charges, tax) → `form.net_pay = round2(net
+  calculé)` ; le champ reste éditable. À l'ouverture en **édition**, on charge la valeur
+  stockée sans l'écraser. `save()` bloque (toast) si `net_pay <= 0`.
+- **C** : `log.warning` dans `generate_entries_for_salary` si `gross > 0` et
+  `net_pay <= 0` (constatation sans paiement). Helper `find_incomplete_salaries`
+  (salaires avec écritures mais sans ligne 512100) testé. Pas d'écran dédié (hors scope).
+
+## Testing Decisions
+
+- **B** : édition changeant un montant → anciennes écritures supprimées, nouvelles
+  cohérentes (paiement présent quand net > 0) ; édition « notes seules » → écritures
+  inchangées ; édition sur exercice clôturé → refus, écritures intactes.
+- **A** : net auto-calculé au changement de brut/charges ; net éditable conservé ; submit
+  refusé si net ≤ 0 (test composant).
+- **C** : warning émis sur salaire net ≤ 0 ; `find_incomplete_salaries` détecte le cas
+  constaté-sans-paiement et ignore les paies complètes.
+
+## Out of Scope
+
+- Écran dédié de revue des salaires incomplets (un helper + log suffisent ici).
+- Rattachement rétroactif des paiements manuels existants à leur salaire.
+- Rapprochement bancaire des écritures de salaire.

--- a/.backlog/SALARY-FIX/tickets/01-regenerate-entries-on-update.md
+++ b/.backlog/SALARY-FIX/tickets/01-regenerate-entries-on-update.md
@@ -1,0 +1,35 @@
+# TEC-213 — Régénérer les écritures comptables à l'édition d'un salaire
+
+Status: ✅ done
+Type: fix
+Files: `backend/services/salary_service.py`, `backend/services/accounting_engine.py`, `backend/routers/salary.py`, `tests/unit/test_salary_service.py`, `tests/integration/test_salary_api.py`, `CHANGELOG.md`
+
+## What to build
+
+`update_salary` ne régénère pas les écritures comptables : corriger un montant après
+coup laisse le journal incohérent (cas WOLFF mai : paiement jamais créé). On régénère
+les écritures du salaire quand un montant comptable change.
+
+- Ajouter un helper de suppression dans `accounting_engine.py` :
+  `delete_entries_for_source(db, source_type, source_id)` (supprime les
+  `AccountingEntry` correspondants ; pas de FK cascade, suppression explicite).
+- Dans `update_salary` : détecter si l'un de `gross`, `employee_charges`,
+  `employer_charges`, `tax`, `net_pay` change réellement (comparer avant/après). Si oui :
+  supprimer les écritures `source_type=salary, source_id=<id>` puis rappeler
+  `generate_entries_for_salary`. Sinon (ex. notes seules), ne rien régénérer.
+- **Garde-fou clôture** : refuser la régénération si l'exercice de la date d'écriture
+  existante **ou** de la nouvelle date est `FiscalYearStatus.CLOSED` → exception typée
+  mappée en `409` par le routeur. Aucune écriture modifiée en cas de refus.
+
+## Acceptance criteria
+
+- [ ] Éditer un montant régénère les écritures : le paiement (421000/512100) apparaît
+      quand `net_pay > 0`, même s'il manquait avant.
+- [ ] Éditer uniquement les notes ne touche aucune écriture.
+- [ ] Régénération refusée (409) si l'exercice concerné est clôturé ; écritures intactes.
+- [ ] Les écritures régénérées partagent le `group_key` `salary:<id>` et `source_id`.
+- [ ] `delete_entries_for_source` est couvert par un test unitaire.
+
+## Blocked by
+
+None — fix de fond, à faire en premier.

--- a/.backlog/SALARY-FIX/tickets/02-net-pay-autofill-validation.md
+++ b/.backlog/SALARY-FIX/tickets/02-net-pay-autofill-validation.md
@@ -1,0 +1,31 @@
+# BIZ-222 — Net à payer auto-rempli et validé dans le formulaire salaire
+
+Status: ✅ done
+Type: fix
+Files: `frontend/src/views/SalaryView.vue`, `frontend/src/i18n/fr.ts`, `frontend/src/tests/views/SalaryView.spec.ts`, `CHANGELOG.md`, `docs/user/changelog-user.md`
+
+## What to build
+
+Le champ « Net à payer » (`form.net_pay`) est manuel, par défaut `0`, et découplé du
+« Net calculé » affiché. On peut donc enregistrer une paie au net nul sans s'en rendre
+compte (cause directe du trou WOLFF mai). On le rend auto-rempli, éditable, et validé.
+
+- `watch` sur (`gross`, `employee_charges`, `tax`) → `form.net_pay = round2(gross −
+  employee_charges − tax)`. Le champ reste **éditable** (une saisie manuelle tient
+  jusqu'au prochain changement d'un composant).
+- À l'ouverture en **mode édition**, charger la valeur stockée sans la faire écraser par
+  le watch au montage (garde déjà présente : ne synchroniser que sur changement réel).
+- `save()` : refuser (toast d'avertissement) si `net_pay <= 0`, avec une clé i18n
+  dédiée. Ne pas envoyer le payload tant que le net est nul.
+
+## Acceptance criteria
+
+- [ ] Modifier brut/charges/impôt met à jour automatiquement le « Net à payer ».
+- [ ] Le « Net à payer » reste modifiable à la main.
+- [ ] L'enregistrement est bloqué avec un message clair si net ≤ 0.
+- [ ] En édition, le net stocké s'affiche correctement (pas écrasé à l'ouverture).
+- [ ] Toutes les chaînes passent par i18n (`fr.ts`).
+
+## Blocked by
+
+None — frontend indépendant.

--- a/.backlog/SALARY-FIX/tickets/03-incomplete-salary-guardrail.md
+++ b/.backlog/SALARY-FIX/tickets/03-incomplete-salary-guardrail.md
@@ -1,0 +1,28 @@
+# TEC-214 — Garde-fou : détecter et signaler un salaire incomplet
+
+Status: ✅ done
+Type: fix
+Files: `backend/services/accounting_engine.py`, `backend/services/salary_service.py`, `tests/unit/test_accounting_engine.py`, `tests/unit/test_salary_service.py`, `CHANGELOG.md`
+
+## What to build
+
+L'étape 5 de `generate_entries_for_salary` saute en silence quand `net_pay <= 0`, tout
+en générant la constatation : on obtient un salaire structurellement incomplet
+(constaté mais non payé) sans aucun signal. Ajouter un garde-fou défensif.
+
+- Dans `generate_entries_for_salary` : `log.warning(...)` lorsque `gross > 0` et
+  `net_pay <= 0` (constatation générée sans paiement), avec l'`id`/le mois du salaire.
+- Helper `find_incomplete_salaries(db)` dans `salary_service.py` : liste les salaires
+  ayant des écritures `source_type=salary` **sans** ligne sur le compte de banque
+  (`512100`) alors que `net_pay > 0`. Réutilisable pour un futur écran/contrôle.
+
+## Acceptance criteria
+
+- [ ] Un warning est journalisé quand un salaire au net ≤ 0 génère sa constatation.
+- [ ] `find_incomplete_salaries` détecte un salaire constaté sans écriture de paiement.
+- [ ] `find_incomplete_salaries` ignore les salaires complets (paiement présent).
+- [ ] N'altère pas le comportement de génération existant (étapes 1-5 inchangées).
+
+## Blocked by
+
+None — défensif ; peut suivre TEC-213.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Ce projet respecte le [Versionnage sémantique](https://semver.org/lang/fr/).
 
 ## [Non publié]
 
+### Corrigé
+- **BIZ-222 / TEC-213/214** (Lot SALARY-FIX) — **Fiabilisation des écritures comptables des salaires**. Un salaire pouvait être enregistré avec un **net à 0** (champ « Net à payer » manuel, par défaut 0, découplé du « Net calculé » affiché), ce qui **sautait silencieusement l'écriture de paiement banque** (421000 D / 512100 C) ; corriger le net ensuite ne régénérait rien (`update_salary` ne touchait pas la comptabilité), laissant un trou permanent (cas réel : paie WOLFF mai 2026, banque faussée de 157,50 €).
+  - **A (BIZ-222)** — Le champ « Net à payer » se **remplit automatiquement** depuis le net calculé (brut − cotisations − impôt) en saisie, tout en restant éditable ; l'enregistrement est **refusé si le net est ≤ 0**.
+  - **B (TEC-213)** — `update_salary` **régénère les écritures comptables** du salaire quand un montant change (brut, cotisations, impôt, net) ; un changement sans incidence comptable (notes) ne régénère rien. Refus (409) si l'exercice concerné est **clôturé**.
+  - **C (TEC-214)** — Garde-fou moteur : **avertissement journalisé** lorsqu'un salaire est constaté sans paiement (net ≤ 0), et fonction `find_incomplete_salaries` pour détecter les salaires constatés mais non payés.
+
 ## [1.9.0] — 2026-06-29
 
 ### Corrigé

--- a/backend/routers/salary.py
+++ b/backend/routers/salary.py
@@ -6,7 +6,7 @@ from fastapi import APIRouter, Depends, Query, Response, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.database import get_db
-from backend.errors import not_found
+from backend.errors import conflict, not_found
 from backend.models.user import User, UserRole
 from backend.routers.auth import require_role
 from backend.schemas.salary import (
@@ -156,7 +156,10 @@ async def update_salary(
     salary = await salary_service.get_salary(db, salary_id)
     if salary is None:
         raise not_found("Salary")
-    updated = await salary_service.update_salary(db, salary, payload)
+    try:
+        updated = await salary_service.update_salary(db, salary, payload)
+    except salary_service.SalaryError as exc:
+        raise conflict("salary_fiscal_year_closed", str(exc)) from exc
     await record_audit(
         db,
         action=AuditAction.SALARY_UPDATED,

--- a/backend/services/accounting_engine.py
+++ b/backend/services/accounting_engine.py
@@ -14,7 +14,7 @@ from datetime import date
 from decimal import Decimal
 from typing import TYPE_CHECKING, cast
 
-from sqlalchemy import func, select
+from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -320,6 +320,24 @@ async def _apply_double_entry(
 
     await db.flush()
     return created
+
+
+async def delete_entries_for_source(
+    db: AsyncSession,
+    source_type: EntrySourceType,
+    source_id: int,
+) -> None:
+    """Delete all accounting entries linked to a given source.
+
+    ``source_id`` is a generic pointer (no FK cascade), so entries must be
+    removed explicitly — e.g. before regenerating a salary's entries on edit.
+    """
+    await db.execute(
+        delete(AccountingEntry)
+        .where(AccountingEntry.source_type == source_type)
+        .where(AccountingEntry.source_id == source_id)
+    )
+    await db.flush()
 
 
 async def _get_rule(db: AsyncSession, trigger: TriggerType) -> AccountingRule | None:
@@ -664,6 +682,15 @@ async def generate_entries_for_salary(
             group_key=group_key,
         )
         all_entries.extend(entries)
+    elif salary.gross > 0 and salary.net_pay <= 0:
+        # Constated (gross/charges generated) but no payment line — structurally
+        # incomplete salary (the WOLFF-May case). Surface it instead of failing silently.
+        logger.warning(
+            "Salary %s (%s) constated without payment line: net_pay=%s",
+            salary.id,
+            salary.month,
+            salary.net_pay,
+        )
 
     await db.flush()
     return all_entries

--- a/backend/services/salary_service.py
+++ b/backend/services/salary_service.py
@@ -103,11 +103,56 @@ async def create_salary(db: AsyncSession, payload: SalaryCreate) -> Salary:
     return result.scalar_one()
 
 
+# Fields whose change requires regenerating the salary's accounting entries.
+_ACCOUNTING_FIELDS = ("gross", "employee_charges", "employer_charges", "tax", "net_pay")
+
+
+async def _ensure_salary_entries_editable(db: AsyncSession, salary: Salary) -> None:
+    """Refuse regeneration when the salary's entries fall in a closed fiscal year."""
+    import calendar  # noqa: PLC0415
+    from datetime import date  # noqa: PLC0415
+
+    from backend.models.fiscal_year import FiscalYearStatus  # noqa: PLC0415
+    from backend.services.fiscal_year_service import find_fiscal_year_for_date  # noqa: PLC0415
+
+    year_str, month_str = salary.month.split("-")
+    last_day = calendar.monthrange(int(year_str), int(month_str))[1]
+    entry_date = date(int(year_str), int(month_str), last_day)
+    fiscal_year = await find_fiscal_year_for_date(db, entry_date)
+    if fiscal_year is not None and fiscal_year.status == FiscalYearStatus.CLOSED:
+        raise SalaryError(
+            f"Cannot regenerate salary entries: fiscal year '{fiscal_year.name}' is closed"
+        )
+
+
 async def update_salary(db: AsyncSession, salary: Salary, payload: SalaryUpdate) -> Salary:
-    for field, value in payload.model_dump(exclude_unset=True, exclude_none=False).items():
+    changes = payload.model_dump(exclude_unset=True, exclude_none=False)
+    accounting_changed = any(
+        changes.get(field) is not None and changes[field] != getattr(salary, field)
+        for field in _ACCOUNTING_FIELDS
+    )
+
+    # Guard before mutating anything: a refusal must leave the salary untouched.
+    if accounting_changed:
+        await _ensure_salary_entries_editable(db, salary)
+
+    for field, value in changes.items():
         if value is not None:
             setattr(salary, field, value)
     await db.flush()
+
+    # Keep accounting entries in sync with the salary's amounts (TEC-213).
+    if accounting_changed:
+        from backend.models.accounting_entry import EntrySourceType  # noqa: PLC0415
+        from backend.services.accounting_engine import (  # noqa: PLC0415
+            delete_entries_for_source,
+            generate_entries_for_salary,
+        )
+
+        await delete_entries_for_source(db, EntrySourceType.SALARY, salary.id)
+        await generate_entries_for_salary(db, salary)
+        await db.flush()
+
     # Same as create_salary: reload with selectinload to avoid expired relationship access.
     result = await db.execute(
         select(Salary).options(selectinload(Salary.employee)).where(Salary.id == salary.id)
@@ -118,6 +163,47 @@ async def update_salary(db: AsyncSession, salary: Salary, payload: SalaryUpdate)
 async def delete_salary(db: AsyncSession, salary: Salary) -> None:
     await db.delete(salary)
     await db.flush()
+
+
+async def find_incomplete_salaries(db: AsyncSession) -> list[Salary]:
+    """Return salaries constated but never paid (TEC-214).
+
+    A salary is incomplete when it has accounting entries but none on the
+    salary-payment account(s), while ``net_pay > 0`` — the WOLFF-May signature.
+    The payment account is read from the active SALARY_PAYMENT rule so it stays
+    consistent with the engine's configuration.
+    """
+    from backend.models.accounting_entry import AccountingEntry, EntrySourceType  # noqa: PLC0415
+    from backend.models.accounting_rule import EntrySide, TriggerType  # noqa: PLC0415
+    from backend.services.accounting_engine import _get_rule  # noqa: PLC0415
+
+    rule = await _get_rule(db, TriggerType.SALARY_PAYMENT)
+    if rule is None:
+        return []
+    payment_accounts = [e.account_number for e in rule.entries if e.side == EntrySide.CREDIT]
+    if not payment_accounts:
+        return []
+
+    salaries_with_entries = (
+        select(AccountingEntry.source_id)
+        .where(AccountingEntry.source_type == EntrySourceType.SALARY)
+        .where(AccountingEntry.source_id.is_not(None))
+    )
+    salaries_with_payment = (
+        select(AccountingEntry.source_id)
+        .where(AccountingEntry.source_type == EntrySourceType.SALARY)
+        .where(AccountingEntry.account_number.in_(payment_accounts))
+    )
+    query = (
+        select(Salary)
+        .options(selectinload(Salary.employee))
+        .where(Salary.net_pay > 0)
+        .where(Salary.id.in_(salaries_with_entries))
+        .where(Salary.id.not_in(salaries_with_payment))
+        .order_by(Salary.month, Salary.employee_id)
+    )
+    result = await db.execute(query)
+    return list(result.scalars())
 
 
 async def get_monthly_summary(

--- a/docs/user/changelog-user.md
+++ b/docs/user/changelog-user.md
@@ -4,6 +4,14 @@ Ce document présente les changements visibles dans l'application, version par v
 
 ---
 
+## Version 1.9.1 — à paraître
+
+### Secrétaire · Trésorier
+
+- **Saisie des salaires plus sûre** : le « Net à payer » se remplit automatiquement à partir du brut et des cotisations, tout en restant modifiable, et une paie ne peut plus être enregistrée avec un net à zéro. Si vous corrigez le montant d'un salaire déjà saisi, ses écritures comptables — y compris le paiement en banque — sont **mises à jour automatiquement**, ce qui évite qu'un règlement manque dans le compte banque.
+
+---
+
 ## Version 1.9.0 — 29 juin 2026
 
 ### Tous les utilisateurs

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/frontend/src/i18n/fr.ts
+++ b/frontend/src/i18n/fr.ts
@@ -1584,6 +1584,7 @@ export default {
     filter_month_to: 'Mois de fin',
     validation_employee_required: 'Veuillez sélectionner un employé.',
     validation_month_required: 'Veuillez renseigner le mois (ex : 2025-01).',
+    validation_net_required: 'Le net à payer doit être supérieur à 0.',
     load_employees_error: 'Impossible de charger la liste des employés.',
   },
   dashboard: {

--- a/frontend/src/tests/views/SalaryView.spec.ts
+++ b/frontend/src/tests/views/SalaryView.spec.ts
@@ -321,6 +321,19 @@ describe('SalaryView', () => {
     expect(vm.form.net_pay).toBe(157.5)
   })
 
+  it('keeps net pay finite when an amount field is non-numeric (BIZ-222)', async () => {
+    const wrapper = mountView()
+    await flushView()
+    const vm = wrapper.vm as unknown as {
+      form: { gross: number; net_pay: number }
+    }
+
+    vm.form.gross = Number.NaN // a cleared InputNumber
+    await nextTick()
+
+    expect(vm.form.net_pay).toBe(0)
+  })
+
   it('blocks save when net pay is zero, and proceeds when positive (BIZ-222)', async () => {
     const wrapper = mountView()
     await flushView()

--- a/frontend/src/tests/views/SalaryView.spec.ts
+++ b/frontend/src/tests/views/SalaryView.spec.ts
@@ -90,12 +90,13 @@ vi.mock('../../api/contacts', () => ({
 }))
 
 import SalaryView from '../../views/SalaryView.vue'
-import { getSalarySummaryApi, listSalariesWithCountApi } from '../../api/accounting'
+import { createSalaryApi, getSalarySummaryApi, listSalariesWithCountApi } from '../../api/accounting'
 import { listContactsApi } from '../../api/contacts'
 
 const mockListSalariesWithCountApi = vi.mocked(listSalariesWithCountApi)
 const mockGetSalarySummaryApi = vi.mocked(getSalarySummaryApi)
 const mockListContactsApi = vi.mocked(listContactsApi)
+const mockCreateSalaryApi = vi.mocked(createSalaryApi)
 
 const ContainerStub = defineComponent({
   template: '<div><slot /></div>',
@@ -303,5 +304,40 @@ describe('SalaryView', () => {
 
     const options = wrapper.findAll('option').map((option) => option.text())
     expect(options).toContain('Alice Martin')
+  })
+
+  it('auto-fills net pay from gross minus charges in create mode (BIZ-222)', async () => {
+    const wrapper = mountView()
+    await flushView()
+    const vm = wrapper.vm as unknown as {
+      form: { gross: number; employee_charges: number; tax: number; net_pay: number }
+    }
+
+    vm.form.gross = 199.99
+    vm.form.employee_charges = 42.49
+    vm.form.tax = 0
+    await nextTick()
+
+    expect(vm.form.net_pay).toBe(157.5)
+  })
+
+  it('blocks save when net pay is zero, and proceeds when positive (BIZ-222)', async () => {
+    const wrapper = mountView()
+    await flushView()
+    mockCreateSalaryApi.mockResolvedValue(undefined as never)
+    const vm = wrapper.vm as unknown as {
+      form: { employee_id: number | null; month: string; net_pay: number }
+      save: () => Promise<void>
+    }
+
+    vm.form.employee_id = 1
+    vm.form.month = '2026-05'
+    vm.form.net_pay = 0
+    await vm.save()
+    expect(mockCreateSalaryApi).not.toHaveBeenCalled()
+
+    vm.form.net_pay = 157.5
+    await vm.save()
+    expect(mockCreateSalaryApi).toHaveBeenCalledTimes(1)
   })
 })

--- a/frontend/src/views/SalaryView.vue
+++ b/frontend/src/views/SalaryView.vue
@@ -1012,7 +1012,10 @@ watch(
   () => [form.value.gross, form.value.employee_charges, form.value.tax] as const,
   () => {
     if (editing.value !== null) return
-    form.value.net_pay = Math.round(netPayComputed.value * 100) / 100
+    const computedNet = netPayComputed.value
+    // Guard against NaN (a cleared/non-numeric amount field) — it would slip past
+    // the `> 0` check in save() since `NaN > 0` is false.
+    form.value.net_pay = Number.isFinite(computedNet) ? Math.round(computedNet * 100) / 100 : 0
   },
 )
 
@@ -1101,7 +1104,7 @@ async function save() {
     toast.add({ severity: 'warn', summary: t('salary.validation_month_required'), life: 3000 })
     return
   }
-  if (form.value.net_pay <= 0) {
+  if (!(form.value.net_pay > 0)) {
     toast.add({ severity: 'warn', summary: t('salary.validation_net_required'), life: 3000 })
     return
   }

--- a/frontend/src/views/SalaryView.vue
+++ b/frontend/src/views/SalaryView.vue
@@ -1004,6 +1004,18 @@ watch(
   },
 )
 
+// Auto-fill "Net à payer" from the computed net in create mode, so a salary can't
+// be saved at net 0 by inadvertence (BIZ-222). The field stays editable: a manual
+// value holds until a component (gross/charges/tax) changes again. In edit mode the
+// stored value is kept untouched.
+watch(
+  () => [form.value.gross, form.value.employee_charges, form.value.tax] as const,
+  () => {
+    if (editing.value !== null) return
+    form.value.net_pay = Math.round(netPayComputed.value * 100) / 100
+  },
+)
+
 function formatAmount(v: number | string | null | undefined): string {
   return formatCurrency(toSalaryNumber(v))
 }
@@ -1087,6 +1099,10 @@ async function save() {
   }
   if (!form.value.month) {
     toast.add({ severity: 'warn', summary: t('salary.validation_month_required'), life: 3000 })
+    return
+  }
+  if (form.value.net_pay <= 0) {
+    toast.add({ severity: 'warn', summary: t('salary.validation_net_required'), life: 3000 })
     return
   }
   saving.value = true
@@ -1206,5 +1222,8 @@ onMounted(async () => {
   workforceToMonth.value = salaryMonthRange.value.to_month ?? ''
   await Promise.all([loadEmployees(), loadSalaries(), loadSummary(), loadWorkforce()])
 })
+
+// Exposed for unit tests (net auto-fill + save validation — BIZ-222).
+defineExpose({ form, save, netPayComputed, editing })
 </script>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "solde"
-version = "1.9.0"
+version = "1.9.1"
 description = "Web app for French non-profit accounting — invoicing, payments, cash management and double-entry bookkeeping."
 requires-python = ">=3.11"
 dependencies = [

--- a/tests/unit/test_accounting_engine.py
+++ b/tests/unit/test_accounting_engine.py
@@ -697,6 +697,45 @@ class TestGenerateEntriesForSalary:
         )
 
     @pytest.mark.asyncio
+    async def test_salary_without_payment_logs_warning(
+        self, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A constated salary with net_pay <= 0 must log a warning (TEC-214)."""
+        from backend.services import accounting_engine
+
+        warnings: list[tuple[object, ...]] = []
+        monkeypatch.setattr(
+            accounting_engine.logger,
+            "warning",
+            lambda *args, **kwargs: warnings.append(args),
+        )
+
+        employee = await _make_employee(db_session)
+        salary = Salary(
+            employee_id=employee.id,
+            month="2024-03",
+            hours=Decimal("0.00"),
+            gross=Decimal("100.00"),
+            employee_charges=Decimal("0.00"),
+            employer_charges=Decimal("0.00"),
+            tax=Decimal("0.00"),
+            net_pay=Decimal("0.00"),  # constated but unpayable
+        )
+        db_session.add(salary)
+        await db_session.commit()
+        await db_session.refresh(salary)
+
+        await _create_fiscal_year(
+            db_session, name="2024", start=date(2024, 1, 1), end=date(2024, 12, 31)
+        )
+        await _seed_one_rule(db_session, TriggerType.SALARY_GROSS, "641000", "421000")
+        await _seed_one_rule(db_session, TriggerType.SALARY_PAYMENT, "421000", "512100")
+
+        await generate_entries_for_salary(db_session, salary)
+
+        assert any("without payment" in str(args[0]) for args in warnings)
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize(
         ("month", "expected_date"),
         [

--- a/tests/unit/test_salary_service.py
+++ b/tests/unit/test_salary_service.py
@@ -16,6 +16,75 @@ async def _make_employee(db: AsyncSession, nom: str = "Dupont", prenom: str = "J
     return c
 
 
+async def _seed_salary_rules(db: AsyncSession) -> None:
+    """Seed the four salary accounting rules used by entry generation."""
+    from backend.models.accounting_rule import (
+        AccountingRule,
+        AccountingRuleEntry,
+        EntrySide,
+        TriggerType,
+    )
+
+    specs = [
+        (TriggerType.SALARY_GROSS, "641000", "421000"),
+        (TriggerType.SALARY_EMPLOYEE_CHARGES, "421000", "431100"),
+        (TriggerType.SALARY_EMPLOYER_CHARGES, "645100", "431100"),
+        (TriggerType.SALARY_PAYMENT, "421000", "512100"),
+    ]
+    for trigger, debit, credit in specs:
+        rule = AccountingRule(
+            name=f"r-{trigger}", trigger_type=trigger, is_active=True, priority=10
+        )
+        db.add(rule)
+        await db.flush()
+        db.add(
+            AccountingRuleEntry(
+                rule_id=rule.id,
+                account_number=debit,
+                side=EntrySide.DEBIT,
+                description_template="{{label}}",
+            )
+        )
+        db.add(
+            AccountingRuleEntry(
+                rule_id=rule.id,
+                account_number=credit,
+                side=EntrySide.CREDIT,
+                description_template="{{label}}",
+            )
+        )
+    await db.flush()
+
+
+async def _make_fiscal_year(db: AsyncSession, year: int, *, closed: bool = False):
+    from datetime import date
+
+    from backend.models.fiscal_year import FiscalYear, FiscalYearStatus
+
+    fy = FiscalYear(
+        name=f"FY-{year}",
+        start_date=date(year, 1, 1),
+        end_date=date(year, 12, 31),
+        status=FiscalYearStatus.CLOSED if closed else FiscalYearStatus.OPEN,
+    )
+    db.add(fy)
+    await db.flush()
+    return fy
+
+
+async def _salary_entries(db: AsyncSession, salary_id: int) -> list:
+    from sqlalchemy import select
+
+    from backend.models.accounting_entry import AccountingEntry, EntrySourceType
+
+    result = await db.execute(
+        select(AccountingEntry)
+        .where(AccountingEntry.source_type == EntrySourceType.SALARY)
+        .where(AccountingEntry.source_id == salary_id)
+    )
+    return list(result.scalars())
+
+
 @pytest.mark.asyncio
 async def test_create_salary_minimal(db_session: AsyncSession) -> None:
     """Creating a salary with minimal data persists correctly."""
@@ -269,6 +338,165 @@ async def test_update_salary(db_session: AsyncSession) -> None:
     assert updated.gross == Decimal("2000.00")
     assert updated.net_pay == Decimal("1700.00")
     assert updated.hours == Decimal("100.00")  # unchanged
+
+
+@pytest.mark.asyncio
+async def test_update_salary_regenerates_entries_when_amount_changes(
+    db_session: AsyncSession,
+) -> None:
+    """Editing a salary amount regenerates its accounting entries (TEC-213).
+
+    Reproduces the WOLFF May case: created at net_pay=0 (payment entry skipped),
+    then corrected to a positive net — the payment pair must now exist.
+    """
+    from backend.schemas.salary import SalaryUpdate
+    from backend.services.salary_service import create_salary, update_salary
+
+    await _seed_salary_rules(db_session)
+    await _make_fiscal_year(db_session, 2025)
+    employee = await _make_employee(db_session, "Wolff", "Philippe")
+
+    salary = await create_salary(
+        db_session,
+        SalaryCreate(
+            employee_id=employee.id,
+            month="2025-03",
+            gross=Decimal("199.99"),
+            employee_charges=Decimal("42.49"),
+            employer_charges=Decimal("80.16"),
+            tax=Decimal("0.00"),
+            net_pay=Decimal("0.00"),  # net left at 0 — payment entry skipped
+        ),
+    )
+    entries = await _salary_entries(db_session, salary.id)
+    assert not any(e.account_number == "512100" for e in entries)  # no payment yet
+
+    await update_salary(db_session, salary, SalaryUpdate(net_pay=Decimal("157.50")))
+
+    entries = await _salary_entries(db_session, salary.id)
+    payment = [e for e in entries if e.account_number == "512100"]
+    assert len(payment) == 1
+    assert payment[0].credit == Decimal("157.50")
+    # entries stay grouped under the salary
+    assert {e.group_key for e in entries} == {f"salary:{salary.id}"}
+
+
+@pytest.mark.asyncio
+async def test_update_salary_notes_only_keeps_entries(db_session: AsyncSession) -> None:
+    """Editing only non-amount fields must not regenerate accounting entries (TEC-213)."""
+    from backend.schemas.salary import SalaryUpdate
+    from backend.services.salary_service import create_salary, update_salary
+
+    await _seed_salary_rules(db_session)
+    await _make_fiscal_year(db_session, 2025)
+    employee = await _make_employee(db_session, "Lay", "Myriam")
+
+    salary = await create_salary(
+        db_session,
+        SalaryCreate(
+            employee_id=employee.id,
+            month="2025-03",
+            gross=Decimal("1700.00"),
+            employee_charges=Decimal("376.39"),
+            employer_charges=Decimal("402.93"),
+            tax=Decimal("0.00"),
+            net_pay=Decimal("1323.61"),
+        ),
+    )
+    before = {e.id for e in await _salary_entries(db_session, salary.id)}
+    assert before  # entries exist
+
+    await update_salary(db_session, salary, SalaryUpdate(notes="commentaire"))
+
+    after = {e.id for e in await _salary_entries(db_session, salary.id)}
+    assert after == before  # identical entry ids — nothing regenerated
+
+
+@pytest.mark.asyncio
+async def test_update_salary_refused_on_closed_fiscal_year(db_session: AsyncSession) -> None:
+    """Regeneration is refused when the entry's fiscal year is closed (TEC-213)."""
+    from backend.schemas.salary import SalaryUpdate
+    from backend.services.salary_service import SalaryError, create_salary, update_salary
+
+    await _seed_salary_rules(db_session)
+    fy = await _make_fiscal_year(db_session, 2025)
+    employee = await _make_employee(db_session, "Wolff", "Philippe")
+
+    salary = await create_salary(
+        db_session,
+        SalaryCreate(
+            employee_id=employee.id,
+            month="2025-03",
+            gross=Decimal("199.99"),
+            employee_charges=Decimal("42.49"),
+            employer_charges=Decimal("80.16"),
+            tax=Decimal("0.00"),
+            net_pay=Decimal("0.00"),
+        ),
+    )
+    before = {e.id for e in await _salary_entries(db_session, salary.id)}
+
+    # Close the fiscal year, then attempt an amount edit.
+    from backend.models.fiscal_year import FiscalYearStatus
+
+    fy.status = FiscalYearStatus.CLOSED
+    await db_session.flush()
+
+    with pytest.raises(SalaryError):
+        await update_salary(db_session, salary, SalaryUpdate(net_pay=Decimal("157.50")))
+
+    after = {e.id for e in await _salary_entries(db_session, salary.id)}
+    assert after == before  # entries untouched on refusal
+
+
+@pytest.mark.asyncio
+async def test_find_incomplete_salaries(db_session: AsyncSession) -> None:
+    """find_incomplete_salaries flags constated-but-unpaid salaries (TEC-214)."""
+    from sqlalchemy import delete
+
+    from backend.models.accounting_entry import AccountingEntry, EntrySourceType
+    from backend.services.salary_service import create_salary, find_incomplete_salaries
+
+    await _seed_salary_rules(db_session)
+    await _make_fiscal_year(db_session, 2025)
+    employee = await _make_employee(db_session, "Wolff", "Philippe")
+
+    complete = await create_salary(
+        db_session,
+        SalaryCreate(
+            employee_id=employee.id,
+            month="2025-04",
+            gross=Decimal("199.99"),
+            employee_charges=Decimal("42.49"),
+            employer_charges=Decimal("80.16"),
+            tax=Decimal("0.00"),
+            net_pay=Decimal("157.50"),
+        ),
+    )
+    incomplete = await create_salary(
+        db_session,
+        SalaryCreate(
+            employee_id=employee.id,
+            month="2025-05",
+            gross=Decimal("199.99"),
+            employee_charges=Decimal("42.49"),
+            employer_charges=Decimal("80.16"),
+            tax=Decimal("0.00"),
+            net_pay=Decimal("157.50"),
+        ),
+    )
+    # Simulate the WOLFF-May state: payment line missing on the incomplete salary.
+    await db_session.execute(
+        delete(AccountingEntry)
+        .where(AccountingEntry.source_type == EntrySourceType.SALARY)
+        .where(AccountingEntry.source_id == incomplete.id)
+        .where(AccountingEntry.account_number == "512100")
+    )
+    await db_session.flush()
+
+    found_ids = {s.id for s in await find_incomplete_salaries(db_session)}
+    assert incomplete.id in found_ids
+    assert complete.id not in found_ids
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Contexte

Diagnostic d'un trou comptable réel (paie **WOLFF mai 2026**, banque faussée de 157,50 €), prouvé via `audit_logs` : salaire créé à **net = 0** (champ « Net à payer » manuel, par défaut 0, découplé du net calculé affiché) → l'écriture de paiement banque (421000 D / 512100 C) **sautée en silence** ; net corrigé 2 min plus tard mais `update_salary` ne régénérait aucune écriture → trou permanent.

La donnée PROD a été corrigée ponctuellement (écriture manuelle). Cette PR corrige les **trois défauts** sous-jacents.

## Changements

- **BIZ-222** (frontend) — « Net à payer » auto-rempli depuis brut − cotisations − impôt en saisie, reste éditable ; enregistrement **refusé si net ≤ 0**.
- **TEC-213** (backend) — `update_salary` **régénère les écritures** quand un montant comptable change (notes seules → rien) ; **refus 409** si l'exercice est clôturé. Nouveau helper `delete_entries_for_source`.
- **TEC-214** (backend) — **avertissement journalisé** sur salaire constaté sans paiement (net ≤ 0) + `find_incomplete_salaries()`.

## Tests

- Backend : régénération sur changement de montant ; pas de régénération sur notes seules ; refus sur exercice clôturé ; warning ; détection des salaires incomplets. **Suite complète : 1168 passed.**
- Frontend : auto-remplissage du net ; blocage du save si net ≤ 0. **vitest : 199 passed.**
- Quality gate complet vert (ruff, mypy, eslint, vue-tsc).

## Lot

`.backlog/SALARY-FIX/` (PRD + 3 tickets). Bump version 1.9.0 → 1.9.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Harden salary accounting so payments are always reflected in the ledger and incomplete cases are detectable, while preventing salaries from being saved with a zero net pay.

New Features:
- Add backend helper to list structurally incomplete salaries whose accounting entries lack a payment line despite a positive net pay.
- Introduce a backend guardrail that logs a warning when a salary is recorded without a corresponding payment entry.
- Automate front-end pre-filling of the salary "Net à payer" field from gross minus charges and tax while keeping it editable, and expose form internals for targeted unit tests.

Bug Fixes:
- Ensure editing salary amounts regenerates all related accounting entries, including payments, instead of leaving the journal inconsistent.
- Block salary creation/update on the API when regeneration would touch a closed fiscal year, returning a conflict error and leaving entries untouched.
- Prevent saving a salary from the UI when the net pay is less than or equal to zero to avoid missing bank payment entries.

Enhancements:
- Add a reusable backend helper to delete all accounting entries for a given source, supporting safe regeneration flows.
- Update salary service and accounting engine tests to cover entry regeneration behavior, closed-year refusal, warning logging, and incomplete salary detection.
- Refine salary view tests to validate net auto-fill and save-time validation logic.

Build:
- Bump backend and frontend versions from 1.9.0 to 1.9.1 and register the SALARY-FIX backlog lot and tickets documentation.

Documentation:
- Extend the user-facing changelog with an entry explaining safer salary entry behavior and automatic accounting updates for corrected salaries.