### PR TITLE
fix(salary): find_incomplete_salaries aveugle aux paiements importés (NULL source_id)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Ce projet respecte le [Versionnage sémantique](https://semver.org/lang/fr/).
   - **A (BIZ-222)** — Le champ « Net à payer » se **remplit automatiquement** depuis le net calculé (brut − cotisations − impôt) en saisie, tout en restant éditable ; l'enregistrement est **refusé si le net est ≤ 0**.
   - **B (TEC-213)** — `update_salary` **régénère les écritures comptables** du salaire quand un montant change (brut, cotisations, impôt, net) ; un changement sans incidence comptable (notes) ne régénère rien. Refus (409) si l'exercice concerné est **clôturé**.
   - **C (TEC-214)** — Garde-fou moteur : **avertissement journalisé** lorsqu'un salaire est constaté sans paiement (net ≤ 0), et fonction `find_incomplete_salaries` pour détecter les salaires constatés mais non payés.
+  - **C (TEC-214, correctif)** — `find_incomplete_salaries` renvoyait une **liste vide** sur la base réelle : les paiements de salaires **importés** ont un `source_id` à `NULL`, et un `NULL` dans la sous-requête `NOT IN` rendait toute la comparaison indéterminée (piège SQL classique). La sous-requête exclut désormais les `NULL`. Détecté en passant le détecteur sur la base de production (un seul salaire incomplet confirmé : le cas WOLFF mai déjà corrigé).
 
 ## [1.9.0] — 2026-06-29
 

--- a/backend/services/salary_service.py
+++ b/backend/services/salary_service.py
@@ -193,6 +193,9 @@ async def find_incomplete_salaries(db: AsyncSession) -> list[Salary]:
         select(AccountingEntry.source_id)
         .where(AccountingEntry.source_type == EntrySourceType.SALARY)
         .where(AccountingEntry.account_number.in_(payment_accounts))
+        # Exclude NULL source_id (imported salary payments): a NULL inside the
+        # NOT IN subquery would make the whole comparison unknown and return [].
+        .where(AccountingEntry.source_id.is_not(None))
     )
     query = (
         select(Salary)

--- a/tests/unit/test_salary_service.py
+++ b/tests/unit/test_salary_service.py
@@ -492,6 +492,22 @@ async def test_find_incomplete_salaries(db_session: AsyncSession) -> None:
         .where(AccountingEntry.source_id == incomplete.id)
         .where(AccountingEntry.account_number == "512100")
     )
+    # An imported legacy salary payment carries no source_id (NULL). A NULL inside
+    # the NOT IN subquery must not blind the whole query (regression guard).
+    from datetime import date
+
+    db_session.add(
+        AccountingEntry(
+            entry_number="LEGACY-PAY",
+            date=date(2024, 12, 31),
+            account_number="512100",
+            label="Imported salary payment",
+            debit=Decimal("0.00"),
+            credit=Decimal("1000.00"),
+            source_type=EntrySourceType.SALARY,
+            source_id=None,
+        )
+    )
     await db_session.flush()
 
     found_ids = {s.id for s in await find_incomplete_salaries(db_session)}


### PR DESCRIPTION
## Contexte

En passant `find_incomplete_salaries` (TEC-214) sur la base de production pour vérifier qu'aucun autre salaire constaté-non-payé ne traînait, le détecteur renvoyait **0** — alors que le cas WOLFF mai est bien présent.

## Cause

Les paiements de salaires **importés d'Excel** portent un `source_id` à **`NULL`** (37 écritures `512100` concernées). La sous-requête `id NOT IN (source_id des paiements)` contenait donc un `NULL`, ce qui rend la comparaison `NOT IN` **indéterminée** en SQL → résultat **vide** (piège classique). Le garde-fou était donc aveugle sur la base réelle.

Les tests initiaux ne le voyaient pas : aucune fixture n'avait d'écriture `source_id=NULL`.

## Correctif

Exclure les `NULL` de la sous-requête des paiements (`source_id IS NOT NULL`), comme c'était déjà fait pour la sous-requête « salaires ayant des écritures ».

Avec le correctif, le scan de production confirme **un seul** salaire incomplet : WOLFF mai (déjà corrigé manuellement). Aucun autre trou.

## Tests

Test `test_find_incomplete_salaries` étendu : une écriture de paiement `source_id=NULL` (legacy importé) est insérée ; sans le correctif le test **échoue** (liste vide), avec il passe. **Suite complète : 1168 passed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure salary incompleteness detection correctly handles imported payments with NULL source_id values.

Bug Fixes:
- Fix find_incomplete_salaries returning an empty result when salary payment entries have a NULL source_id.

Documentation:
- Update changelog to document the find_incomplete_salaries correctness fix for imported salary payments with NULL source_id.

Tests:
- Extend find_incomplete_salaries unit test to cover legacy imported salary payments with NULL source_id and guard against regression.