### PR TITLE
fix(dashboard): tuiles « Recettes/Dépenses du mois » au mois courant (TEC-215)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Ce projet respecte le [Versionnage sémantique](https://semver.org/lang/fr/).
   - **B (TEC-213)** — `update_salary` **régénère les écritures comptables** du salaire quand un montant change (brut, cotisations, impôt, net) ; un changement sans incidence comptable (notes) ne régénère rien. Refus (409) si l'exercice concerné est **clôturé**.
   - **C (TEC-214)** — Garde-fou moteur : **avertissement journalisé** lorsqu'un salaire est constaté sans paiement (net ≤ 0), et fonction `find_incomplete_salaries` pour détecter les salaires constatés mais non payés.
   - **C (TEC-214, correctif)** — `find_incomplete_salaries` renvoyait une **liste vide** sur la base réelle : les paiements de salaires **importés** ont un `source_id` à `NULL`, et un `NULL` dans la sous-requête `NOT IN` rendait toute la comparaison indéterminée (piège SQL classique). La sous-requête exclut désormais les `NULL`. Détecté en passant le détecteur sur la base de production (un seul salaire incomplet confirmé : le cas WOLFF mai déjà corrigé).
+- **TEC-215** — **Tableau de bord : tuiles « Recettes/Dépenses du mois » corrigées**. Elles affichaient le **dernier mois de l'exercice** (souvent encore vide car dans le futur) au lieu du **mois calendaire en cours**, d'où des montants à 0 € alors que le graphique montrait bien une activité. La tuile cible désormais le mois courant (repli sur le dernier mois de l'exercice si celui consulté ne contient pas le mois en cours).
 
 ## [1.9.0] — 2026-06-29
 

--- a/docs/user/changelog-user.md
+++ b/docs/user/changelog-user.md
@@ -6,6 +6,10 @@ Ce document présente les changements visibles dans l'application, version par v
 
 ## Version 1.9.1 — à paraître
 
+### Tous les utilisateurs
+
+- **Tableau de bord : « Recettes/Dépenses du mois » justes** — ces deux indicateurs pouvaient afficher 0 € (ils montraient le dernier mois de l'exercice, souvent encore à venir, au lieu du mois en cours). Ils reflètent désormais bien le mois courant.
+
 ### Secrétaire · Trésorier
 
 - **Saisie des salaires plus sûre** : le « Net à payer » se remplit automatiquement à partir du brut et des cotisations, tout en restant modifiable, et une paie ne peut plus être enregistrée avec un net à zéro. Si vous corrigez le montant d'un salaire déjà saisi, ses écritures comptables — y compris le paiement en banque — sont **mises à jour automatiquement**, ce qui évite qu'un règlement manque dans le compte banque.

--- a/frontend/src/tests/views/DashboardView.spec.ts
+++ b/frontend/src/tests/views/DashboardView.spec.ts
@@ -174,8 +174,17 @@ describe('DashboardView', () => {
       const cards = wrapper.findAll('.stat').map((c) => c.text())
       const income = cards.find((t) => t.startsWith('dashboard.month_income:'))
       const expense = cards.find((t) => t.startsWith('dashboard.month_expense:'))
-      expect(income).toContain('546') // June produits, not July's 0
-      expect(expense).toContain('300') // June charges 2 300, not July's 0
+      // Parse the formatted amount, handling the FR locale (thin spaces as thousands
+      // separators, comma as decimal) so we can assert the exact value, not a substring.
+      const amountOf = (text: string | undefined): number =>
+        Number(
+          (text ?? '')
+            .replace(/^[^:]*:/, '')
+            .replace(/[\s €]/g, '')
+            .replace(',', '.'),
+        )
+      expect(amountOf(income)).toBe(546) // June produits, not July's 0
+      expect(amountOf(expense)).toBe(2300) // June charges, not July's 0
     } finally {
       vi.useRealTimers()
     }

--- a/frontend/src/tests/views/DashboardView.spec.ts
+++ b/frontend/src/tests/views/DashboardView.spec.ts
@@ -141,4 +141,43 @@ describe('DashboardView', () => {
     // 36480.10 + 4750.00 + 455.73 = 41685.83
     expect(amount).toContain('685')
   })
+
+  it('shows the current calendar month figures, not the last (empty) fiscal month', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 5, 15)) // 15 June 2026
+    try {
+      mockGetDashboard.mockResolvedValue({
+        bank_balance: 0,
+        bank_epargne_balance: 0,
+        cash_balance: 0,
+        unpaid_count: 0,
+        unpaid_total: 0,
+        overdue_count: 0,
+        overdue_total: 0,
+        undeposited_count: 0,
+        to_reconcile_count: 0,
+        current_fy_name: '2025',
+        current_resultat: 0,
+        alerts: [],
+      })
+      // Fiscal year Aug→Jul: the last row (July) is still empty; June is the current month.
+      mockGetMonthly.mockResolvedValue([
+        { month: '2026-05', charges: 100, produits: 100 },
+        { month: '2026-06', charges: 2300, produits: 546 },
+        { month: '2026-07', charges: 0, produits: 0 },
+      ])
+      mockGetResources.mockResolvedValue([])
+
+      const wrapper = mount(DashboardView, { global: { stubs } })
+      await flush()
+
+      const cards = wrapper.findAll('.stat').map((c) => c.text())
+      const income = cards.find((t) => t.startsWith('dashboard.month_income:'))
+      const expense = cards.find((t) => t.startsWith('dashboard.month_expense:'))
+      expect(income).toContain('546') // June produits, not July's 0
+      expect(expense).toContain('300') // June charges 2 300, not July's 0
+    } finally {
+      vi.useRealTimers()
+    }
+  })
 })

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -241,9 +241,17 @@ const sparklineAreaPath = computed(() =>
   sparklinePath.value ? `${sparklinePath.value} L 100 32 L 0 32 Z` : '',
 )
 
-const lastMonth = computed(
-  () => chartData.value.at(-1) ?? { month: '', charges: 0, produits: 0 },
-)
+// "Recettes/Dépenses du mois" = the current calendar month. chartData spans the whole
+// fiscal year, so its last row is the year's final month (often still in the future and
+// empty). Target the current month explicitly, falling back to the last row when the
+// displayed fiscal year doesn't contain it (e.g. a past year is selected).
+const lastMonth = computed(() => {
+  const rows = chartData.value
+  if (rows.length === 0) return { month: '', charges: 0, produits: 0 }
+  const now = new Date()
+  const currentKey = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`
+  return rows.find((row) => row.month === currentKey) ?? rows.at(-1)!
+})
 
 const overviewSubtitle = computed(() => {
   const fy = kpis.value?.current_fy_name ?? fiscalYearStore.selectedFiscalYear?.name ?? '—'


### PR DESCRIPTION
## Bug

Les tuiles **« Recettes du mois »** et **« Dépenses du mois »** du tableau de bord affichaient **0 €** alors que le graphique « Charges / Produits par exercice » montrait bien une activité pour le mois en cours.

## Cause

`lastMonth = chartData.value.at(-1)` prenait le **dernier mois de l'exercice**. L'exercice court d'août à juillet ; fin juin, le dernier mois (**juillet**) est encore dans le futur et **vide (0/0)**. C'est lui qui alimentait les deux tuiles, au lieu du **mois calendaire en cours** (juin).

## Correctif

`lastMonth` cible désormais le mois courant (`new Date()` → `"YYYY-MM"`) dans `chartData`, avec repli sur le dernier mois de l'exercice lorsque l'exercice consulté ne contient pas le mois en cours (consultation d'un exercice passé).

## Tests

Nouveau test (date système figée à juin 2026, jeu de données août→juillet avec juillet vide) : la tuile affiche les chiffres de juin, pas ceux de juillet. Sans le correctif le test échoue. **vitest : 201 passed**, eslint + vue-tsc OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix dashboard month income/expense tiles to show the current calendar month instead of the last fiscal month, and document the correction.

Bug Fixes:
- Ensure dashboard "Recettes/Dépenses du mois" tiles use the current calendar month figures, with fallback to the last fiscal month when the current month is outside the selected fiscal year.

Documentation:
- Update user-facing changelogs to describe the dashboard month tiles correction for all users.

Tests:
- Add a dashboard test that freezes system time and validates that the month tiles display the current month data rather than an empty future fiscal month.